### PR TITLE
Stop creating README.md on init in empty repos

### DIFF
--- a/docs/git-flow-init.1.md
+++ b/docs/git-flow-init.1.md
@@ -270,6 +270,7 @@ By default, git-flow stores configuration in the repository's **.git/config** fi
 - **git-flow init** requires **--force** to reconfigure an already initialized repository in non-interactive mode
 - In interactive mode without **--force**, users are prompted for confirmation before reconfiguring
 - Existing branches are preserved during initialization
+- When initializing a repository with no existing commits, **git-flow init** creates an empty initial commit to enable branch creation. No files are added to the working directory
 - Compatible with repositories previously initialized with git-flow-avh
 - Configuration scope options (**--local**, **--global**, **--system**, **--file**) only affect the **init** command. All other git-flow commands (start, finish, update, etc.) always read from merged config using Git's standard precedence (local > global > system)
 - When checking initialization status without an explicit scope flag, git-flow checks merged config and reports which scope the configuration was found in

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -2,7 +2,6 @@ package git
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -154,30 +153,14 @@ func HasCommits() (bool, error) {
 
 // CreateInitialCommit creates an initial commit and branch
 func CreateInitialCommit(branch string) error {
-	// Create a README.md file if it doesn't exist
-	if _, err := os.Stat("README.md"); os.IsNotExist(err) {
-		content := fmt.Sprintf("# Git Flow Repository\n\nThis repository is using git-flow with the following branches:\n- %s: Production releases\n- develop: Development\n", branch)
-		err = os.WriteFile("README.md", []byte(content), 0644)
-		if err != nil {
-			return fmt.Errorf("failed to create README.md: %w", err)
-		}
-	}
-
-	// Add the file to git
-	cmd := exec.Command("git", "add", "README.md")
+	// Create an empty initial commit
+	cmd := exec.Command("git", "commit", "--allow-empty", "-m", "Initial commit")
 	_, err := cmd.Output()
-	if err != nil {
-		return fmt.Errorf("failed to add README.md: %w", err)
-	}
-
-	// Create the initial commit
-	cmd = exec.Command("git", "commit", "-m", "Initial commit")
-	_, err = cmd.Output()
 	if err != nil {
 		return fmt.Errorf("failed to create initial commit: %w", err)
 	}
 
-	// Create the branch (it will be created automatically as the first branch)
+	// Rename the default branch to the target name
 	cmd = exec.Command("git", "branch", "-m", branch)
 	_, err = cmd.Output()
 	if err != nil {

--- a/test/testutil/git.go
+++ b/test/testutil/git.go
@@ -126,6 +126,31 @@ func SetupTestRepo(t *testing.T) string {
 	return dir
 }
 
+// SetupEmptyTestRepo creates a temporary Git repository with no commits.
+// This is useful for testing behavior when git-flow init encounters an empty repo.
+func SetupEmptyTestRepo(t *testing.T) string {
+	dir, err := os.MkdirTemp("", "git-flow-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temporary directory: %v", err)
+	}
+
+	_, err = RunGit(t, dir, "init", "--initial-branch=main")
+	if err != nil {
+		t.Fatalf("Failed to initialize Git repository: %v", err)
+	}
+
+	_, err = RunGit(t, dir, "config", "user.name", "Test User")
+	if err != nil {
+		t.Fatalf("Failed to configure Git user name: %v", err)
+	}
+	_, err = RunGit(t, dir, "config", "user.email", "test@example.com")
+	if err != nil {
+		t.Fatalf("Failed to configure Git user email: %v", err)
+	}
+
+	return dir
+}
+
 // CleanupTestRepo removes the temporary test repository
 func CleanupTestRepo(t *testing.T, dir string) {
 	err := os.RemoveAll(dir)


### PR DESCRIPTION
Stop creating README.md when running `git flow init` in an empty repository; use an empty initial commit instead.

Previously, `git flow init` in a repo with no commits would create a README.md with boilerplate content ("# Git Flow Repository...") and commit it. This was an unwanted side effect that polluted the working directory. The fix replaces this with `git commit --allow-empty -m "Initial commit"`, matching the behavior of both the original git-flow and git-flow-avh. Changes touch `internal/git/repo.go` (simplified `CreateInitialCommit()`), `test/cmd/init_test.go` (three new tests), `test/testutil/git.go` (new `SetupEmptyTestRepo` helper), and `docs/git-flow-init.1.md`.

Resolves #73

## Remarks

- Repos that already have commits are unaffected -- `CreateInitialCommit()` is only called when `HasCommits()` returns false
- The existing `SetupTestRepo()` test helper creates its own README.md independently, so all existing tests continue to pass unchanged
- The `os` import was removed from `internal/git/repo.go` since it was only used for README file operations

**Review focus:**
- `internal/git/repo.go` -- simplified `CreateInitialCommit()` function
- `test/cmd/init_test.go` -- three new empty-repo tests at the end of the file