### PR TITLE
Add --merge-message and --update-message options to finish command (#58)

### DIFF
--- a/cmd/topicbranch.go
+++ b/cmd/topicbranch.go
@@ -203,6 +203,10 @@ func registerBranchCommand(branchType string) {
 				ForceDelete: getBoolFlag(forceDelete, noForceDelete),
 			}
 
+			// Get merge message flags
+			mergeMessage, _ := cmd.Flags().GetString("merge-message")
+			updateMessage, _ := cmd.Flags().GetString("update-message")
+
 			// Create merge strategy options
 			mergeOptions := &config.MergeStrategyOptions{
 				Rebase:         getBoolFlag(rebase, noRebase),
@@ -210,6 +214,8 @@ func registerBranchCommand(branchType string) {
 				NoFF:           getBoolFlag(noFF, ff),
 				Squash:         getBoolFlag(squash, noSquash),
 				SquashMessage:  getStringPtr(squashMessage),
+				MergeMessage:   getStringPtr(mergeMessage),
+				UpdateMessage:  getStringPtr(updateMessage),
 			}
 
 			// Call the generic finish command with the branch type and name
@@ -429,6 +435,8 @@ func addFinishFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolP("squash", "S", false, "Squash all commits into single commit")
 	cmd.Flags().Bool("no-squash", false, "Keep individual commits (don't squash)")
 	cmd.Flags().String("squash-message", "", "Custom commit message for squash merge")
+	cmd.Flags().StringP("merge-message", "M", "", "Custom commit message for the upstream merge operation")
+	cmd.Flags().String("update-message", "", "Custom commit message for child branch update operations")
 
 	// Fetch Flags
 	cmd.Flags().Bool("fetch", false, "Fetch from remote before finishing")

--- a/docs/git-flow-finish.1.md
+++ b/docs/git-flow-finish.1.md
@@ -113,10 +113,10 @@ The operation maintains a persistent state file that allows it to resume after c
 : Custom commit message for squash merge. This is a CLI-only option with no git config equivalent, as squash messages are specific to each branch being finished.
 
 **--merge-message**, **-M** *message*
-: Custom commit message for the upstream merge operation (topic branch to parent). This is a CLI-only option with no git config equivalent, as merge messages are specific to each branch being finished. Useful for teams using commit message validation hooks (e.g., conventional commits) where auto-generated messages like "Merge branch 'feature/foo'" would be rejected.
+: Custom commit message for the upstream merge operation (topic branch to parent). This is a CLI-only option with no git config equivalent, as merge messages are specific to each branch being finished. Useful for teams using commit message validation hooks (e.g., conventional commits) where auto-generated messages like "Merge branch 'feature/foo'" would be rejected. Supports placeholders (see MESSAGE PLACEHOLDERS below).
 
 **--update-message** *message*
-: Custom commit message for child branch update operations (parent to child branches). When finishing a release or hotfix, child branches like develop are automatically updated from the parent. This option allows customizing those merge commit messages. This is a CLI-only option with no git config equivalent.
+: Custom commit message for child branch update operations (parent to child branches). When finishing a release or hotfix, child branches like develop are automatically updated from the parent. This option allows customizing those merge commit messages. This is a CLI-only option with no git config equivalent. Supports placeholders (see MESSAGE PLACEHOLDERS below).
 
 **--preserve-merges**
 : Preserve merges during rebase operations
@@ -207,6 +207,50 @@ The following options modify strategy behavior:
 - **--preserve-merges**: Only valid with rebase operations
 - **--no-ff**: Forces creation of merge commits, even for fast-forward cases
 - **--ff**: Allows fast-forward merges when possible (default)
+
+## MESSAGE PLACEHOLDERS
+
+Custom merge and update messages can include placeholders that are automatically expanded with branch names. This allows creating dynamic commit messages without hardcoding branch names.
+
+### Supported Placeholders
+
+| Placeholder | Description | Example Value |
+|-------------|-------------|---------------|
+| **%b** | Branch name | `feature/my-feature` |
+| **%B** | Full refname | `refs/heads/feature/my-feature` |
+| **%p** | Parent branch name | `develop` |
+| **%P** | Full parent refname | `refs/heads/develop` |
+| **%%** | Literal percent sign | `%` |
+
+### Context for Placeholders
+
+**For --merge-message** (topic branch to parent):
+- `%b` = the topic branch being merged (e.g., `feature/my-feature`)
+- `%p` = the parent branch receiving the merge (e.g., `develop`)
+
+**For --update-message** (parent to child branches):
+- `%b` = the child branch being updated (e.g., `develop`)
+- `%p` = the source branch (e.g., `main`)
+
+### Examples
+
+```bash
+# Simple branch name placeholder
+git flow feature finish my-feature --merge-message "feat: merge %b"
+# Result: "feat: merge feature/my-feature"
+
+# Branch and parent placeholders
+git flow feature finish my-feature --merge-message "feat: merge %b into %p"
+# Result: "feat: merge feature/my-feature into develop"
+
+# Child updates with placeholders
+git flow release finish 1.0 --update-message "chore: sync %b from %p"
+# Result on develop: "chore: sync develop from main"
+
+# Escaped percent sign
+git flow feature finish my-feature --merge-message "100%% complete: %b"
+# Result: "100% complete: feature/my-feature"
+```
 
 ## EXAMPLES
 

--- a/docs/git-flow-finish.1.md
+++ b/docs/git-flow-finish.1.md
@@ -113,10 +113,10 @@ The operation maintains a persistent state file that allows it to resume after c
 : Custom commit message for squash merge. This is a CLI-only option with no git config equivalent, as squash messages are specific to each branch being finished.
 
 **--merge-message**, **-M** *message*
-: Custom commit message for the upstream merge operation (topic branch to parent). This is a CLI-only option with no git config equivalent, as merge messages are specific to each branch being finished. Useful for teams using commit message validation hooks (e.g., conventional commits) where auto-generated messages like "Merge branch 'feature/foo'" would be rejected. Supports placeholders (see MESSAGE PLACEHOLDERS below).
+: Custom commit message for the upstream merge operation (topic branch to parent). Useful for teams using commit message validation hooks (e.g., conventional commits) where auto-generated messages like "Merge branch 'feature/foo'" would be rejected. Supports placeholders (see MESSAGE PLACEHOLDERS below). Can be configured as default via `gitflow.<type>.finish.mergemessage`.
 
 **--update-message** *message*
-: Custom commit message for child branch update operations (parent to child branches). When finishing a release or hotfix, child branches like develop are automatically updated from the parent. This option allows customizing those merge commit messages. This is a CLI-only option with no git config equivalent. Supports placeholders (see MESSAGE PLACEHOLDERS below).
+: Custom commit message for child branch update operations (parent to child branches). When finishing a release or hotfix, child branches like develop are automatically updated from the parent. This option allows customizing those merge commit messages. Supports placeholders (see MESSAGE PLACEHOLDERS below). Can be configured as default via `gitflow.<type>.finish.updatemessage`.
 
 **--preserve-merges**
 : Preserve merges during rebase operations
@@ -408,6 +408,10 @@ git config gitflow.<type>.finish.signingkey ABC123DEF
 
 # Remote fetch options
 git config gitflow.<type>.finish.fetch true
+
+# Custom merge commit messages (with placeholder support)
+git config gitflow.<type>.finish.mergemessage "feat: merge %b into %p"
+git config gitflow.<type>.finish.updatemessage "chore: sync %b from %p"
 ```
 
 ## EXIT STATUS
@@ -448,5 +452,6 @@ git config gitflow.<type>.finish.fetch true
 - The **git-flow finish** shorthand automatically detects current topic branch type
 - Child branches are automatically updated when their parent changes
 - Some topic branch types (like releases and hotfixes) may create tags by default
-- Custom merge messages (**--merge-message**, **--update-message**, **--squash-message**) are CLI-only options with no git config equivalent
+- **--merge-message** and **--update-message** can be configured as defaults via `gitflow.<type>.finish.mergemessage` and `gitflow.<type>.finish.updatemessage`
+- **--squash-message** is CLI-only with no git config equivalent, as squash messages are specific to each branch being finished
 - Custom messages are preserved in merge state and survive conflict resolution

--- a/docs/git-flow-finish.1.md
+++ b/docs/git-flow-finish.1.md
@@ -112,6 +112,12 @@ The operation maintains a persistent state file that allows it to resume after c
 **--squash-message** *message*
 : Custom commit message for squash merge. This is a CLI-only option with no git config equivalent, as squash messages are specific to each branch being finished.
 
+**--merge-message**, **-M** *message*
+: Custom commit message for the upstream merge operation (topic branch to parent). This is a CLI-only option with no git config equivalent, as merge messages are specific to each branch being finished. Useful for teams using commit message validation hooks (e.g., conventional commits) where auto-generated messages like "Merge branch 'feature/foo'" would be rejected.
+
+**--update-message** *message*
+: Custom commit message for child branch update operations (parent to child branches). When finishing a release or hotfix, child branches like develop are automatically updated from the parent. This option allows customizing those merge commit messages. This is a CLI-only option with no git config equivalent.
+
 **--preserve-merges**
 : Preserve merges during rebase operations
 
@@ -285,6 +291,20 @@ Squash with custom commit message:
 git flow feature finish my-feature --squash --squash-message "feat: add login functionality"
 ```
 
+### Custom Merge Commit Messages
+
+Use custom merge message for conventional commits:
+```bash
+git flow feature finish my-feature --merge-message "feat(auth): add user authentication"
+```
+
+Custom messages for both merge and child updates:
+```bash
+git flow release finish 1.2.0 \
+  --merge-message "release: version 1.2.0" \
+  --update-message "chore: sync develop with main after release 1.2.0"
+```
+
 ### Branch Retention
 
 Keep branch for backporting:
@@ -380,7 +400,9 @@ git config gitflow.<type>.finish.fetch true
 - **--preserve-merges** flag only applies to rebase operations
 - **--squash** and **--rebase** flags are mutually exclusive when both set explicitly
 - Use **--continue** and **--abort** for conflict resolution
-- Tag creation behavior varies by topic branch type configuration  
+- Tag creation behavior varies by topic branch type configuration
 - The **git-flow finish** shorthand automatically detects current topic branch type
 - Child branches are automatically updated when their parent changes
 - Some topic branch types (like releases and hotfixes) may create tags by default
+- Custom merge messages (**--merge-message**, **--update-message**, **--squash-message**) are CLI-only options with no git config equivalent
+- Custom messages are preserved in merge state and survive conflict resolution

--- a/docs/gitflow-config.5.md
+++ b/docs/gitflow-config.5.md
@@ -324,14 +324,32 @@ These are operational settings that adjust command behavior. Some can override L
 [gitflow "release.finish"]
     sign = true
     signingkey = ABC123DEF456
-    
+
 # Use custom tag message pattern
 [gitflow "release.finish"]
     message = "Release version %s"
-    
+
 # Always fetch before release operations
 [gitflow "release"]
     fetch = true
+```
+
+### Custom Merge Message Overrides
+
+```ini
+# Feature branches: conventional commit format for merges
+[gitflow "feature.finish"]
+    mergemessage = "feat: merge %b into %p"
+
+# Release branches: sync message for develop updates
+[gitflow "release.finish"]
+    mergemessage = "release: merge %b into %p"
+    updatemessage = "chore: sync %b from main after release"
+
+# Hotfix branches: clear tracking of hotfix merges
+[gitflow "hotfix.finish"]
+    mergemessage = "fix: merge %b into %p"
+    updatemessage = "chore: sync %b with hotfix changes"
 ```
 
 ### Hotfix Branch Overrides
@@ -402,13 +420,20 @@ The finish command supports extensive merge strategy configuration through comma
 : *Type*: boolean
 : *Default*: true
 
-### CLI-Only Merge Message Options
+### Merge Message Options
 
-The following options are CLI-only and have **no git config equivalent**. They are designed for per-operation customization rather than persistent configuration because merge messages are specific to each branch being finished:
+**gitflow.*type*.finish.mergemessage**
+: Custom commit message for upstream merge (topic → parent). Supports placeholders: `%b` (branch name), `%B` (full refname), `%p` (parent branch), `%P` (full parent refname), `%%` (literal percent).
+: *Type*: string
+: *Default*: (none, uses Git's default merge message)
 
-- **--merge-message**: Custom commit message for upstream merge (topic → parent)
-- **--update-message**: Custom commit message for child branch updates (parent → child)
-- **--squash-message**: Custom commit message for squash merges
+**gitflow.*type*.finish.updatemessage**
+: Custom commit message for child branch updates (parent → child). Supports the same placeholders as mergemessage.
+: *Type*: string
+: *Default*: (none, uses auto-generated message)
+
+**--squash-message** (CLI-only)
+: Custom commit message for squash merges. This option has no git config equivalent, as squash messages are specific to each branch being finished.
 
 These options are useful for teams using commit message validation hooks (e.g., conventional commits) where auto-generated messages would be rejected.
 

--- a/docs/gitflow-config.5.md
+++ b/docs/gitflow-config.5.md
@@ -402,6 +402,16 @@ The finish command supports extensive merge strategy configuration through comma
 : *Type*: boolean
 : *Default*: true
 
+### CLI-Only Merge Message Options
+
+The following options are CLI-only and have **no git config equivalent**. They are designed for per-operation customization rather than persistent configuration because merge messages are specific to each branch being finished:
+
+- **--merge-message**: Custom commit message for upstream merge (topic → parent)
+- **--update-message**: Custom commit message for child branch updates (parent → child)
+- **--squash-message**: Custom commit message for squash merges
+
+These options are useful for teams using commit message validation hooks (e.g., conventional commits) where auto-generated messages would be rejected.
+
 ### Strategy Precedence
 
 1. **Command-line flags** (Layer 3 — highest priority, one-off overrides)

--- a/internal/mergestate/mergestate.go
+++ b/internal/mergestate/mergestate.go
@@ -51,6 +51,10 @@ type MergeState struct {
 
 	// Squash merge options
 	SquashMessage string `json:"squashMessage,omitempty"` // Custom commit message for squash merge
+
+	// Custom merge commit messages
+	MergeMessage  string `json:"mergeMessage,omitempty"`  // Custom commit message for upstream merge
+	UpdateMessage string `json:"updateMessage,omitempty"` // Custom commit message for child updates
 }
 
 // SaveMergeState saves the current merge state to a file

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -12,6 +12,11 @@ import (
 
 // UpdateBranchFromParent updates a branch with changes from its parent branch using the configured strategy
 func UpdateBranchFromParent(branchName string, parentBranch string, strategy string, saveState bool, state *mergestate.MergeState) error {
+	return UpdateBranchFromParentWithMessage(branchName, parentBranch, strategy, "", saveState, state)
+}
+
+// UpdateBranchFromParentWithMessage updates a branch with changes from its parent branch using the configured strategy and optional custom message
+func UpdateBranchFromParentWithMessage(branchName string, parentBranch string, strategy string, customMessage string, saveState bool, state *mergestate.MergeState) error {
 	// Checkout the branch if needed
 	currentBranch, err := git.GetCurrentBranch()
 	if err != nil {
@@ -31,10 +36,18 @@ func UpdateBranchFromParent(branchName string, parentBranch string, strategy str
 		mergeErr = git.Rebase(parentBranch)
 	case "squash":
 		fmt.Printf("Using squash strategy for '%s'\n", branchName)
-		mergeErr = git.SquashMerge(parentBranch)
+		if customMessage != "" {
+			mergeErr = git.MergeSquashWithMessage(parentBranch, customMessage)
+		} else {
+			mergeErr = git.SquashMerge(parentBranch)
+		}
 	default:
 		fmt.Printf("Using merge strategy for '%s'\n", branchName)
-		mergeErr = git.Merge(parentBranch)
+		if customMessage != "" {
+			mergeErr = git.MergeWithMessage(parentBranch, customMessage, true)
+		} else {
+			mergeErr = git.Merge(parentBranch)
+		}
 	}
 
 	if mergeErr != nil {

--- a/internal/util/placeholder.go
+++ b/internal/util/placeholder.go
@@ -1,0 +1,24 @@
+package util
+
+import "strings"
+
+// ExpandMessagePlaceholders expands placeholders in merge commit messages.
+// Supported placeholders:
+//
+//	%b - branch name (e.g., feature/my-feature)
+//	%B - full refname (e.g., refs/heads/feature/my-feature)
+//	%p - parent branch name (e.g., develop)
+//	%P - full parent refname (e.g., refs/heads/develop)
+//	%% - literal percent sign
+func ExpandMessagePlaceholders(message, branch, parent string) string {
+	// Use strings.NewReplacer for efficient multi-replacement
+	replacer := strings.NewReplacer(
+		"%%", "\x00", // Temporarily escape %%
+		"%b", branch,
+		"%B", "refs/heads/"+branch,
+		"%p", parent,
+		"%P", "refs/heads/"+parent,
+	)
+	result := replacer.Replace(message)
+	return strings.ReplaceAll(result, "\x00", "%")
+}

--- a/test/internal/util/placeholder_test.go
+++ b/test/internal/util/placeholder_test.go
@@ -1,0 +1,155 @@
+package util_test
+
+import (
+	"testing"
+
+	"github.com/gittower/git-flow-next/internal/util"
+)
+
+func TestExpandMessagePlaceholdersBasic(t *testing.T) {
+	tests := []struct {
+		name     string
+		message  string
+		branch   string
+		parent   string
+		expected string
+	}{
+		{
+			name:     "branch name placeholder",
+			message:  "Merge %b",
+			branch:   "feature/my-feature",
+			parent:   "develop",
+			expected: "Merge feature/my-feature",
+		},
+		{
+			name:     "full branch refname placeholder",
+			message:  "Merge %B",
+			branch:   "feature/my-feature",
+			parent:   "develop",
+			expected: "Merge refs/heads/feature/my-feature",
+		},
+		{
+			name:     "parent name placeholder",
+			message:  "Merge into %p",
+			branch:   "feature/my-feature",
+			parent:   "develop",
+			expected: "Merge into develop",
+		},
+		{
+			name:     "full parent refname placeholder",
+			message:  "Merge into %P",
+			branch:   "feature/my-feature",
+			parent:   "develop",
+			expected: "Merge into refs/heads/develop",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := util.ExpandMessagePlaceholders(tt.message, tt.branch, tt.parent)
+			if result != tt.expected {
+				t.Errorf("ExpandMessagePlaceholders(%q, %q, %q) = %q, want %q",
+					tt.message, tt.branch, tt.parent, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExpandMessagePlaceholdersMultiple(t *testing.T) {
+	tests := []struct {
+		name     string
+		message  string
+		branch   string
+		parent   string
+		expected string
+	}{
+		{
+			name:     "branch and parent",
+			message:  "Merge %b into %p",
+			branch:   "feature/login",
+			parent:   "develop",
+			expected: "Merge feature/login into develop",
+		},
+		{
+			name:     "all placeholders",
+			message:  "Merge %b (%B) into %p (%P)",
+			branch:   "hotfix/1.0.1",
+			parent:   "main",
+			expected: "Merge hotfix/1.0.1 (refs/heads/hotfix/1.0.1) into main (refs/heads/main)",
+		},
+		{
+			name:     "repeated placeholders",
+			message:  "%b %b %p %p",
+			branch:   "release/2.0",
+			parent:   "main",
+			expected: "release/2.0 release/2.0 main main",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := util.ExpandMessagePlaceholders(tt.message, tt.branch, tt.parent)
+			if result != tt.expected {
+				t.Errorf("ExpandMessagePlaceholders(%q, %q, %q) = %q, want %q",
+					tt.message, tt.branch, tt.parent, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExpandMessagePlaceholdersEscaped(t *testing.T) {
+	tests := []struct {
+		name     string
+		message  string
+		branch   string
+		parent   string
+		expected string
+	}{
+		{
+			name:     "escaped percent sign",
+			message:  "100%% complete",
+			branch:   "feature/test",
+			parent:   "develop",
+			expected: "100% complete",
+		},
+		{
+			name:     "escaped with placeholders",
+			message:  "Merge %b (100%% done) into %p",
+			branch:   "feature/test",
+			parent:   "develop",
+			expected: "Merge feature/test (100% done) into develop",
+		},
+		{
+			name:     "multiple escaped",
+			message:  "%%b is %b, %%p is %p",
+			branch:   "feature/x",
+			parent:   "main",
+			expected: "%b is feature/x, %p is main",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := util.ExpandMessagePlaceholders(tt.message, tt.branch, tt.parent)
+			if result != tt.expected {
+				t.Errorf("ExpandMessagePlaceholders(%q, %q, %q) = %q, want %q",
+					tt.message, tt.branch, tt.parent, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExpandMessagePlaceholdersNoPlaceholders(t *testing.T) {
+	message := "Simple merge message without placeholders"
+	result := util.ExpandMessagePlaceholders(message, "feature/test", "develop")
+	if result != message {
+		t.Errorf("ExpandMessagePlaceholders(%q, ...) = %q, want unchanged", message, result)
+	}
+}
+
+func TestExpandMessagePlaceholdersEmpty(t *testing.T) {
+	result := util.ExpandMessagePlaceholders("", "feature/test", "develop")
+	if result != "" {
+		t.Errorf("ExpandMessagePlaceholders(\"\", ...) = %q, want empty string", result)
+	}
+}


### PR DESCRIPTION
Adds `--merge-message` and `--update-message` flags to customize merge commit messages during finish operations for users with specific commit message conventions.

The implementation supports git config defaults (`gitflow.<branchtype>.finish.mergeMessage`) and CLI flags (highest priority). Messages support placeholder expansion (`%b` for branch, `%B` for full ref, `%p` for parent, `%P` for parent ref) and persist through conflict resolution via `--continue`. Changes touch `cmd/finish.go`, `cmd/topicbranch.go`, `internal/config/resolver.go`, `internal/git/repo.go`, `internal/util/placeholder.go`, and `internal/mergestate/mergestate.go`.

Resolves #58

## Remarks

- `--merge-message` controls the upstream merge (topic → parent)
- `--update-message` controls child branch updates (parent → children like develop)
- Squash message remains CLI-only since content is branch-specific
- Default git merge messages used when flags/config not provided

**Review focus:**
- `cmd/finish.go:180-220` - merge message handling and placeholder expansion
- `internal/config/resolver.go:340-380` - git config resolution
- `internal/util/placeholder.go` - new placeholder expansion utility