### PR TITLE
Add --force flag to allow reinitialization

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -38,13 +38,16 @@ If git-flow-avh configuration exists, it will be imported.`,
 		hotfixPrefix, _ := cmd.Flags().GetString("hotfix")
 		supportPrefix, _ := cmd.Flags().GetString("support")
 		tagPrefix, _ := cmd.Flags().GetString("tag")
-		InitCommand(useDefaults, !noCreateBranches, preset, custom, mainBranch, developBranch, featurePrefix, bugfixPrefix, releasePrefix, hotfixPrefix, supportPrefix, tagPrefix)
+		force, _ := cmd.Flags().GetBool("force")
+		noForce, _ := cmd.Flags().GetBool("no-force")
+		forceFlag := getBoolFlagInit(force, noForce)
+		InitCommand(useDefaults, !noCreateBranches, preset, custom, mainBranch, developBranch, featurePrefix, bugfixPrefix, releasePrefix, hotfixPrefix, supportPrefix, tagPrefix, forceFlag)
 	},
 }
 
 // InitCommand is the implementation of the init command
-func InitCommand(useDefaults, createBranches bool, preset string, custom bool, mainBranch, developBranch, featurePrefix, bugfixPrefix, releasePrefix, hotfixPrefix, supportPrefix, tagPrefix string) {
-	if err := initFlow(useDefaults, createBranches, preset, custom, mainBranch, developBranch, featurePrefix, bugfixPrefix, releasePrefix, hotfixPrefix, supportPrefix, tagPrefix); err != nil {
+func InitCommand(useDefaults, createBranches bool, preset string, custom bool, mainBranch, developBranch, featurePrefix, bugfixPrefix, releasePrefix, hotfixPrefix, supportPrefix, tagPrefix string, force *bool) {
+	if err := initFlow(useDefaults, createBranches, preset, custom, mainBranch, developBranch, featurePrefix, bugfixPrefix, releasePrefix, hotfixPrefix, supportPrefix, tagPrefix, force); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -57,16 +60,42 @@ func InitCommand(useDefaults, createBranches bool, preset string, custom bool, m
 }
 
 // initFlow performs the actual initialization logic and returns any errors
-func initFlow(useDefaults, createBranches bool, preset string, custom bool, mainBranch, developBranch, featurePrefix, bugfixPrefix, releasePrefix, hotfixPrefix, supportPrefix, tagPrefix string) error {
+func initFlow(useDefaults, createBranches bool, preset string, custom bool, mainBranch, developBranch, featurePrefix, bugfixPrefix, releasePrefix, hotfixPrefix, supportPrefix, tagPrefix string, force *bool) error {
 	// Check if we're in a git repo
 	if !git.IsGitRepo() {
 		return &errors.GitError{Operation: "check if git repository", Err: fmt.Errorf("not a git repository. Please run 'git init' first")}
 	}
 
-	var cfg *config.Config
+	// Determine if force is enabled (default: false)
+	forceReinit := false
+	if force != nil {
+		forceReinit = *force
+	}
 
 	// Check if any configuration options are provided
 	hasConfigFlags := mainBranch != "" || developBranch != "" || featurePrefix != "" || bugfixPrefix != "" || releasePrefix != "" || hotfixPrefix != "" || supportPrefix != "" || tagPrefix != ""
+
+	// Check if already initialized
+	initialized, err := config.IsInitialized()
+	if err != nil {
+		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
+	}
+
+	if initialized {
+		// Special case: AVH import should work without --force (migration, not reconfiguration)
+		isAVHImport := config.CheckGitFlowAVHConfig() && preset == "" && !custom &&
+			!useDefaults && !hasConfigFlags
+
+		if !forceReinit && !isAVHImport {
+			return &errors.AlreadyInitializedError{}
+		}
+
+		if forceReinit {
+			fmt.Fprintln(os.Stderr, "Warning: Reinitializing git-flow. Existing configuration will be overwritten.")
+		}
+	}
+
+	var cfg *config.Config
 
 	// Check if git-flow-avh config exists and no explicit options are provided
 	if config.CheckGitFlowAVHConfig() && preset == "" && !custom && !useDefaults && !hasConfigFlags {
@@ -559,6 +588,18 @@ func interactiveConfig() config.ConfigOverrides {
 	return overrides
 }
 
+// getBoolFlagInit converts two opposite boolean flags into a single *bool value
+func getBoolFlagInit(positive, negative bool) *bool {
+	if positive {
+		return &positive
+	}
+	if negative {
+		falseBool := false
+		return &falseBool
+	}
+	return nil
+}
+
 func init() {
 	rootCmd.AddCommand(initCmd)
 
@@ -575,4 +616,6 @@ func init() {
 	initCmd.Flags().StringP("hotfix", "x", "", "Hotfix branch prefix")
 	initCmd.Flags().StringP("support", "s", "", "Support branch prefix")
 	initCmd.Flags().StringP("tag", "t", "", "Version tag prefix")
+	initCmd.Flags().BoolP("force", "f", false, "Force reinitialization of an already initialized repository")
+	initCmd.Flags().Bool("no-force", false, "Don't force reinitialize (default behavior)")
 }

--- a/docs/git-flow-init.1.md
+++ b/docs/git-flow-init.1.md
@@ -6,7 +6,7 @@ git-flow-init - Initialize git-flow in a repository
 
 ## SYNOPSIS
 
-**git-flow init** [**--preset**=*preset*] [**--custom**] [**--defaults**] [*options*]
+**git-flow init** [**-f**|**--force**|**--no-force**] [**--preset**=*preset*] [**--custom**] [**--defaults**] [*options*]
 
 ## DESCRIPTION
 
@@ -33,6 +33,14 @@ Initialize git-flow configuration in the current Git repository. This command se
 
 **--no-create-branches**
 : Don't create branches even if they don't exist in the repository.
+
+### Initialization Control
+
+**--force**, **-f**
+: Force reinitialization of an already initialized repository. Existing git-flow configuration will be overwritten.
+
+**--no-force**
+: Don't allow reinitialization if already initialized (default behavior). Exits with error if git-flow is already configured.
 
 ### Branch Name Overrides
 
@@ -171,6 +179,11 @@ Interactive initialization:
 git flow init
 ```
 
+Reinitialize with different settings:
+```bash
+git flow init --force --preset=github
+```
+
 ## CONFIGURATION
 
 After initialization, git-flow stores configuration in **.git/config** under the **gitflow.*** namespace:
@@ -200,7 +213,7 @@ After initialization, git-flow stores configuration in **.git/config** under the
 : Repository not found or not a git repository
 
 **2**
-: Repository already initialized (use config commands to modify)
+: Repository already initialized (use **--force** to reinitialize)
 
 **3**
 : Invalid preset or configuration options
@@ -211,7 +224,8 @@ After initialization, git-flow stores configuration in **.git/config** under the
 
 ## NOTES
 
-- **git-flow init** can be run multiple times safely
+- **git-flow init** requires **--force** to reinitialize an already initialized repository
+- Existing git-flow-avh configuration is automatically imported without requiring **--force**
 - Existing branches are preserved during initialization
 - Compatible with repositories previously initialized with git-flow-avh
 - All configuration is stored locally in the repository

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -44,6 +44,17 @@ func (e *NotInitializedError) ExitCode() ExitCode {
 	return ExitCodeNotInitialized
 }
 
+// AlreadyInitializedError indicates git-flow is already initialized
+type AlreadyInitializedError struct{}
+
+func (e *AlreadyInitializedError) Error() string {
+	return "git flow is already initialized (use --force to reinitialize)"
+}
+
+func (e *AlreadyInitializedError) ExitCode() ExitCode {
+	return ExitCodeInvalidInput
+}
+
 // EmptyBranchNameError indicates that a branch name was not provided
 type EmptyBranchNameError struct{}
 

--- a/test/cmd/init_test.go
+++ b/test/cmd/init_test.go
@@ -564,3 +564,89 @@ func TestInitWithDefaultsAndOverrides(t *testing.T) {
 		t.Error("Expected 'hotfix' branch configuration to exist")
 	}
 }
+
+// TestInitAlreadyInitializedError tests that init fails when already initialized
+func TestInitAlreadyInitializedError(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// First init should succeed
+	_, err := runGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("First init failed: %v", err)
+	}
+
+	// Second init should fail with exit code 2
+	output, err := runGitFlow(t, dir, "init", "--defaults")
+	if err == nil {
+		t.Fatalf("Expected second init to fail")
+	}
+
+	if !strings.Contains(output, "already initialized") {
+		t.Errorf("Expected 'already initialized' error, got: %s", output)
+	}
+}
+
+// TestInitWithForceReinit tests that --force allows reinitialization
+func TestInitWithForceReinit(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// First init
+	_, err := runGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("First init failed: %v", err)
+	}
+
+	// Reinit with --force and different settings
+	output, err := runGitFlow(t, dir, "init", "--force", "--defaults", "--feature=feat/")
+	if err != nil {
+		t.Fatalf("Force reinit failed: %v\nOutput: %s", err, output)
+	}
+
+	// Verify new config applied
+	featurePrefix := getGitConfig(t, dir, "gitflow.branch.feature.prefix")
+	if featurePrefix != "feat/" {
+		t.Errorf("Expected feature prefix 'feat/', got: %s", featurePrefix)
+	}
+}
+
+// TestInitWithForceShortFlag tests that -f short flag works
+func TestInitWithForceShortFlag(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// First init
+	_, err := runGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("First init failed: %v", err)
+	}
+
+	// Reinit with -f short flag
+	_, err = runGitFlow(t, dir, "init", "-f", "--defaults")
+	if err != nil {
+		t.Fatalf("Force reinit with -f failed: %v", err)
+	}
+}
+
+// TestInitNoForceFlag tests that --no-force explicitly denies reinit
+func TestInitNoForceFlag(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// First init
+	_, err := runGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("First init failed: %v", err)
+	}
+
+	// Reinit with --no-force should fail
+	output, err := runGitFlow(t, dir, "init", "--no-force", "--defaults")
+	if err == nil {
+		t.Fatalf("Expected --no-force to prevent reinit")
+	}
+
+	if !strings.Contains(output, "already initialized") {
+		t.Errorf("Expected 'already initialized' error, got: %s", output)
+	}
+}


### PR DESCRIPTION
  Resolves #7

  Prevents accidental reconfiguration by blocking `git flow init` when already initialized. Users must now explicitly use `--force` to reinitialize, protecting existing configuration from unintended overwrites.

  ### Changes

  - **Reinit protection**: Init now exits with code 2 if git-flow is already configured
  - **`--force`/`-f` flag**: Allows intentional reinitialization with a warning message
  - **AVH migration preserved**: Importing existing git-flow-avh config still works without `--force`
  - **New error type**: `AlreadyInitializedError` in `internal/errors/errors.go`

  ### Notes

  - Default behavior changed: previously init could run multiple times silently
  - AVH import is treated as migration (not reconfiguration) so it doesn't require `--force`
  - Four new integration tests in `test/cmd/init_test.go` cover reinit scenario