### PR TITLE
fix(finish): Use the start point branch when finishing

### DIFF
--- a/cmd/finish.go
+++ b/cmd/finish.go
@@ -191,6 +191,14 @@ func executeFinish(branchType string, name string, continueOp bool, abortOp bool
 		shortName = parts[len(parts)-1]
 	}
 
+	// If a different parent branch was used to create the branch, use this instead of the configured one
+	if startPoint, err := git.GetBaseBranch(name); err == nil {
+		if startPoint != branchConfig.StartPoint {
+			fmt.Printf("Using base branch '%s'\n", startPoint)
+			branchConfig.Parent = startPoint
+		}
+	}
+
 	// Resolve all options once before starting operations
 	resolvedOptions := config.ResolveFinishOptions(cfg, branchType, shortName, tagOptions, retentionOptions, mergeOptions, fetch, noVerify)
 


### PR DESCRIPTION
When finishing a branch, check the (stored) start point used to create the branch. If it differs from the configured start point, merge back to this branch instead. This ensures that e.g. creating releases from another branch works as expected.

Resolves #71
Refs #36

## Remarks

- No tests added yet
- Docs not updated yet

**Review focus:**

- Current tests suggest to me that the changed behavior is NOT intended
- However, the current test (TestFinishUsesConfiguredParent) still passes and should be adapted
- I want to start a discussion for this changed behavior nevertheless because I need this fix

