### PR TITLE
Support gitflow.path.hooks and core.hooksPath for hooks directory

### DIFF
--- a/docs/gitflow-config.5.md
+++ b/docs/gitflow-config.5.md
@@ -96,6 +96,24 @@ Command-line flags always take the highest precedence and override both configur
 : Name of the remote repository to use for operations.
 : *Default*: "origin"
 
+## PATH CONFIGURATION
+
+**gitflow.path.hooks**
+: Override the directory where git-flow looks for hook and filter scripts. When set, git-flow uses this directory instead of the default `.git/hooks/` or Git's `core.hooksPath`. Supports absolute paths or paths relative to the repository root.
+: *Default*: not set (falls back to `core.hooksPath`, then `.git/hooks`)
+: *Compatibility*: matches git-flow-avh `gitflow.path.hooks` behavior
+
+```bash
+# Absolute path
+git config gitflow.path.hooks /shared/team-hooks
+
+# Relative path (resolved from repository root)
+git config gitflow.path.hooks .githooks
+
+# Global default for all repositories
+git config --global gitflow.path.hooks .githooks
+```
+
 ## BRANCH CONFIGURATION
 
 Branch configuration uses the pattern: **gitflow.branch.*name*.*property***

--- a/docs/gitflow-hooks.7.md
+++ b/docs/gitflow-hooks.7.md
@@ -6,7 +6,7 @@ gitflow-hooks - Git-flow hooks and filters for customizing workflow behavior
 
 ## SYNOPSIS
 
-Custom scripts in `.git/hooks/` to extend and customize git-flow operations.
+Custom scripts to extend and customize git-flow operations, located in a configurable hooks directory.
 
 ## DESCRIPTION
 
@@ -16,7 +16,32 @@ Git-flow supports two types of extension points:
 
 **Hooks** execute scripts before and after operations (e.g., running CI checks before starting a release).
 
-All scripts are located in the `.git/hooks/` directory following specific naming conventions.
+All scripts are located in the hooks directory following specific naming conventions.
+
+## HOOKS DIRECTORY
+
+By default, git-flow looks for hook and filter scripts in `.git/hooks/`. This can be overridden using configuration, following a three-level precedence:
+
+1. **gitflow.path.hooks** — git-flow-specific override. Set this to use a dedicated directory for git-flow hooks, independent of Git's own hooks. Compatible with git-flow-avh.
+
+2. **core.hooksPath** — Git's native hooks path configuration. If set and `gitflow.path.hooks` is not, git-flow respects this setting.
+
+3. **.git/hooks** — Default location when neither configuration is set. Worktree-aware: in a git worktree, hooks are resolved from the main repository's `.git/hooks` directory.
+
+Both absolute and relative paths are supported. Relative paths are resolved from the repository root.
+
+### Examples
+
+```bash
+# Use a tracked directory for git-flow hooks (absolute)
+git config gitflow.path.hooks /shared/team-hooks
+
+# Use a tracked directory for git-flow hooks (relative to repo root)
+git config gitflow.path.hooks .githooks
+
+# Use Git's native hooks path (also respected by git-flow)
+git config core.hooksPath .githooks
+```
 
 ## FILTERS
 
@@ -268,8 +293,8 @@ fi
 
 ## CREATING HOOK SCRIPTS
 
-1. Create the script in `.git/hooks/` with the appropriate name
-2. Make the script executable: `chmod +x .git/hooks/<script-name>`
+1. Create the script in the hooks directory (default: `.git/hooks/`) with the appropriate name
+2. Make the script executable: `chmod +x <hooks-dir>/<script-name>`
 3. Test the script manually before relying on it
 
 ### Tips
@@ -284,14 +309,38 @@ fi
 
 Since `.git/hooks/` is not tracked by Git, consider these approaches for sharing hooks:
 
-### Using a hooks directory in the repository
+### Using gitflow.path.hooks (recommended)
 
 ```bash
 # Store hooks in a tracked directory
 mkdir .githooks
 
-# Configure Git to use this directory
+# Configure git-flow to use this directory
+git config gitflow.path.hooks .githooks
+```
+
+This only affects git-flow hooks and filters, leaving Git's own hooks unaffected.
+
+### Using core.hooksPath
+
+```bash
+# Store hooks in a tracked directory
+mkdir .githooks
+
+# Configure Git (and git-flow) to use this directory
 git config core.hooksPath .githooks
+```
+
+Note: This also affects Git's own hooks (pre-commit, commit-msg, etc.).
+
+### Using global or system configuration
+
+```bash
+# Set a shared hooks directory for all repositories (user-wide)
+git config --global gitflow.path.hooks /shared/team-hooks
+
+# Set a shared hooks directory system-wide
+sudo git config --system gitflow.path.hooks /etc/git-flow-hooks
 ```
 
 ### Using symbolic links
@@ -381,7 +430,7 @@ exit 0
 
 ## SEE ALSO
 
-**git-flow**(1), **git-flow-start**(1), **git-flow-finish**(1), **githooks**(5)
+**git-flow**(1), **git-flow-start**(1), **git-flow-finish**(1), **gitflow-config**(5), **githooks**(5)
 
 ## REFERENCES
 


### PR DESCRIPTION
Support configurable hooks directories via `gitflow.path.hooks` and `core.hooksPath`, allowing hooks to live outside `.git/hooks/`.

The `getHooksDir()` function now resolves the hooks directory using a three-level precedence: `gitflow.path.hooks` (git-flow-avh compatible) > `core.hooksPath` (Git native) > `.git/hooks/` (default). Both absolute and relative paths are supported, with relative paths resolved from the repository root. This applies to both hooks and filters since they share the same resolution function. Changes touch `internal/hooks/hooks.go`, `docs/gitflow-hooks.7.md`, and `docs/gitflow-config.5.md`, with 9 new tests covering all resolution paths and integration scenarios.

Resolves #63

## Remarks

- `gitflow.path.hooks` takes highest priority for avh compatibility and as an escape hatch when `core.hooksPath` is set for Git's own hooks but git-flow hooks should come from elsewhere
- Non-existent configured directories cause hooks to be silently skipped, matching Git's own behavior
- Worktree support is preserved — the default `.git/hooks` fallback remains worktree-aware

**Review focus:**
- `internal/hooks/hooks.go:37-68` — three-level precedence logic and path resolution
- `test/internal/hooks/hooks_test.go:828-1282` — new test coverage