### PR TITLE
Add --no-verify option to finish command (#59)

### DIFF
--- a/cmd/shorthand.go
+++ b/cmd/shorthand.go
@@ -151,7 +151,13 @@ func RegisterShorthandCommands() {
 				Squash:         getBoolPtr(cmd, "squash", "no-squash"),
 				SquashMessage:  getStringPtrFromFlag(cmd, "squash-message"),
 			}
-			FinishCommand(branchType, name, continueOp, abortOp, force, tagOptions, retentionOptions, mergeOptions, nil)
+			// Get no-verify flag
+			noVerify, _ := cmd.Flags().GetBool("no-verify")
+			var noVerifyPtr *bool
+			if noVerify {
+				noVerifyPtr = &noVerify
+			}
+			FinishCommand(branchType, name, continueOp, abortOp, force, tagOptions, retentionOptions, mergeOptions, nil, noVerifyPtr)
 		},
 	}
 

--- a/cmd/topicbranch.go
+++ b/cmd/topicbranch.go
@@ -154,6 +154,9 @@ func registerBranchCommand(branchType string) {
 			fetch, _ := cmd.Flags().GetBool("fetch")
 			noFetch, _ := cmd.Flags().GetBool("no-fetch")
 
+			// Get hook bypass flag
+			noVerify, _ := cmd.Flags().GetBool("no-verify")
+
 			// Determine branch name - use provided arg or detect from current branch
 			var name string
 			if len(args) > 0 {
@@ -219,7 +222,7 @@ func registerBranchCommand(branchType string) {
 			}
 
 			// Call the generic finish command with the branch type and name
-			FinishCommand(branchType, name, continueOp, abortOp, force, tagOptions, retentionOptions, mergeOptions, getBoolFlag(fetch, noFetch))
+			FinishCommand(branchType, name, continueOp, abortOp, force, tagOptions, retentionOptions, mergeOptions, getBoolFlag(fetch, noFetch), getSingleBoolPtr(noVerify))
 		},
 	}
 
@@ -441,6 +444,9 @@ func addFinishFlags(cmd *cobra.Command) {
 	// Fetch Flags
 	cmd.Flags().Bool("fetch", false, "Fetch from remote before finishing")
 	cmd.Flags().Bool("no-fetch", false, "Don't fetch from remote before finishing")
+
+	// Hook Control Flags
+	cmd.Flags().Bool("no-verify", false, "Bypass pre-commit and commit-msg hooks during merge and commit operations")
 }
 
 // getBoolFlag converts two opposite boolean flags into a single *bool value
@@ -464,4 +470,13 @@ func getStringPtr(s string) *string {
 		return nil
 	}
 	return &s
+}
+
+// getSingleBoolPtr converts a bool to a *bool, returning nil for false
+// This is used for flags that only have a positive form (e.g., --no-verify)
+func getSingleBoolPtr(b bool) *bool {
+	if !b {
+		return nil
+	}
+	return &b
 }

--- a/docs/git-flow-finish.1.md
+++ b/docs/git-flow-finish.1.md
@@ -138,6 +138,11 @@ The operation maintains a persistent state file that allows it to resume after c
 **--no-fetch**
 : Don't fetch from remote before finishing. Disables the default fetch behavior. Overrides git config setting `gitflow.<type>.finish.fetch`.
 
+### Hook Control
+
+**--no-verify**
+: Bypass pre-commit and commit-msg hooks during merge and commit operations. This passes the `--no-verify` flag to the underlying `git merge` and `git commit` commands. Useful when hooks would interfere with automated finishing workflows or when you want to temporarily skip validation. The setting is persisted through `--continue` operations after conflict resolution. Overrides git config setting `gitflow.<type>.finish.noverify`.
+
 ## REMOTE SYNC CHECK
 
 Before performing the merge operation, the finish command checks if the local topic branch is in sync with its remote tracking branch. This safety check prevents accidental data loss when the remote has commits that are not present locally.
@@ -361,6 +366,18 @@ Clean up both local and remote:
 git flow feature finish my-feature --no-keeplocal --no-keepremote
 ```
 
+### Bypassing Hooks
+
+Skip pre-commit and commit-msg hooks during finish:
+```bash
+git flow feature finish my-feature --no-verify
+```
+
+Useful in CI/CD environments where hooks might interfere:
+```bash
+git flow release finish 1.2.0 --no-verify --tag
+```
+
 ## WORKFLOW BEHAVIOR
 
 ### Dual Merge Pattern
@@ -412,6 +429,9 @@ git config gitflow.<type>.finish.fetch true
 # Custom merge commit messages (with placeholder support)
 git config gitflow.<type>.finish.mergemessage "feat: merge %b into %p"
 git config gitflow.<type>.finish.updatemessage "chore: sync %b from %p"
+
+# Hook control
+git config gitflow.<type>.finish.noverify true
 ```
 
 ## EXIT STATUS

--- a/docs/gitflow-config.5.md
+++ b/docs/gitflow-config.5.md
@@ -437,6 +437,13 @@ The finish command supports extensive merge strategy configuration through comma
 
 These options are useful for teams using commit message validation hooks (e.g., conventional commits) where auto-generated messages would be rejected.
 
+### Hook Control Options
+
+**gitflow.*type*.finish.noverify**
+: Bypass pre-commit and commit-msg hooks during merge and commit operations. When enabled, passes `--no-verify` to the underlying `git merge` and `git commit` commands. This is useful in CI/CD pipelines or when hooks would interfere with automated workflows. The setting is persisted through `--continue` operations after conflict resolution.
+: *Type*: boolean
+: *Default*: false
+
 ### Strategy Precedence
 
 1. **Command-line flags** (Layer 3 — highest priority, one-off overrides)

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -188,8 +188,14 @@ func CreateInitialCommit(branch string) error {
 }
 
 // Merge merges a branch into the current branch
-func Merge(branch string) error {
-	cmd := exec.Command("git", "merge", "--no-ff", branch)
+func Merge(branch string, noVerify bool) error {
+	args := []string{"merge", "--no-ff"}
+	if noVerify {
+		args = append(args, "--no-verify")
+	}
+	args = append(args, branch)
+
+	cmd := exec.Command("git", args...)
 	output, err := cmd.CombinedOutput()
 	outputStr := string(output)
 
@@ -226,8 +232,14 @@ func Rebase(branch string) error {
 }
 
 // SquashMerge performs a squash merge of a branch into the current branch
-func SquashMerge(branch string) error {
-	cmd := exec.Command("git", "merge", "--squash", branch)
+func SquashMerge(branch string, noVerify bool) error {
+	args := []string{"merge", "--squash"}
+	if noVerify {
+		args = append(args, "--no-verify")
+	}
+	args = append(args, branch)
+
+	cmd := exec.Command("git", args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		if strings.Contains(string(output), "conflict") {
@@ -237,7 +249,11 @@ func SquashMerge(branch string) error {
 	}
 
 	// Commit the squashed changes
-	cmd = exec.Command("git", "commit", "-m", fmt.Sprintf("Squashed commit of branch '%s'", branch))
+	commitArgs := []string{"commit", "-m", fmt.Sprintf("Squashed commit of branch '%s'", branch)}
+	if noVerify {
+		commitArgs = append(commitArgs, "--no-verify")
+	}
+	cmd = exec.Command("git", commitArgs...)
 	output, err = cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to commit squashed changes: %s", string(output))
@@ -412,10 +428,13 @@ func RebaseWithOptions(targetBranch string, preserveMerges bool) error {
 }
 
 // MergeWithOptions merges a branch into current branch with optional no-fast-forward
-func MergeWithOptions(branchName string, noFF bool) error {
+func MergeWithOptions(branchName string, noFF bool, noVerify bool) error {
 	args := []string{"merge"}
 	if noFF {
 		args = append(args, "--no-ff")
+	}
+	if noVerify {
+		args = append(args, "--no-verify")
 	}
 	args = append(args, branchName)
 
@@ -443,10 +462,13 @@ func MergeWithOptions(branchName string, noFF bool) error {
 }
 
 // MergeWithMessage merges a branch into current branch with a custom commit message
-func MergeWithMessage(branchName string, message string, noFF bool) error {
+func MergeWithMessage(branchName string, message string, noFF bool, noVerify bool) error {
 	args := []string{"merge"}
 	if noFF {
 		args = append(args, "--no-ff")
+	}
+	if noVerify {
+		args = append(args, "--no-verify")
 	}
 	args = append(args, "-m", message, branchName)
 
@@ -474,8 +496,12 @@ func MergeWithMessage(branchName string, message string, noFF bool) error {
 }
 
 // Commit creates a commit with the given message
-func Commit(message string) error {
-	cmd := exec.Command("git", "commit", "-m", message)
+func Commit(message string, noVerify bool) error {
+	args := []string{"commit", "-m", message}
+	if noVerify {
+		args = append(args, "--no-verify")
+	}
+	cmd := exec.Command("git", args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to commit: %s", string(output))
@@ -502,8 +528,14 @@ func RebaseContinue() error {
 }
 
 // MergeSquashWithMessage performs a squash merge with a custom commit message
-func MergeSquashWithMessage(branchName string, message string) error {
-	cmd := exec.Command("git", "merge", "--squash", branchName)
+func MergeSquashWithMessage(branchName string, message string, noVerify bool) error {
+	args := []string{"merge", "--squash"}
+	if noVerify {
+		args = append(args, "--no-verify")
+	}
+	args = append(args, branchName)
+
+	cmd := exec.Command("git", args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		if strings.Contains(string(output), "conflict") {
@@ -513,7 +545,11 @@ func MergeSquashWithMessage(branchName string, message string) error {
 	}
 
 	// Commit the squashed changes with custom message
-	cmd = exec.Command("git", "commit", "-m", message)
+	commitArgs := []string{"commit", "-m", message}
+	if noVerify {
+		commitArgs = append(commitArgs, "--no-verify")
+	}
+	cmd = exec.Command("git", commitArgs...)
 	output, err = cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to commit squashed changes: %s", string(output))

--- a/internal/mergestate/mergestate.go
+++ b/internal/mergestate/mergestate.go
@@ -55,6 +55,9 @@ type MergeState struct {
 	// Custom merge commit messages
 	MergeMessage  string `json:"mergeMessage,omitempty"`  // Custom commit message for upstream merge
 	UpdateMessage string `json:"updateMessage,omitempty"` // Custom commit message for child updates
+
+	// Hook options
+	NoVerify bool `json:"noVerify,omitempty"` // Skip pre-commit and commit-msg hooks
 }
 
 // SaveMergeState saves the current merge state to a file

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -29,6 +29,7 @@ func UpdateBranchFromParentWithMessage(branchName string, parentBranch string, s
 	}
 
 	// Use the configured merge strategy
+	// Note: noVerify is false for update operations (only finish supports --no-verify)
 	var mergeErr error
 	switch strings.ToLower(strategy) {
 	case "rebase":
@@ -37,16 +38,16 @@ func UpdateBranchFromParentWithMessage(branchName string, parentBranch string, s
 	case "squash":
 		fmt.Printf("Using squash strategy for '%s'\n", branchName)
 		if customMessage != "" {
-			mergeErr = git.MergeSquashWithMessage(parentBranch, customMessage)
+			mergeErr = git.MergeSquashWithMessage(parentBranch, customMessage, false)
 		} else {
-			mergeErr = git.SquashMerge(parentBranch)
+			mergeErr = git.SquashMerge(parentBranch, false)
 		}
 	default:
 		fmt.Printf("Using merge strategy for '%s'\n", branchName)
 		if customMessage != "" {
-			mergeErr = git.MergeWithMessage(parentBranch, customMessage, true)
+			mergeErr = git.MergeWithMessage(parentBranch, customMessage, true, false)
 		} else {
-			mergeErr = git.Merge(parentBranch)
+			mergeErr = git.Merge(parentBranch, false)
 		}
 	}
 

--- a/test/cmd/finish_noverify_test.go
+++ b/test/cmd/finish_noverify_test.go
@@ -1,0 +1,533 @@
+package cmd_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// createRejectingHooks creates hooks that reject merge and commit operations.
+// This installs both pre-merge-commit (for merge commits) and pre-commit (for regular commits).
+// The --no-verify flag on git merge bypasses pre-merge-commit.
+// The --no-verify flag on git commit bypasses pre-commit.
+func createRejectingHooks(t *testing.T, dir string) {
+	t.Helper()
+	hooksDir := filepath.Join(dir, ".git", "hooks")
+	if err := os.MkdirAll(hooksDir, 0755); err != nil {
+		t.Fatalf("Failed to create hooks directory: %v", err)
+	}
+
+	script := `#!/bin/sh
+echo "Hook: operation rejected by hook" >&2
+exit 1
+`
+	// Install pre-merge-commit hook (runs during merge commits, Git 2.24+)
+	preMergeCommitPath := filepath.Join(hooksDir, "pre-merge-commit")
+	if err := os.WriteFile(preMergeCommitPath, []byte(script), 0755); err != nil {
+		t.Fatalf("Failed to create pre-merge-commit hook: %v", err)
+	}
+
+	// Install pre-commit hook (runs during regular commits like squash merge final commit)
+	preCommitPath := filepath.Join(hooksDir, "pre-commit")
+	if err := os.WriteFile(preCommitPath, []byte(script), 0755); err != nil {
+		t.Fatalf("Failed to create pre-commit hook: %v", err)
+	}
+}
+
+// TestFinishFeatureFailsWithRejectingPreCommitHook tests that finish fails when a pre-merge-commit hook rejects.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow
+// 2. Creates a feature branch
+// 3. Adds a test file and commits to the feature branch
+// 4. Adds a different commit on develop to force a non-fast-forward merge
+// 5. Installs pre-merge-commit and pre-commit hooks that reject (exit code 1)
+// 6. Attempts to finish the feature branch without --no-verify
+// 7. Verifies the finish operation fails (hook blocked the merge commit)
+// 8. Verifies the feature branch still exists (not deleted)
+func TestFinishFeatureFailsWithRejectingPreCommitHook(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// Initialize git-flow
+	_, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+
+	// Start a feature branch
+	_, err = testutil.RunGitFlow(t, dir, "feature", "start", "test-hook")
+	if err != nil {
+		t.Fatalf("Failed to start feature: %v", err)
+	}
+
+	// Add a commit to the feature branch
+	testutil.WriteFile(t, dir, "feature.txt", "feature content")
+	_, _ = testutil.RunGit(t, dir, "add", "feature.txt")
+	_, _ = testutil.RunGit(t, dir, "commit", "-m", "Add feature file")
+
+	// Add a commit to develop to force a non-fast-forward merge
+	// (Fast-forward merges don't create merge commits and don't trigger pre-merge-commit hooks)
+	_, _ = testutil.RunGit(t, dir, "checkout", "develop")
+	testutil.WriteFile(t, dir, "develop.txt", "develop content")
+	_, _ = testutil.RunGit(t, dir, "add", "develop.txt")
+	_, _ = testutil.RunGit(t, dir, "commit", "-m", "Add develop file")
+
+	// Switch back to feature branch for finish command
+	_, _ = testutil.RunGit(t, dir, "checkout", "feature/test-hook")
+
+	// Install rejecting hooks AFTER setting up the branches
+	createRejectingHooks(t, dir)
+
+	// Try to finish without --no-verify - should fail due to hook
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "--no-fetch", "test-hook")
+	if err == nil {
+		t.Fatal("Expected finish to fail due to pre-merge-commit hook, but it succeeded")
+	}
+
+	// Verify the error mentions the hook or commit failure
+	outputLower := strings.ToLower(output)
+	if !strings.Contains(outputLower, "hook") && !strings.Contains(outputLower, "rejected") {
+		t.Logf("Output: %s", output)
+	}
+
+	// Verify feature branch still exists (finish was blocked)
+	if !testutil.BranchExists(t, dir, "feature/test-hook") {
+		t.Error("Feature branch should still exist when finish failed")
+	}
+}
+
+// TestFinishFeatureWithNoVerifyFlagBypassesHook tests that --no-verify bypasses the pre-merge-commit hook.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow
+// 2. Creates a feature branch
+// 3. Adds a test file and commits to the feature branch
+// 4. Adds a different commit on develop to force a non-fast-forward merge
+// 5. Installs pre-merge-commit and pre-commit hooks that reject (exit code 1)
+// 6. Finishes the feature branch with --no-verify flag
+// 7. Verifies the finish operation succeeds (hook was bypassed)
+// 8. Verifies the feature branch is deleted
+// 9. Verifies changes are merged into develop
+func TestFinishFeatureWithNoVerifyFlagBypassesHook(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// Initialize git-flow
+	_, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+
+	// Start a feature branch
+	_, err = testutil.RunGitFlow(t, dir, "feature", "start", "noverify-test")
+	if err != nil {
+		t.Fatalf("Failed to start feature: %v", err)
+	}
+
+	// Add a commit to the feature branch
+	testutil.WriteFile(t, dir, "feature.txt", "feature content")
+	_, _ = testutil.RunGit(t, dir, "add", "feature.txt")
+	_, _ = testutil.RunGit(t, dir, "commit", "-m", "Add feature file")
+
+	// Add a commit to develop to force a non-fast-forward merge
+	// (Fast-forward merges don't create merge commits and don't trigger pre-merge-commit hooks)
+	_, _ = testutil.RunGit(t, dir, "checkout", "develop")
+	testutil.WriteFile(t, dir, "develop.txt", "develop content")
+	_, _ = testutil.RunGit(t, dir, "add", "develop.txt")
+	_, _ = testutil.RunGit(t, dir, "commit", "-m", "Add develop file")
+
+	// Switch back to feature branch for finish command
+	_, _ = testutil.RunGit(t, dir, "checkout", "feature/noverify-test")
+
+	// Install rejecting hooks AFTER setting up the branches
+	createRejectingHooks(t, dir)
+
+	// Finish with --no-verify - should succeed (hook bypassed)
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "--no-fetch", "--no-verify", "noverify-test")
+	if err != nil {
+		t.Fatalf("Expected finish with --no-verify to succeed, but it failed: %v\nOutput: %s", err, output)
+	}
+
+	// Verify feature branch is deleted
+	if testutil.BranchExists(t, dir, "feature/noverify-test") {
+		t.Error("Feature branch should be deleted after successful finish")
+	}
+
+	// Verify we're on develop
+	currentBranch := testutil.GetCurrentBranch(t, dir)
+	if currentBranch != "develop" {
+		t.Errorf("Expected to be on develop branch, got: %s", currentBranch)
+	}
+
+	// Verify the feature file exists on develop (changes merged)
+	featureFile := filepath.Join(dir, "feature.txt")
+	if _, err := os.Stat(featureFile); os.IsNotExist(err) {
+		t.Error("Feature file should exist on develop after merge")
+	}
+}
+
+// TestFinishFeatureWithNoVerifyConfig tests that gitflow.feature.finish.noVerify config bypasses the hook.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow
+// 2. Sets gitflow.feature.finish.noVerify=true in git config
+// 3. Creates a feature branch
+// 4. Adds a test file and commits to the feature branch
+// 5. Adds a different commit on develop to force a non-fast-forward merge
+// 6. Installs pre-merge-commit and pre-commit hooks that reject (exit code 1)
+// 7. Finishes the feature branch without any CLI flags
+// 8. Verifies the finish operation succeeds (hook bypassed via config)
+// 9. Verifies the feature branch is deleted
+// 10. Verifies changes are merged into develop
+func TestFinishFeatureWithNoVerifyConfig(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// Initialize git-flow
+	_, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+
+	// Set noVerify config before creating the branch
+	_, err = testutil.RunGit(t, dir, "config", "gitflow.feature.finish.noVerify", "true")
+	if err != nil {
+		t.Fatalf("Failed to set noVerify config: %v", err)
+	}
+
+	// Start a feature branch
+	_, err = testutil.RunGitFlow(t, dir, "feature", "start", "config-test")
+	if err != nil {
+		t.Fatalf("Failed to start feature: %v", err)
+	}
+
+	// Add a commit to the feature branch
+	testutil.WriteFile(t, dir, "feature.txt", "feature content")
+	_, _ = testutil.RunGit(t, dir, "add", "feature.txt")
+	_, _ = testutil.RunGit(t, dir, "commit", "-m", "Add feature file")
+
+	// Add a commit to develop to force a non-fast-forward merge
+	_, _ = testutil.RunGit(t, dir, "checkout", "develop")
+	testutil.WriteFile(t, dir, "develop.txt", "develop content")
+	_, _ = testutil.RunGit(t, dir, "add", "develop.txt")
+	_, _ = testutil.RunGit(t, dir, "commit", "-m", "Add develop file")
+
+	// Switch back to feature branch for finish command
+	_, _ = testutil.RunGit(t, dir, "checkout", "feature/config-test")
+
+	// Install rejecting hooks
+	createRejectingHooks(t, dir)
+
+	// Finish WITHOUT --no-verify flag - config should enable it
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "--no-fetch", "config-test")
+	if err != nil {
+		t.Fatalf("Expected finish to succeed with noVerify config, but it failed: %v\nOutput: %s", err, output)
+	}
+
+	// Verify feature branch is deleted
+	if testutil.BranchExists(t, dir, "feature/config-test") {
+		t.Error("Feature branch should be deleted after successful finish")
+	}
+
+	// Verify the feature file exists on develop
+	featureFile := filepath.Join(dir, "feature.txt")
+	if _, err := os.Stat(featureFile); os.IsNotExist(err) {
+		t.Error("Feature file should exist on develop after merge")
+	}
+}
+
+// TestFinishFeatureNoVerifyFlagOverridesConfig tests that CLI --no-verify overrides noVerify=false config.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow
+// 2. Sets gitflow.feature.finish.noVerify=false in git config
+// 3. Creates a feature branch
+// 4. Adds a test file and commits to the feature branch
+// 5. Adds a different commit on develop to force a non-fast-forward merge
+// 6. Installs pre-merge-commit and pre-commit hooks that reject (exit code 1)
+// 7. Finishes the feature branch with --no-verify flag
+// 8. Verifies the finish operation succeeds (CLI flag overrides config)
+// 9. Verifies the feature branch is deleted
+// 10. Verifies changes are merged into develop
+func TestFinishFeatureNoVerifyFlagOverridesConfig(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// Initialize git-flow
+	_, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+
+	// Explicitly set noVerify=false in config
+	_, err = testutil.RunGit(t, dir, "config", "gitflow.feature.finish.noVerify", "false")
+	if err != nil {
+		t.Fatalf("Failed to set noVerify config: %v", err)
+	}
+
+	// Start a feature branch
+	_, err = testutil.RunGitFlow(t, dir, "feature", "start", "override-test")
+	if err != nil {
+		t.Fatalf("Failed to start feature: %v", err)
+	}
+
+	// Add a commit to the feature branch
+	testutil.WriteFile(t, dir, "feature.txt", "feature content")
+	_, _ = testutil.RunGit(t, dir, "add", "feature.txt")
+	_, _ = testutil.RunGit(t, dir, "commit", "-m", "Add feature file")
+
+	// Add a commit to develop to force a non-fast-forward merge
+	_, _ = testutil.RunGit(t, dir, "checkout", "develop")
+	testutil.WriteFile(t, dir, "develop.txt", "develop content")
+	_, _ = testutil.RunGit(t, dir, "add", "develop.txt")
+	_, _ = testutil.RunGit(t, dir, "commit", "-m", "Add develop file")
+
+	// Switch back to feature branch for finish command
+	_, _ = testutil.RunGit(t, dir, "checkout", "feature/override-test")
+
+	// Install rejecting hooks
+	createRejectingHooks(t, dir)
+
+	// Finish WITH --no-verify flag - should override config=false
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "--no-fetch", "--no-verify", "override-test")
+	if err != nil {
+		t.Fatalf("Expected finish with --no-verify to succeed, but it failed: %v\nOutput: %s", err, output)
+	}
+
+	// Verify feature branch is deleted
+	if testutil.BranchExists(t, dir, "feature/override-test") {
+		t.Error("Feature branch should be deleted after successful finish")
+	}
+
+	// Verify the feature file exists on develop
+	featureFile := filepath.Join(dir, "feature.txt")
+	if _, err := os.Stat(featureFile); os.IsNotExist(err) {
+		t.Error("Feature file should exist on develop after merge")
+	}
+}
+
+// TestFinishFeatureNoVerifyPersistedThroughContinue tests that --no-verify persists through --continue.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow
+// 2. Creates a feature branch with a test file
+// 3. Switches to develop and adds conflicting content to the same file
+// 4. Switches back to feature branch
+// 5. Installs pre-merge-commit and pre-commit hooks that reject (exit code 1)
+// 6. Runs finish with --no-verify and --no-fetch (conflict occurs, hook hasn't fired yet)
+// 7. Verifies merge state exists with NoVerify=true persisted in state file
+// 8. Resolves the conflict and stages the resolved file
+// 9. Runs finish --continue WITHOUT --no-verify on the command line
+// 10. Verifies the finish succeeds (hook bypassed via persisted MergeState.NoVerify)
+// 11. Verifies the feature branch is deleted
+// 12. Verifies the resolved changes are merged into develop
+func TestFinishFeatureNoVerifyPersistedThroughContinue(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// Initialize git-flow
+	_, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+
+	// Start a feature branch
+	_, err = testutil.RunGitFlow(t, dir, "feature", "start", "conflict-test")
+	if err != nil {
+		t.Fatalf("Failed to start feature: %v", err)
+	}
+
+	// Add a file on the feature branch
+	testutil.WriteFile(t, dir, "conflict.txt", "feature version")
+	_, _ = testutil.RunGit(t, dir, "add", "conflict.txt")
+	_, _ = testutil.RunGit(t, dir, "commit", "-m", "Add feature version of file")
+
+	// Switch to develop and create conflicting content
+	_, _ = testutil.RunGit(t, dir, "checkout", "develop")
+	testutil.WriteFile(t, dir, "conflict.txt", "develop version")
+	_, _ = testutil.RunGit(t, dir, "add", "conflict.txt")
+	_, _ = testutil.RunGit(t, dir, "commit", "-m", "Add develop version of file")
+
+	// Switch back to feature
+	_, _ = testutil.RunGit(t, dir, "checkout", "feature/conflict-test")
+
+	// Install rejecting pre-commit hook BEFORE finish
+	// The hook will fire during the commit after conflict resolution
+	createRejectingHooks(t, dir)
+
+	// Try to finish with --no-verify - will conflict
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "--no-fetch", "--no-verify", "conflict-test")
+	if err == nil {
+		t.Fatalf("Expected finish to fail with merge conflict, but it succeeded\nOutput: %s", output)
+	}
+
+	// Verify we have a conflict state
+	if !strings.Contains(output, "conflict") && !strings.Contains(strings.ToLower(output), "conflict") {
+		t.Logf("Output: %s", output)
+	}
+
+	// Verify merge state file exists and contains NoVerify=true
+	stateFile := filepath.Join(dir, ".git", "gitflow", "state", "merge.json")
+	stateContent, err := os.ReadFile(stateFile)
+	if err != nil {
+		t.Fatalf("Failed to read merge state file: %v", err)
+	}
+	if !strings.Contains(string(stateContent), `"noVerify":true`) {
+		t.Errorf("Expected merge state to contain noVerify:true, got: %s", string(stateContent))
+	}
+
+	// Resolve the conflict
+	testutil.WriteFile(t, dir, "conflict.txt", "resolved content")
+	_, _ = testutil.RunGit(t, dir, "add", "conflict.txt")
+
+	// Continue WITHOUT --no-verify flag - should use persisted state
+	output, err = testutil.RunGitFlow(t, dir, "feature", "finish", "--continue", "conflict-test")
+	if err != nil {
+		t.Fatalf("Expected finish --continue to succeed (noVerify persisted), but it failed: %v\nOutput: %s", err, output)
+	}
+
+	// Verify feature branch is deleted
+	if testutil.BranchExists(t, dir, "feature/conflict-test") {
+		t.Error("Feature branch should be deleted after successful finish --continue")
+	}
+
+	// Verify the resolved file exists on develop
+	content, err := os.ReadFile(filepath.Join(dir, "conflict.txt"))
+	if err != nil {
+		t.Fatal("Resolved file should exist on develop")
+	}
+	if string(content) != "resolved content" {
+		t.Errorf("Expected resolved content, got: %s", string(content))
+	}
+}
+
+// TestFinishReleaseWithNoVerifyStillCreatesTag tests that --no-verify bypasses hooks but tag is still created.
+// Note: Release finish merges to main (not develop), and then updates develop from main.
+// The child branch update (develop from main) does NOT use --no-verify (by design).
+// To isolate the release merge test, we disable auto-update on develop.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow
+// 2. Disables auto-update on develop branch
+// 3. Creates a release branch (release/1.0.0)
+// 4. Adds a test file and commits to the release branch
+// 5. Adds a commit on main to force a non-fast-forward merge
+// 6. Installs pre-merge-commit and pre-commit hooks that reject (exit code 1)
+// 7. Finishes the release branch with --no-verify flag
+// 8. Verifies the finish operation succeeds (hook was bypassed)
+// 9. Verifies tag '1.0.0' was created (tag creation is unaffected by --no-verify)
+// 10. Verifies the release branch is deleted
+func TestFinishReleaseWithNoVerifyStillCreatesTag(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// Initialize git-flow
+	_, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+
+	// Disable auto-update on develop to avoid child branch update triggering hooks
+	// (Child branch updates don't use --no-verify by design)
+	_, err = testutil.RunGit(t, dir, "config", "gitflow.branch.develop.autoUpdate", "false")
+	if err != nil {
+		t.Fatalf("Failed to disable auto-update: %v", err)
+	}
+
+	// Start a release branch
+	_, err = testutil.RunGitFlow(t, dir, "release", "start", "1.0.0")
+	if err != nil {
+		t.Fatalf("Failed to start release: %v", err)
+	}
+
+	// Add a commit to the release branch
+	testutil.WriteFile(t, dir, "release.txt", "release content")
+	_, _ = testutil.RunGit(t, dir, "add", "release.txt")
+	_, _ = testutil.RunGit(t, dir, "commit", "-m", "Add release file")
+
+	// Add a commit to main to force a non-fast-forward merge
+	_, _ = testutil.RunGit(t, dir, "checkout", "main")
+	testutil.WriteFile(t, dir, "main.txt", "main content")
+	_, _ = testutil.RunGit(t, dir, "add", "main.txt")
+	_, _ = testutil.RunGit(t, dir, "commit", "-m", "Add main file")
+
+	// Switch back to release branch for finish command
+	_, _ = testutil.RunGit(t, dir, "checkout", "release/1.0.0")
+
+	// Install rejecting hooks
+	createRejectingHooks(t, dir)
+
+	// Finish with --no-verify
+	output, err := testutil.RunGitFlow(t, dir, "release", "finish", "--no-fetch", "--no-verify", "1.0.0")
+	if err != nil {
+		t.Fatalf("Expected release finish with --no-verify to succeed, but it failed: %v\nOutput: %s", err, output)
+	}
+
+	// Verify tag was created
+	tagOutput, err := testutil.RunGit(t, dir, "tag", "-l", "1.0.0")
+	if err != nil {
+		t.Fatalf("Failed to list tags: %v", err)
+	}
+	if !strings.Contains(tagOutput, "1.0.0") {
+		t.Errorf("Expected tag 1.0.0 to be created, got: %s", tagOutput)
+	}
+
+	// Verify release branch is deleted
+	if testutil.BranchExists(t, dir, "release/1.0.0") {
+		t.Error("Release branch should be deleted after successful finish")
+	}
+}
+
+// TestFinishFeatureDefaultDoesNotSkipVerify tests that without --no-verify, hooks run normally.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow
+// 2. Creates a feature branch
+// 3. Adds a test file and commits to the feature branch
+// 4. Adds a different commit on develop to force a non-fast-forward merge
+// 5. Installs pre-merge-commit and pre-commit hooks that reject (exit code 1)
+// 6. Attempts to finish the feature branch without --no-verify flag and without config
+// 7. Verifies the finish operation fails (hook is active by default)
+// 8. Verifies the feature branch still exists
+func TestFinishFeatureDefaultDoesNotSkipVerify(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// Initialize git-flow
+	_, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+
+	// Start a feature branch
+	_, err = testutil.RunGitFlow(t, dir, "feature", "start", "default-test")
+	if err != nil {
+		t.Fatalf("Failed to start feature: %v", err)
+	}
+
+	// Add a commit to the feature branch
+	testutil.WriteFile(t, dir, "feature.txt", "feature content")
+	_, _ = testutil.RunGit(t, dir, "add", "feature.txt")
+	_, _ = testutil.RunGit(t, dir, "commit", "-m", "Add feature file")
+
+	// Add a commit to develop to force a non-fast-forward merge
+	// (Fast-forward merges don't create merge commits and don't trigger pre-merge-commit hooks)
+	_, _ = testutil.RunGit(t, dir, "checkout", "develop")
+	testutil.WriteFile(t, dir, "develop.txt", "develop content")
+	_, _ = testutil.RunGit(t, dir, "add", "develop.txt")
+	_, _ = testutil.RunGit(t, dir, "commit", "-m", "Add develop file")
+
+	// Switch back to feature branch for finish command
+	_, _ = testutil.RunGit(t, dir, "checkout", "feature/default-test")
+
+	// Install rejecting hooks
+	createRejectingHooks(t, dir)
+
+	// Try to finish WITHOUT any noVerify flags or config - should fail
+	_, err = testutil.RunGitFlow(t, dir, "feature", "finish", "--no-fetch", "default-test")
+	if err == nil {
+		t.Fatal("Expected finish to fail due to pre-merge-commit hook (default behavior), but it succeeded")
+	}
+
+	// Verify feature branch still exists (finish was blocked)
+	if !testutil.BranchExists(t, dir, "feature/default-test") {
+		t.Error("Feature branch should still exist when finish failed due to hook")
+	}
+}


### PR DESCRIPTION
Adds `--no-verify` flag to the finish command that bypasses pre-commit and commit-msg hooks during merge and commit operations. The setting can also be configured via `gitflow.<type>.finish.noVerify` and is persisted through `--continue` operations after conflict resolution.

Changes touch `cmd/finish.go`, `cmd/topicbranch.go`, `internal/git/repo.go`, `internal/config/resolver.go`, and `internal/mergestate/mergestate.go`. Includes 7 new tests covering flag usage, config override, and state persistence. Documentation updated in `docs/git-flow-finish.1.md` and `docs/gitflow-config.5.md`.

Resolves #59