### PR TITLE
provided support for windows arm64

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -43,6 +43,8 @@ echo "Building windows/amd64..."
 CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -trimpath -ldflags "${BUILD_FLAGS}" -o "$BUILD_DIR/${BINARY_NAME}-${VERSION}-windows-amd64.exe" main.go
 echo "Building windows/386..."
 CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -trimpath -ldflags "${BUILD_FLAGS}" -o "$BUILD_DIR/${BINARY_NAME}-${VERSION}-windows-386.exe" main.go
+echo "Building windows/arm64..."
+CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build -trimpath -ldflags "${BUILD_FLAGS}" -o "$BUILD_DIR/${BINARY_NAME}-${VERSION}-windows-arm64.exe" main.go
 
 # Verify all binaries were created
 echo "Verifying binaries..."
@@ -50,7 +52,7 @@ MISSING_BINARIES=()
 
 for binary in "${BINARY_NAME}-${VERSION}-darwin-amd64" "${BINARY_NAME}-${VERSION}-darwin-arm64" \
               "${BINARY_NAME}-${VERSION}-linux-amd64" "${BINARY_NAME}-${VERSION}-linux-arm64" "${BINARY_NAME}-${VERSION}-linux-386" \
-              "${BINARY_NAME}-${VERSION}-windows-amd64.exe" "${BINARY_NAME}-${VERSION}-windows-386.exe"; do
+              "${BINARY_NAME}-${VERSION}-windows-amd64.exe" "${BINARY_NAME}-${VERSION}-windows-386.exe" "${BINARY_NAME}-${VERSION}-windows-arm64.exe"; do
     if [[ ! -f "$BUILD_DIR/$binary" ]]; then
         MISSING_BINARIES+=("$binary")
     fi
@@ -83,12 +85,22 @@ echo "Creating windows archives..."
 if command -v zip >/dev/null 2>&1; then
     (cd "$BUILD_DIR" && zip "${PACKAGE_NAME}-${VERSION}-windows-amd64.zip" "${BINARY_NAME}-${VERSION}-windows-amd64.exe")
     (cd "$BUILD_DIR" && zip "${PACKAGE_NAME}-${VERSION}-windows-386.zip" "${BINARY_NAME}-${VERSION}-windows-386.exe")
+    (cd "$BUILD_DIR" && zip "${PACKAGE_NAME}-${VERSION}-windows-arm64.zip" "${BINARY_NAME}-${VERSION}-windows-arm64.exe")
 else
-    echo "Warning: zip command not found, skipping Windows archives"
+    echo "Warning: zip command not found, falling back to tar.gz for Windows"
+    tar czf "$BUILD_DIR/${PACKAGE_NAME}-${VERSION}-windows-amd64.tar.gz" -C "$BUILD_DIR" "${BINARY_NAME}-${VERSION}-windows-amd64.exe"
+    tar czf "$BUILD_DIR/${PACKAGE_NAME}-${VERSION}-windows-386.tar.gz" -C "$BUILD_DIR" "${BINARY_NAME}-${VERSION}-windows-386.exe"
+    tar czf "$BUILD_DIR/${PACKAGE_NAME}-${VERSION}-windows-arm64.tar.gz" -C "$BUILD_DIR" "${BINARY_NAME}-${VERSION}-windows-arm64.exe"
 fi
 
 # Generate checksums
 echo "Generating checksums..."
-(cd "$BUILD_DIR" && shasum -a 256 * > "${PACKAGE_NAME}-${VERSION}-checksums.txt")
+if command -v shasum >/dev/null 2>&1; then
+    (cd "$BUILD_DIR" && shasum -a 256 * > "${PACKAGE_NAME}-${VERSION}-checksums.txt")
+elif command -v sha256sum >/dev/null 2>&1; then
+    (cd "$BUILD_DIR" && sha256sum * > "${PACKAGE_NAME}-${VERSION}-checksums.txt")
+else
+    echo "Warning: Neither shasum nor sha256sum found, skipping checksums"
+fi
 
 echo "Build complete! Artifacts are in the $BUILD_DIR directory" 


### PR DESCRIPTION
Adds support for Windows ARM64 builds and enhances build script robustness with utility fallbacks.

  The scripts/build.sh script now includes windows/arm64 in the cross-compilation targets. Additionally, it dynamically detects available checksum tools (preferring shasum but falling back to sha256sum) and archiving tools. For Windows builds, it now falls back to tar.gz if the zip command is unavailable, ensuring
  the build process completes successfully in environments like Git Bash.

  Relates to multi-platform support and build environment compatibility

  Remarks

   - Windows ARM64 binaries are now verified, archived, and included in the checksum list.
   - The fallback to tar.gz for Windows is a sensible default as tar is standard in Git Bash, whereas zip often requires separate installation.
   - Checksum generation now gracefully warns instead of failing if no supported tool is found.

  Review focus:
   - scripts/build.sh:46-48 - Windows arm64 build command
   - scripts/build.sh:88-102 - conditional logic for zip fallback and ARM64 archiving.

  ---

  Author Checklist (Verified)
   - [x] Commit messages follow COMMIT_GUIDELINES.md
   - [x] Build script verified by successfully generating artifacts in dist/ (including windows-arm64)
   - [x] No changes to CLI commands, so documentation in docs/ remains accurate