### PR TITLE
Add --force option to init command

### DIFF
--- a/docs/git-flow-init.1.md
+++ b/docs/git-flow-init.1.md
@@ -6,7 +6,7 @@ git-flow-init - Initialize git-flow in a repository
 
 ## SYNOPSIS
 
-**git-flow init** [**--preset**=*preset*] [**--custom**] [**--defaults**] [*options*]
+**git-flow init** [**-f**|**--force**] [**--preset**=*preset*] [**--custom**] [**--defaults**] [*options*]
 
 ## DESCRIPTION
 
@@ -19,6 +19,11 @@ Initialize git-flow configuration in the current Git repository. This command se
 3. **Custom Mode** - Sets up only the trunk branch and shows configuration commands
 
 ## OPTIONS
+
+### General Options
+
+**-f**, **--force**
+: Force reconfiguration of git-flow even if already initialized. Without this option, **git flow init** will fail if configuration already exists (in non-interactive mode) or prompt for confirmation (in interactive mode).
 
 ### Preset Options
 
@@ -171,6 +176,21 @@ Interactive initialization:
 git flow init
 ```
 
+Reconfigure git-flow with new settings:
+```bash
+git flow init --force --feature=feat/
+```
+
+Force reinitialize with github preset:
+```bash
+git flow init --preset=github --force
+```
+
+Reconfigure with short flag:
+```bash
+git flow init -f --defaults
+```
+
 ## CONFIGURATION
 
 After initialization, git-flow stores configuration in **.git/config** under the **gitflow.*** namespace:
@@ -211,7 +231,8 @@ After initialization, git-flow stores configuration in **.git/config** under the
 
 ## NOTES
 
-- **git-flow init** can be run multiple times safely
+- **git-flow init** requires **--force** to reconfigure an already initialized repository in non-interactive mode
+- In interactive mode without **--force**, users are prompted for confirmation before reconfiguring
 - Existing branches are preserved during initialization
 - Compatible with repositories previously initialized with git-flow-avh
 - All configuration is stored locally in the repository

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -284,6 +284,7 @@ func LoadConfig() (*Config, error) {
 }
 
 // IsInitialized checks if git-flow is initialized in the repository
+// This includes both git-flow-next and git-flow-avh configurations
 func IsInitialized() (bool, error) {
 	// Get current directory for git operations
 	currentDir, err := os.Getwd()
@@ -299,6 +300,24 @@ func IsInitialized() (bool, error) {
 
 	// Check for git-flow-avh configuration
 	if CheckGitFlowAVHConfig() {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// IsGitFlowNextInitialized checks if git-flow-next specifically is initialized
+// This only checks for our own configuration, not git-flow-avh
+func IsGitFlowNextInitialized() (bool, error) {
+	// Get current directory for git operations
+	currentDir, err := os.Getwd()
+	if err != nil {
+		return false, fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	// Check for our own gitflow.version config
+	version, err := git.GetConfigInDir(currentDir, "gitflow.version")
+	if err == nil && version != "" {
 		return true, nil
 	}
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -240,3 +240,14 @@ func (e *RemoteBranchNotFoundError) Error() string {
 func (e *RemoteBranchNotFoundError) ExitCode() ExitCode {
 	return ExitCodeBranchNotFound
 }
+
+// AlreadyInitializedError indicates git-flow is already configured
+type AlreadyInitializedError struct{}
+
+func (e *AlreadyInitializedError) Error() string {
+	return "git-flow is already initialized in this repository. Use --force to reconfigure"
+}
+
+func (e *AlreadyInitializedError) ExitCode() ExitCode {
+	return ExitCodeValidationError
+}

--- a/test/cmd/init_force_test.go
+++ b/test/cmd/init_force_test.go
@@ -1,0 +1,391 @@
+package cmd_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// TestInitFreshRepo tests that init works on a fresh repository without --force.
+// Steps:
+// 1. Sets up a new test repository
+// 2. Runs 'git flow init --defaults'
+// 3. Verifies initialization succeeds and config is created
+func TestInitFreshRepo(t *testing.T) {
+	// Setup
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// Run git-flow init --defaults
+	output, err := runGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to run git-flow init --defaults: %v\nOutput: %s", err, output)
+	}
+
+	// Check if the output contains the expected message
+	if !strings.Contains(output, "Initializing git-flow with default settings") {
+		t.Errorf("Expected output to contain 'Initializing git-flow with default settings', got: %s", output)
+	}
+
+	// Verify configuration was created
+	version := getGitConfig(t, dir, "gitflow.version")
+	if version != "1.0" {
+		t.Errorf("Expected gitflow.version to be '1.0', got: %s", version)
+	}
+
+	initialized := getGitConfig(t, dir, "gitflow.initialized")
+	if initialized != "true" {
+		t.Errorf("Expected gitflow.initialized to be 'true', got: %s", initialized)
+	}
+}
+
+// TestInitWithoutForceFailsWhenAlreadyInitialized tests that re-init without --force fails.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow
+// 2. Attempts to run 'git flow init --defaults' again without --force
+// 3. Verifies the operation fails with "already initialized" error
+func TestInitWithoutForceFailsWhenAlreadyInitialized(t *testing.T) {
+	// Setup
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// First initialization
+	output, err := runGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed initial git-flow init: %v\nOutput: %s", err, output)
+	}
+
+	// Attempt second initialization without --force
+	output, err = runGitFlow(t, dir, "init", "--defaults")
+	if err == nil {
+		t.Fatalf("Expected git-flow init to fail when already initialized, but it succeeded\nOutput: %s", output)
+	}
+
+	// Check error message
+	if !strings.Contains(output, "already initialized") {
+		t.Errorf("Expected error to contain 'already initialized', got: %s", output)
+	}
+
+	if !strings.Contains(output, "--force") {
+		t.Errorf("Expected error to mention '--force' option, got: %s", output)
+	}
+}
+
+// TestInitWithForceSucceedsWhenAlreadyInitialized tests that re-init with --force succeeds.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow
+// 2. Runs 'git flow init --defaults --force'
+// 3. Verifies the operation succeeds and shows reconfiguration message
+func TestInitWithForceSucceedsWhenAlreadyInitialized(t *testing.T) {
+	// Setup
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// First initialization
+	output, err := runGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed initial git-flow init: %v\nOutput: %s", err, output)
+	}
+
+	// Second initialization with --force
+	output, err = runGitFlow(t, dir, "init", "--defaults", "--force")
+	if err != nil {
+		t.Fatalf("Failed to run git-flow init --defaults --force: %v\nOutput: %s", err, output)
+	}
+
+	// Check for reconfiguration message
+	if !strings.Contains(output, "Reconfiguring git-flow") {
+		t.Errorf("Expected output to contain 'Reconfiguring git-flow', got: %s", output)
+	}
+
+	// Verify configuration still exists
+	version := getGitConfig(t, dir, "gitflow.version")
+	if version != "1.0" {
+		t.Errorf("Expected gitflow.version to be '1.0', got: %s", version)
+	}
+}
+
+// TestInitInteractiveReconfirmYes tests interactive re-init with 'y' confirmation.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow
+// 2. Runs 'git flow init' interactively with 'y' response to reconfigure prompt
+// 3. Verifies the operation proceeds after confirmation
+func TestInitInteractiveReconfirmYes(t *testing.T) {
+	// Setup
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// First initialization with defaults
+	output, err := runGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed initial git-flow init: %v\nOutput: %s", err, output)
+	}
+
+	// Interactive second initialization - confirm with 'y' followed by standard interactive input
+	// Input: y (confirm), then defaults for all prompts (empty lines use defaults)
+	input := "y\n\n\n\n\n\n\n\n"
+	output, err = runGitFlowWithInput(t, dir, input, "init")
+	if err != nil {
+		t.Fatalf("Failed to run interactive git-flow init with confirmation: %v\nOutput: %s", err, output)
+	}
+
+	// Check for confirmation prompt
+	if !strings.Contains(output, "already configured") {
+		t.Errorf("Expected output to contain 'already configured', got: %s", output)
+	}
+
+	if !strings.Contains(output, "reconfigure") {
+		t.Errorf("Expected output to contain 'reconfigure', got: %s", output)
+	}
+
+	// Verify initialization completed
+	if !strings.Contains(output, "Git flow has been initialized") {
+		t.Errorf("Expected output to contain 'Git flow has been initialized', got: %s", output)
+	}
+}
+
+// TestInitInteractiveReconfirmNo tests interactive re-init with 'n' cancellation.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow
+// 2. Runs 'git flow init' interactively with 'n' response to reconfigure prompt
+// 3. Verifies the operation is cancelled
+func TestInitInteractiveReconfirmNo(t *testing.T) {
+	// Setup
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// First initialization with defaults
+	output, err := runGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed initial git-flow init: %v\nOutput: %s", err, output)
+	}
+
+	// Get initial config to compare later
+	initialFeaturePrefix := getGitConfig(t, dir, "gitflow.branch.feature.prefix")
+
+	// Interactive second initialization - cancel with 'n'
+	input := "n\n"
+	output, err = runGitFlowWithInput(t, dir, input, "init")
+	if err != nil {
+		t.Fatalf("Unexpected error when cancelling reconfiguration: %v\nOutput: %s", err, output)
+	}
+
+	// Check for cancellation message
+	if !strings.Contains(output, "cancelled") {
+		t.Errorf("Expected output to contain 'cancelled', got: %s", output)
+	}
+
+	// Verify configuration wasn't changed
+	currentFeaturePrefix := getGitConfig(t, dir, "gitflow.branch.feature.prefix")
+	if currentFeaturePrefix != initialFeaturePrefix {
+		t.Errorf("Expected feature prefix to remain '%s', got: '%s'", initialFeaturePrefix, currentFeaturePrefix)
+	}
+}
+
+// TestInitForceWithPresetChange tests force reconfiguration with a different preset.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with default preset
+// 2. Runs 'git flow init --preset github --force'
+// 3. Verifies the configuration is updated to GitHub preset
+func TestInitForceWithPresetChange(t *testing.T) {
+	// Setup
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// First initialization with classic preset (defaults)
+	output, err := runGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed initial git-flow init: %v\nOutput: %s", err, output)
+	}
+
+	// Verify develop branch exists (classic preset has develop)
+	developType := getGitConfig(t, dir, "gitflow.branch.develop.type")
+	if developType != "base" {
+		t.Errorf("Expected develop branch to exist after classic init, got type: %s", developType)
+	}
+
+	// Reinitialize with github preset
+	output, err = runGitFlow(t, dir, "init", "--preset", "github", "--force")
+	if err != nil {
+		t.Fatalf("Failed to run git-flow init --preset github --force: %v\nOutput: %s", err, output)
+	}
+
+	// Verify GitHub preset was applied (feature branches point to main)
+	featureParent := getGitConfig(t, dir, "gitflow.branch.feature.parent")
+	if featureParent != "main" {
+		t.Errorf("Expected feature parent to be 'main' for GitHub preset, got: %s", featureParent)
+	}
+}
+
+// TestInitForceWithCustomPrefix tests force reconfiguration with custom branch prefix.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Runs 'git flow init --force --feature feat/'
+// 3. Verifies the feature prefix is updated
+func TestInitForceWithCustomPrefix(t *testing.T) {
+	// Setup
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// First initialization with defaults
+	output, err := runGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed initial git-flow init: %v\nOutput: %s", err, output)
+	}
+
+	// Verify initial feature prefix
+	initialPrefix := getGitConfig(t, dir, "gitflow.branch.feature.prefix")
+	if initialPrefix != "feature/" {
+		t.Errorf("Expected initial feature prefix to be 'feature/', got: %s", initialPrefix)
+	}
+
+	// Reinitialize with custom prefix
+	output, err = runGitFlow(t, dir, "init", "--force", "--feature", "feat/")
+	if err != nil {
+		t.Fatalf("Failed to run git-flow init --force --feature feat/: %v\nOutput: %s", err, output)
+	}
+
+	// Verify feature prefix was updated
+	newPrefix := getGitConfig(t, dir, "gitflow.branch.feature.prefix")
+	if newPrefix != "feat/" {
+		t.Errorf("Expected feature prefix to be 'feat/', got: %s", newPrefix)
+	}
+}
+
+// TestInitWithPresetFailsWithoutForce tests that re-init with preset fails without --force.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow
+// 2. Attempts to run 'git flow init --preset github' without --force
+// 3. Verifies the operation fails
+func TestInitWithPresetFailsWithoutForce(t *testing.T) {
+	// Setup
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// First initialization
+	output, err := runGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed initial git-flow init: %v\nOutput: %s", err, output)
+	}
+
+	// Attempt second initialization with preset but without --force
+	output, err = runGitFlow(t, dir, "init", "--preset", "github")
+	if err == nil {
+		t.Fatalf("Expected git-flow init --preset to fail when already initialized, but it succeeded\nOutput: %s", output)
+	}
+
+	// Check error message
+	if !strings.Contains(output, "already initialized") {
+		t.Errorf("Expected error to contain 'already initialized', got: %s", output)
+	}
+}
+
+// TestInitWithCustomFlagFailsWithoutForce tests that re-init with custom flags fails without --force.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow
+// 2. Attempts to run 'git flow init --feature feat/' without --force
+// 3. Verifies the operation fails
+func TestInitWithCustomFlagFailsWithoutForce(t *testing.T) {
+	// Setup
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// First initialization
+	output, err := runGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed initial git-flow init: %v\nOutput: %s", err, output)
+	}
+
+	// Attempt second initialization with custom flag but without --force
+	output, err = runGitFlow(t, dir, "init", "--feature", "feat/")
+	if err == nil {
+		t.Fatalf("Expected git-flow init with custom flag to fail when already initialized, but it succeeded\nOutput: %s", output)
+	}
+
+	// Check error message
+	if !strings.Contains(output, "already initialized") {
+		t.Errorf("Expected error to contain 'already initialized', got: %s", output)
+	}
+}
+
+// TestAVHConfigDoesNotRequireForce verifies that importing AVH config works without --force.
+// AVH-only configuration (without gitflow.version) should be importable without --force,
+// since it's not considered a git-flow-next re-initialization.
+// Steps:
+// 1. Sets up a test repository with AVH configuration only
+// 2. Runs 'git flow init' without --force
+// 3. Verifies the operation succeeds and imports AVH config
+func TestAVHConfigDoesNotRequireForce(t *testing.T) {
+	// Setup
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// Set up AVH configuration (without git-flow-next's gitflow.version)
+	avhConfigs := [][]string{
+		{"gitflow.branch.master", "main"},
+		{"gitflow.branch.develop", "dev"},
+		{"gitflow.prefix.feature", "feat/"},
+		{"gitflow.prefix.release", "rel/"},
+		{"gitflow.prefix.hotfix", "fix/"},
+	}
+
+	for _, cfg := range avhConfigs {
+		cmd := exec.Command("git", "config", cfg[0], cfg[1])
+		cmd.Dir = dir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("Failed to set %s: %v", cfg[0], err)
+		}
+	}
+
+	// Run git-flow init without --force - should work since only AVH config exists
+	output, err := runGitFlow(t, dir, "init")
+	if err != nil {
+		t.Fatalf("Expected git-flow init to succeed with AVH-only config, but it failed: %v\nOutput: %s", err, output)
+	}
+
+	// Check that AVH import message was shown
+	if !strings.Contains(output, "Found existing git-flow-avh configuration, importing") {
+		t.Errorf("Expected output to contain AVH import message, got: %s", output)
+	}
+
+	// Verify that imported config has the AVH prefixes
+	featurePrefix := getGitConfig(t, dir, "gitflow.branch.feature.prefix")
+	if featurePrefix != "feat/" {
+		t.Errorf("Expected feature prefix to be 'feat/' from AVH import, got: %s", featurePrefix)
+	}
+}
+
+// TestInitForceOnFreshRepo verifies that --force on an uninitialized repo works normally.
+// Steps:
+// 1. Sets up a new test repository
+// 2. Runs 'git flow init --defaults --force'
+// 3. Verifies the operation succeeds
+func TestInitForceOnFreshRepo(t *testing.T) {
+	// Setup
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// Run git-flow init --defaults --force on fresh repo
+	output, err := runGitFlow(t, dir, "init", "--defaults", "--force")
+	if err != nil {
+		t.Fatalf("Expected git-flow init --force to succeed on fresh repo, but it failed: %v\nOutput: %s", err, output)
+	}
+
+	// Should show normal initialization message (not reconfiguration)
+	if !strings.Contains(output, "Initializing git-flow with default settings") {
+		t.Errorf("Expected output to contain 'Initializing git-flow with default settings', got: %s", output)
+	}
+
+	// Should NOT show reconfiguration message since repo wasn't initialized before
+	if strings.Contains(output, "Reconfiguring git-flow") {
+		t.Errorf("Did not expect reconfiguration message on fresh repo, got: %s", output)
+	}
+
+	// Verify configuration was created
+	version := getGitConfig(t, dir, "gitflow.version")
+	if version != "1.0" {
+		t.Errorf("Expected gitflow.version to be '1.0', got: %s", version)
+	}
+}


### PR DESCRIPTION
Users need the ability to reconfigure git-flow in repositories that are already initialized. Previously, re-running `git flow init` had inconsistent behavior—sometimes silently proceeding, sometimes failing cryptically.

This adds a `-f/--force` flag that explicitly allows reconfiguration. Without it:
- Non-interactive mode (`--defaults`, `--preset`, etc.) fails with a clear error suggesting `--force`
- Interactive mode prompts "Do you want to reconfigure? [y/N]"

Repositories with only AVH config (`gitflow.branch.master`, `gitflow.prefix.feature`) but no git-flow-next config (`gitflow.version`) are not considered "already initialized"—this triggers the migration path, which imports AVH settings without requiring `--force`.

## Notes

- No breaking changes for existing scripts—fresh init is unchanged, and the new error for re-init is an improvement over undefined behavior
- The `--no-force` flag mentioned in the issue is intentionally not implemented; it would only make the default behavior explicit, adding complexity without value
- 12 tests cover the core scenarios plus edge cases (AVH import, `--force` on fresh repo)

Resolves #7