### PR TITLE
Fix docs link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ These commands currently show "not implemented" messages when used.
 
 ## Documentation
 
-For detailed documentation, please visit our [documentation site](https://github.com/gittower/git-flow-next/wiki).
+For detailed documentation, please visit our [documentation site](https://git-flow.sh/docs/).
 
 ### Configuration Reference
 


### PR DESCRIPTION
Point docs link to git-flow.sh/docs rather than nonexistent GitHub wiki