### PR TITLE
Check if branch is behind remote before finishing

### DIFF
--- a/cmd/finish.go
+++ b/cmd/finish.go
@@ -79,8 +79,8 @@ const (
 // =============================================================================
 
 // FinishCommand is the implementation of the finish command for topic branches
-func FinishCommand(branchType string, name string, continueOp bool, abortOp bool, force bool, tagOptions *config.TagOptions, retentionOptions *config.BranchRetentionOptions, mergeOptions *config.MergeStrategyOptions, fetch *bool) {
-	if err := executeFinish(branchType, name, continueOp, abortOp, force, tagOptions, retentionOptions, mergeOptions, fetch); err != nil {
+func FinishCommand(branchType string, name string, continueOp bool, abortOp bool, force bool, tagOptions *config.TagOptions, retentionOptions *config.BranchRetentionOptions, mergeOptions *config.MergeStrategyOptions, fetch *bool, noRemoteCheck bool) {
+	if err := executeFinish(branchType, name, continueOp, abortOp, force, tagOptions, retentionOptions, mergeOptions, fetch, noRemoteCheck); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -97,7 +97,7 @@ func FinishCommand(branchType string, name string, continueOp bool, abortOp bool
 // =============================================================================
 
 // executeFinish performs the actual branch finishing logic and returns any errors
-func executeFinish(branchType string, name string, continueOp bool, abortOp bool, force bool, tagOptions *config.TagOptions, retentionOptions *config.BranchRetentionOptions, mergeOptions *config.MergeStrategyOptions, fetch *bool) error {
+func executeFinish(branchType string, name string, continueOp bool, abortOp bool, force bool, tagOptions *config.TagOptions, retentionOptions *config.BranchRetentionOptions, mergeOptions *config.MergeStrategyOptions, fetch *bool, noRemoteCheck bool) error {
 	// Get configuration early
 	cfg, err := config.LoadConfig()
 	if err != nil {
@@ -200,6 +200,21 @@ func executeFinish(branchType string, name string, continueOp bool, abortOp bool
 			return &errors.GitError{Operation: "fetch from remote", Err: err}
 		}
 		fmt.Printf("Fetch completed\n")
+
+		// Check if branch is behind remote (only if we fetched and check is enabled)
+		if !noRemoteCheck {
+			behindCount, err := git.GetBehindCount(name, cfg.Remote)
+			if err != nil {
+				// Non-fatal warning - proceed if we can't determine status
+				fmt.Fprintf(os.Stderr, "Warning: Could not check remote status: %v\n", err)
+			} else if behindCount > 0 {
+				return &errors.BranchBehindRemoteError{
+					BranchName:    name,
+					RemoteName:    cfg.Remote,
+					CommitsBehind: behindCount,
+				}
+			}
+		}
 	}
 
 	// Regular finish command flow

--- a/cmd/shorthand.go
+++ b/cmd/shorthand.go
@@ -151,7 +151,8 @@ func RegisterShorthandCommands() {
 				Squash:         getBoolPtr(cmd, "squash", "no-squash"),
 				SquashMessage:  getStringPtrFromFlag(cmd, "squash-message"),
 			}
-			FinishCommand(branchType, name, continueOp, abortOp, force, tagOptions, retentionOptions, mergeOptions, nil)
+			noRemoteCheck, _ := cmd.Flags().GetBool("no-remote-check")
+			FinishCommand(branchType, name, continueOp, abortOp, force, tagOptions, retentionOptions, mergeOptions, nil, noRemoteCheck)
 		},
 	}
 

--- a/cmd/topicbranch.go
+++ b/cmd/topicbranch.go
@@ -154,6 +154,9 @@ func registerBranchCommand(branchType string) {
 			fetch, _ := cmd.Flags().GetBool("fetch")
 			noFetch, _ := cmd.Flags().GetBool("no-fetch")
 
+			// Get remote check flag
+			noRemoteCheck, _ := cmd.Flags().GetBool("no-remote-check")
+
 			// Determine branch name - use provided arg or detect from current branch
 			var name string
 			if len(args) > 0 {
@@ -213,7 +216,7 @@ func registerBranchCommand(branchType string) {
 			}
 
 			// Call the generic finish command with the branch type and name
-			FinishCommand(branchType, name, continueOp, abortOp, force, tagOptions, retentionOptions, mergeOptions, getBoolFlag(fetch, noFetch))
+			FinishCommand(branchType, name, continueOp, abortOp, force, tagOptions, retentionOptions, mergeOptions, getBoolFlag(fetch, noFetch), noRemoteCheck)
 		},
 	}
 
@@ -433,6 +436,9 @@ func addFinishFlags(cmd *cobra.Command) {
 	// Fetch Flags
 	cmd.Flags().Bool("fetch", false, "Fetch from remote before finishing")
 	cmd.Flags().Bool("no-fetch", false, "Don't fetch from remote before finishing")
+
+	// Remote Check Flags
+	cmd.Flags().Bool("no-remote-check", false, "Skip check for commits behind remote tracking branch")
 }
 
 // getBoolFlag converts two opposite boolean flags into a single *bool value

--- a/docs/git-flow-finish.1.md
+++ b/docs/git-flow-finish.1.md
@@ -132,6 +132,9 @@ The operation maintains a persistent state file that allows it to resume after c
 **--no-fetch**
 : Don't fetch from remote before finishing. Overrides git config setting `gitflow.<type>.finish.fetch`.
 
+**--no-remote-check**
+: Skip the check that verifies the local branch is not behind its remote tracking branch. By default (when fetch is enabled), finish will abort if the branch is behind to prevent incomplete integrations.
+
 ## MERGE STRATEGIES
 
 The merge strategy used when finishing follows a three-layer precedence system:
@@ -314,7 +317,7 @@ git config gitflow.<type>.finish.fetch true
 : Topic branch not found
 
 **2**
-: Git operation failed (conflicts, etc.)
+: Branch is behind remote tracking branch (use **--no-remote-check** to override), or other invalid input
 
 **3**
 : Invalid branch name or configuration
@@ -339,7 +342,8 @@ git config gitflow.<type>.finish.fetch true
 - **--preserve-merges** flag only applies to rebase operations
 - **--squash** and **--rebase** flags are mutually exclusive when both set explicitly
 - Use **--continue** and **--abort** for conflict resolution
-- Tag creation behavior varies by topic branch type configuration  
+- Tag creation behavior varies by topic branch type configuration
 - The **git-flow finish** shorthand automatically detects current topic branch type
 - Child branches are automatically updated when their parent changes
 - Some topic branch types (like releases and hotfixes) may create tags by default
+- When fetch is enabled, the local branch is checked against its remote tracking branch; if behind, finish aborts to prevent incomplete integrations (use **--no-remote-check** to skip)

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -240,3 +240,19 @@ func (e *RemoteBranchNotFoundError) Error() string {
 func (e *RemoteBranchNotFoundError) ExitCode() ExitCode {
 	return ExitCodeBranchNotFound
 }
+
+// BranchBehindRemoteError indicates the local branch is behind its remote tracking branch
+type BranchBehindRemoteError struct {
+	BranchName    string
+	RemoteName    string
+	CommitsBehind int
+}
+
+func (e *BranchBehindRemoteError) Error() string {
+	return fmt.Sprintf("branch '%s' is %d commit(s) behind '%s/%s'. Pull the latest changes or use --no-remote-check to proceed anyway",
+		e.BranchName, e.CommitsBehind, e.RemoteName, e.BranchName)
+}
+
+func (e *BranchBehindRemoteError) ExitCode() ExitCode {
+	return ExitCodeInvalidInput
+}

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -495,3 +495,30 @@ func CreateTrackingBranch(localBranch, remote, remoteBranch string) error {
 	}
 	return nil
 }
+
+// GetBehindCount returns how many commits the local branch is behind its remote tracking branch.
+// Returns 0 if the branch has no remote tracking branch or is up to date.
+func GetBehindCount(branch, remote string) (int, error) {
+	remoteBranch := remote + "/" + branch
+
+	// Check if remote branch exists first
+	if !RemoteBranchExists(remote, branch) {
+		return 0, nil // No remote branch, nothing to be behind
+	}
+
+	// git rev-list --count branch..remote/branch
+	cmd := exec.Command("git", "rev-list", "--count", branch+".."+remoteBranch)
+	output, err := cmd.Output()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get behind count: %w", err)
+	}
+
+	countStr := strings.TrimSpace(string(output))
+	var count int
+	_, err = fmt.Sscanf(countStr, "%d", &count)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse commit count '%s': %w", countStr, err)
+	}
+
+	return count, nil
+}

--- a/test/cmd/finish_test.go
+++ b/test/cmd/finish_test.go
@@ -1362,3 +1362,249 @@ func TestFinishCleansUpBaseBranch(t *testing.T) {
 		t.Error("Expected feature branch to be deleted after finish")
 	}
 }
+
+// TestFinishBranchBehindRemote tests that finish fails when local branch is behind remote
+func TestFinishBranchBehindRemote(t *testing.T) {
+	// Setup test repo with remote
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	// Create a feature branch
+	output, err := testutil.RunGitFlow(t, dir, "feature", "start", "behind-test")
+	if err != nil {
+		t.Fatalf("Failed to create feature branch: %v\nOutput: %s", err, output)
+	}
+
+	// Add a commit to the feature branch
+	testutil.WriteFile(t, dir, "local.txt", "local content")
+	_, err = testutil.RunGit(t, dir, "add", "local.txt")
+	if err != nil {
+		t.Fatalf("Failed to add file: %v", err)
+	}
+	_, err = testutil.RunGit(t, dir, "commit", "-m", "Local commit")
+	if err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// Push the feature branch to remote
+	_, err = testutil.RunGit(t, dir, "push", "-u", "origin", "feature/behind-test")
+	if err != nil {
+		t.Fatalf("Failed to push feature branch: %v", err)
+	}
+
+	// Clone the remote to simulate a teammate
+	teammateDir, err := os.MkdirTemp("", "git-flow-test-teammate-*")
+	if err != nil {
+		t.Fatalf("Failed to create teammate directory: %v", err)
+	}
+	defer os.RemoveAll(teammateDir)
+
+	_, err = testutil.RunGit(t, teammateDir, "clone", remoteDir, ".")
+	if err != nil {
+		t.Fatalf("Failed to clone remote: %v", err)
+	}
+	_, err = testutil.RunGit(t, teammateDir, "config", "user.name", "Teammate")
+	if err != nil {
+		t.Fatalf("Failed to configure teammate user name: %v", err)
+	}
+	_, err = testutil.RunGit(t, teammateDir, "config", "user.email", "teammate@example.com")
+	if err != nil {
+		t.Fatalf("Failed to configure teammate user email: %v", err)
+	}
+
+	// Teammate checks out the feature branch and adds a commit
+	_, err = testutil.RunGit(t, teammateDir, "checkout", "feature/behind-test")
+	if err != nil {
+		t.Fatalf("Failed to checkout feature branch in teammate repo: %v", err)
+	}
+	testutil.WriteFile(t, teammateDir, "teammate.txt", "teammate content")
+	_, err = testutil.RunGit(t, teammateDir, "add", "teammate.txt")
+	if err != nil {
+		t.Fatalf("Failed to add teammate file: %v", err)
+	}
+	_, err = testutil.RunGit(t, teammateDir, "commit", "-m", "Teammate commit")
+	if err != nil {
+		t.Fatalf("Failed to commit teammate file: %v", err)
+	}
+	_, err = testutil.RunGit(t, teammateDir, "push")
+	if err != nil {
+		t.Fatalf("Failed to push teammate commit: %v", err)
+	}
+
+	// Now back to original repo - local is behind remote
+	// Try to finish with fetch enabled - should fail
+	output, err = testutil.RunGitFlow(t, dir, "feature", "finish", "behind-test", "--fetch")
+	if err == nil {
+		t.Fatalf("Expected finish to fail when branch is behind remote, but it succeeded\nOutput: %s", output)
+	}
+
+	if !strings.Contains(output, "behind") {
+		t.Errorf("Expected error message to mention 'behind', got: %s", output)
+	}
+
+	// Verify branch still exists (not deleted since finish failed)
+	if !testutil.BranchExists(t, dir, "feature/behind-test") {
+		t.Error("Expected feature branch to still exist after failed finish")
+	}
+}
+
+// TestFinishBranchBehindRemoteWithNoCheck tests that --no-remote-check bypasses the check
+func TestFinishBranchBehindRemoteWithNoCheck(t *testing.T) {
+	// Setup test repo with remote
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	// Create a feature branch
+	output, err := testutil.RunGitFlow(t, dir, "feature", "start", "nocheck-test")
+	if err != nil {
+		t.Fatalf("Failed to create feature branch: %v\nOutput: %s", err, output)
+	}
+
+	// Add a commit to the feature branch
+	testutil.WriteFile(t, dir, "local.txt", "local content")
+	_, err = testutil.RunGit(t, dir, "add", "local.txt")
+	if err != nil {
+		t.Fatalf("Failed to add file: %v", err)
+	}
+	_, err = testutil.RunGit(t, dir, "commit", "-m", "Local commit")
+	if err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// Push the feature branch to remote
+	_, err = testutil.RunGit(t, dir, "push", "-u", "origin", "feature/nocheck-test")
+	if err != nil {
+		t.Fatalf("Failed to push feature branch: %v", err)
+	}
+
+	// Clone the remote to simulate a teammate
+	teammateDir, err := os.MkdirTemp("", "git-flow-test-teammate-*")
+	if err != nil {
+		t.Fatalf("Failed to create teammate directory: %v", err)
+	}
+	defer os.RemoveAll(teammateDir)
+
+	_, err = testutil.RunGit(t, teammateDir, "clone", remoteDir, ".")
+	if err != nil {
+		t.Fatalf("Failed to clone remote: %v", err)
+	}
+	_, err = testutil.RunGit(t, teammateDir, "config", "user.name", "Teammate")
+	if err != nil {
+		t.Fatalf("Failed to configure teammate user name: %v", err)
+	}
+	_, err = testutil.RunGit(t, teammateDir, "config", "user.email", "teammate@example.com")
+	if err != nil {
+		t.Fatalf("Failed to configure teammate user email: %v", err)
+	}
+
+	// Teammate checks out the feature branch and adds a commit
+	_, err = testutil.RunGit(t, teammateDir, "checkout", "feature/nocheck-test")
+	if err != nil {
+		t.Fatalf("Failed to checkout feature branch in teammate repo: %v", err)
+	}
+	testutil.WriteFile(t, teammateDir, "teammate.txt", "teammate content")
+	_, err = testutil.RunGit(t, teammateDir, "add", "teammate.txt")
+	if err != nil {
+		t.Fatalf("Failed to add teammate file: %v", err)
+	}
+	_, err = testutil.RunGit(t, teammateDir, "commit", "-m", "Teammate commit")
+	if err != nil {
+		t.Fatalf("Failed to commit teammate file: %v", err)
+	}
+	_, err = testutil.RunGit(t, teammateDir, "push")
+	if err != nil {
+		t.Fatalf("Failed to push teammate commit: %v", err)
+	}
+
+	// Now back to original repo - local is behind remote
+	// Finish with --no-remote-check should succeed
+	output, err = testutil.RunGitFlow(t, dir, "feature", "finish", "nocheck-test", "--fetch", "--no-remote-check")
+	if err != nil {
+		t.Fatalf("Expected finish with --no-remote-check to succeed, but it failed: %v\nOutput: %s", err, output)
+	}
+
+	// Verify branch is deleted (finish succeeded)
+	if testutil.BranchExists(t, dir, "feature/nocheck-test") {
+		t.Error("Expected feature branch to be deleted after successful finish")
+	}
+}
+
+// TestFinishBranchNoRemoteTracking tests finish works when no remote tracking exists
+func TestFinishBranchNoRemoteTracking(t *testing.T) {
+	// Setup test repo with remote (but we won't push the feature branch)
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	// Create a feature branch (local only, not pushed)
+	output, err := testutil.RunGitFlow(t, dir, "feature", "start", "local-only")
+	if err != nil {
+		t.Fatalf("Failed to create feature branch: %v\nOutput: %s", err, output)
+	}
+
+	// Add a commit
+	testutil.WriteFile(t, dir, "local.txt", "local content")
+	_, err = testutil.RunGit(t, dir, "add", "local.txt")
+	if err != nil {
+		t.Fatalf("Failed to add file: %v", err)
+	}
+	_, err = testutil.RunGit(t, dir, "commit", "-m", "Local commit")
+	if err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// Finish with fetch enabled - should succeed because no remote tracking branch exists
+	output, err = testutil.RunGitFlow(t, dir, "feature", "finish", "local-only", "--fetch")
+	if err != nil {
+		t.Fatalf("Expected finish to succeed for local-only branch, but it failed: %v\nOutput: %s", err, output)
+	}
+
+	// Verify branch is deleted
+	if testutil.BranchExists(t, dir, "feature/local-only") {
+		t.Error("Expected feature branch to be deleted after finish")
+	}
+}
+
+// TestFinishBranchUpToDateWithRemote tests finish works when branch is up to date with remote
+func TestFinishBranchUpToDateWithRemote(t *testing.T) {
+	// Setup test repo with remote
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	// Create a feature branch
+	output, err := testutil.RunGitFlow(t, dir, "feature", "start", "uptodate-test")
+	if err != nil {
+		t.Fatalf("Failed to create feature branch: %v\nOutput: %s", err, output)
+	}
+
+	// Add a commit
+	testutil.WriteFile(t, dir, "local.txt", "local content")
+	_, err = testutil.RunGit(t, dir, "add", "local.txt")
+	if err != nil {
+		t.Fatalf("Failed to add file: %v", err)
+	}
+	_, err = testutil.RunGit(t, dir, "commit", "-m", "Local commit")
+	if err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// Push to remote (so we're up to date)
+	_, err = testutil.RunGit(t, dir, "push", "-u", "origin", "feature/uptodate-test")
+	if err != nil {
+		t.Fatalf("Failed to push feature branch: %v", err)
+	}
+
+	// Finish with fetch enabled - should succeed because we're up to date
+	output, err = testutil.RunGitFlow(t, dir, "feature", "finish", "uptodate-test", "--fetch")
+	if err != nil {
+		t.Fatalf("Expected finish to succeed when up to date with remote, but it failed: %v\nOutput: %s", err, output)
+	}
+
+	// Verify branch is deleted
+	if testutil.BranchExists(t, dir, "feature/uptodate-test") {
+		t.Error("Expected feature branch to be deleted after finish")
+	}
+}


### PR DESCRIPTION
  Resolves #38

  Adds a safety check during `git flow finish` that detects if the local branch is behind its remote tracking branch. This prevents accidentally finishing a branch without integrating teammate's changes, which could lead to incomplete or broken integrations.

  ### Changes

  - **Remote sync check**: When `--fetch` is enabled, finish now compares local branch against remote and aborts if behind (exit code 2)
  - **`--no-remote-check` flag**: Allows bypassing the check when intentionally finishing with local-only changes
  - **New error type**: `BranchBehindRemoteError` with clear message showing how many commits behind
  - **New git helper**: `GetBehindCount()` in `internal/git/repo.go`

  ###  Notes

  - The check only runs when fetch is enabled (either via `--fetch` flag or config)
  - Branches without remote tracking are unaffected and finish normally