### PR TITLE
fix(delete): Check if remote exists before deleting it

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -141,11 +141,20 @@ func performDelete(branchType, name, fullBranchName string, branchConfig config.
 			remoteName = "origin"
 		}
 
-		// Delete remote branch
-		if err := git.DeleteRemoteBranch(remoteName, fullBranchName); err != nil {
-			return &errors.GitError{Operation: fmt.Sprintf("delete remote branch '%s'", fullBranchName), Err: err}
+		deletedRemote := false
+		if git.RemoteBranchExists(remoteName, fullBranchName) {
+			// Delete remote branch
+			if err := git.DeleteRemoteBranch(remoteName, fullBranchName); err != nil {
+				return &errors.GitError{Operation: fmt.Sprintf("delete remote branch '%s'", fullBranchName), Err: err}
+			} else {
+				deletedRemote = true
+			}
 		}
-		fmt.Printf("Deleted branch %s and its remote tracking branch\n", fullBranchName)
+		if deletedRemote {
+			fmt.Printf("Deleted branch %s and its remote tracking branch\n", fullBranchName)
+		} else {
+			fmt.Printf("Deleted branch %s (no remote tracking branch found)\n", fullBranchName)
+		}
 	} else {
 		fmt.Printf("Deleted branch %s\n", fullBranchName)
 	}

--- a/test/cmd/delete_test.go
+++ b/test/cmd/delete_test.go
@@ -445,7 +445,7 @@ func TestDeleteFeatureWithCommandLineOverride(t *testing.T) {
 // 3. Adds a remote repository but doesn't push the branch
 // 4. Attempts to delete the branch with --remote flag
 // 5. Verifies the branch is deleted locally
-// 6. Verifies an error occurs when trying to delete the non-existent remote branch
+// 6. Verifies no error occurs when trying to delete the non-existent remote branch
 func TestDeleteFeatureWithNonExistentRemote(t *testing.T) {
 	// Setup test repository
 	dir := testutil.SetupTestRepo(t)
@@ -476,10 +476,10 @@ func TestDeleteFeatureWithNonExistentRemote(t *testing.T) {
 		t.Fatalf("Feature branch unexpectedly exists on remote")
 	}
 
-	// Delete feature branch with remote deletion - should fail
+	// Delete feature branch with remote deletion - should succeed
 	_, err = testutil.RunGitFlow(t, dir, "feature", "delete", "test-feature", "--remote")
-	if err == nil {
-		t.Fatalf("Expected error when deleting non-existent remote branch")
+	if err != nil {
+		t.Fatalf("Failed to delete remote: %v", err)
 	}
 
 	// Verify branch is deleted locally


### PR DESCRIPTION
When deleting a remote branch, check whether if exists first. Trying to delete a branch that doesn't exist anymore isn't a failure.

The implemented fix is a simple check before trying to delete the remote branch.

Resolves #82