### PR TITLE
Add --fetch flag to delete command

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -194,6 +194,21 @@ from the branch push. A missing remote skips the push with a note (finish still
 succeeds); a rejected non-fast-forward push is a hard error, leaving the
 already-completed local finish intact.
 
+### Delete Command Options
+
+| Option | Description | Values | Default |
+|--------|-------------|--------|---------|
+| `fetch` | Fetch (and fast-forward the parent when it is checked out) before delete | `true`, `false` | `false` |
+
+#### Examples
+
+```bash
+# Always fetch before deleting feature branches
+gitflow.feature.delete.fetch=true
+```
+
+When `fetch` is enabled, delete fetches from the remote so Git can detect a branch that was merged remotely (e.g., via a GitHub PR merge). The parent is fast-forwarded from its remote only when it is the branch currently checked out (`git merge --ff-only` acts on HEAD); delete auto-checks-out the parent when you delete the branch you are on, which is the common case. A fetch failure against an unreachable remote is a non-fatal note — deletion is not blocked by the fetch itself, but the topic sync check still runs against existing local tracking data and can still abort (behind/diverged) unless `--force` is given. `--no-fetch` skips only the fetch, not the sync check.
+
 ### Update Command Options
 
 | Option | Description | Values | Default |

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -11,8 +11,8 @@ import (
 )
 
 // DeleteCommand handles the deletion of a topic branch
-func DeleteCommand(branchType string, name string, force *bool, remote *bool) {
-	if err := executeDelete(branchType, name, force, remote); err != nil {
+func DeleteCommand(branchType string, name string, force *bool, remote *bool, fetch *bool) {
+	if err := executeDelete(branchType, name, force, remote, fetch); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -25,7 +25,7 @@ func DeleteCommand(branchType string, name string, force *bool, remote *bool) {
 }
 
 // executeDelete performs the actual branch deletion logic and returns any errors
-func executeDelete(branchType string, name string, force *bool, remote *bool) error {
+func executeDelete(branchType string, name string, force *bool, remote *bool, fetch *bool) error {
 	// Load configuration
 	cfg, err := config.LoadConfig()
 	if err != nil {
@@ -73,13 +73,25 @@ func executeDelete(branchType string, name string, force *bool, remote *bool) er
 
 	// Run delete operation wrapped with hooks
 	return hooks.WithHooks(gitDir, branchType, hooks.HookActionDelete, hookCtx, func() error {
-		return performDelete(branchType, name, fullBranchName, branchConfig, force, remote, cfg)
+		return performDelete(branchType, name, fullBranchName, branchConfig, force, remote, fetch, cfg)
 	})
 }
 
 // performDelete performs the actual delete operation (called within hooks wrapper)
-func performDelete(branchType, name, fullBranchName string, branchConfig config.BranchConfig, force *bool, remote *bool, cfg *config.Config) error {
-	// Determine if we should force delete the branch
+func performDelete(branchType, name, fullBranchName string, branchConfig config.BranchConfig, force *bool, remote *bool, fetch *bool, cfg *config.Config) error {
+	// Determine if we should fetch before deleting (flag > config, default false).
+	shouldFetch := false
+	if fetch != nil {
+		shouldFetch = *fetch
+	} else {
+		configKey := fmt.Sprintf("gitflow.%s.delete.fetch", branchType)
+		fetchConfig, err := git.GetConfig(configKey)
+		if err == nil && fetchConfig == "true" {
+			shouldFetch = true
+		}
+	}
+
+	// Determine if we should force delete the branch (flag > config).
 	forceDelete := false
 	if force != nil {
 		// Command line flag takes precedence
@@ -113,13 +125,14 @@ func performDelete(branchType, name, fullBranchName string, branchConfig config.
 		return &errors.RemoteNotConfiguredError{Remote: cfg.Remote, Operation: "delete remote branch"}
 	}
 
-	// Check if we're currently on the branch to be deleted
+	// If we're on the branch to be deleted, switch to its parent first. This happens before the
+	// fetch/sync preflight so that fast-forwarding the parent (see below) operates on HEAD, which
+	// is what `git branch -d` checks a topic against when it has no upstream.
 	currentBranch, err := git.GetCurrentBranch()
 	if err != nil {
 		return &errors.GitError{Operation: "get current branch", Err: err}
 	}
 	if currentBranch == fullBranchName {
-		// If we're on the branch to be deleted, try to switch to its parent
 		parentBranch := branchConfig.Parent
 		if parentBranch != "" {
 			if err := git.Checkout(parentBranch); err != nil {
@@ -128,6 +141,20 @@ func performDelete(branchType, name, fullBranchName string, branchConfig config.
 		} else {
 			return &errors.GitError{Operation: "delete branch", Err: fmt.Errorf("cannot delete the current branch without a parent branch configured")}
 		}
+	}
+
+	// Fetch the parent and topic, fast-forward the parent from its remote (so a branch that was
+	// merged remotely, e.g. via a PR, is recognized as merged by `git branch -d`), and sync-check
+	// the topic. Delete uses the relaxed preflight variant: a fetch failure is a non-fatal note and
+	// a topic that is merely ahead of its remote is tolerated (a non-force `git branch -d` still
+	// guards genuinely unmerged work). A topic that is behind/diverged aborts unless forced.
+	if err := runFetchSyncPreflight(cfg, branchType, cfg.Remote, fullBranchName, name, branchConfig.Parent, shouldFetch, forceDelete, preflightOptions{
+		ffParent:             true,
+		tolerateAhead:        true,
+		fetchFailureNonFatal: true,
+		operation:            "delete",
+	}); err != nil {
+		return err
 	}
 
 	// Delete the branch with appropriate flag

--- a/cmd/finish.go
+++ b/cmd/finish.go
@@ -208,7 +208,7 @@ func executeFinish(branchType string, name string, continueOp bool, abortOp bool
 	// Fetch the topic (and parent, best-effort) and verify the topic is in sync with its remote.
 	// This runs only on the initial finish, never on --continue/--abort (handled above). A fatal
 	// fetch failure or an out-of-sync topic aborts here, before any merge.
-	if err := runFetchSyncPreflight(cfg, branchType, cfg.Remote, name, shortName, branchConfig.Parent, resolvedOptions.ShouldFetch, force); err != nil {
+	if err := runFetchSyncPreflight(cfg, branchType, cfg.Remote, name, shortName, branchConfig.Parent, resolvedOptions.ShouldFetch, force, preflightOptions{}); err != nil {
 		return err
 	}
 

--- a/cmd/preflight.go
+++ b/cmd/preflight.go
@@ -9,22 +9,52 @@ import (
 	"github.com/gittower/git-flow-next/internal/git"
 )
 
-// runFetchSyncPreflight guards the initial finish against an out-of-date topic branch. It fetches
+// preflightOptions tunes runFetchSyncPreflight for callers whose needs differ from finish's strict
+// pre-merge guard. The zero value reproduces finish's original behavior, so finish passes an empty
+// struct and only relaxed/extra behavior has to be opted into (currently by delete, see #88).
+type preflightOptions struct {
+	// ffParent fast-forwards the local parent to its freshly fetched remote-tracking branch. This
+	// is the #88 hook: it lets a branch that was merged remotely (e.g. via a PR) be recognized as
+	// merged by `git branch -d`. `git merge --ff-only` operates on HEAD, so the fast-forward is
+	// applied only when the parent is the current branch; otherwise it is a no-op. finish does not
+	// fast-forward the parent.
+	ffParent bool
+
+	// tolerateAhead downgrades a topic that is *ahead* of its remote (local-only commits) from a
+	// fatal out-of-sync error to a note. delete only cares that the topic is not *behind*/diverged
+	// (losing remote work); a non-force `git branch -d` still guards genuinely unmerged commits.
+	// finish treats ahead as out-of-sync.
+	tolerateAhead bool
+
+	// fetchFailureNonFatal downgrades a transport/auth fetch failure from fatal to a note. delete's
+	// --fetch is an opt-in convenience, so an unreachable remote must not block a local deletion
+	// (matching how start treats fetch failures). finish aborts on a fatal fetch failure unless
+	// forced.
+	fetchFailureNonFatal bool
+
+	// operation names the command driving the preflight ("finish" or "delete"). It is propagated
+	// into BranchNotInSyncError so a sync abort suggests the right `git flow <type> <op> --force`
+	// command. Empty renders as finish (the zero-value default).
+	operation string
+}
+
+// runFetchSyncPreflight guards a topic operation against an out-of-date topic branch. It fetches
 // the topic (and, best-effort, the parent) and then verifies the topic is in sync with its remote.
+// Callers tune the behavior with opts; the zero value is finish's strict pre-merge guard.
 //
 // Behavior:
 //   - shouldFetch=false or no remote configured: fetch is skipped (no "Fetching" line). The topic
 //     sync check still runs against existing tracking data (so --no-fetch does not skip it).
 //   - Topic fetch reports a missing remote ref (never pushed / deleted after a remote merge): the
 //     missing ref is benign — the stale tracking ref is pruned and the sync check is skipped.
-//   - Topic fetch fails with a transport/auth error: fatal (FetchFailedError) unless force.
-//   - Topic ahead/behind/diverged from its remote: fatal (BranchNotInSyncError) unless force.
+//   - Topic fetch fails with a transport/auth error: fatal (FetchFailedError) unless force, or a
+//     non-fatal note when opts.fetchFailureNonFatal is set.
+//   - Topic behind/diverged from its remote: fatal (BranchNotInSyncError) unless force. Ahead is
+//     also fatal unless force, unless opts.tolerateAhead downgrades it to a note.
 //
-// The parent is fetched only best-effort here; it is intentionally NOT sync-checked. Future
-// extension points (kept out of this signature to avoid unused hooks):
-//   - #99: parent sync-check before merge.
-//   - #88: fast-forward the parent from its remote before merge.
-func runFetchSyncPreflight(cfg *config.Config, branchType, remote, topicBranch, shortName, parentBranch string, shouldFetch, force bool) error {
+// The parent is fetched best-effort. It is not sync-checked (see #99), but when opts.ffParent is
+// set and the parent is the current branch, it is fast-forwarded from its remote (#88).
+func runFetchSyncPreflight(cfg *config.Config, branchType, remote, topicBranch, shortName, parentBranch string, shouldFetch, force bool, opts preflightOptions) error {
 	// topicRefFound tracks whether the topic still has a remote ref to compare against. It stays
 	// true when the fetch is skipped (we then rely on existing tracking data).
 	topicRefFound := true
@@ -32,10 +62,23 @@ func runFetchSyncPreflight(cfg *config.Config, branchType, remote, topicBranch, 
 	if shouldFetch && git.RemoteExists(remote) {
 		fmt.Printf("Fetching from remote '%s'...\n", remote)
 
-		// Fetch the parent best-effort. Any failure (including a missing ref) is a non-fatal
-		// note; the parent is not sync-checked here (see #99).
-		if err := git.FetchBranch(remote, parentBranch); err != nil {
-			fmt.Printf("Note: Could not fetch base branch '%s': %v\n", parentBranch, err)
+		// Fetch the parent best-effort. Any failure (including a missing ref) is a non-fatal note;
+		// the parent is not sync-checked here (see #99). Skip entirely when the branch type has no
+		// configured parent, so we never issue `git fetch <remote> ""` or emit a spurious note.
+		if parentBranch != "" {
+			if err := git.FetchBranch(remote, parentBranch); err != nil {
+				fmt.Printf("Note: Could not fetch base branch '%s': %v\n", parentBranch, err)
+			} else if opts.ffParent {
+				// #88: fast-forward the local parent to its just-fetched remote so that a branch merged
+				// remotely is seen as merged by `git branch -d`. `git merge --ff-only` acts on HEAD, so
+				// only fast-forward when the parent is checked out; otherwise leave HEAD untouched.
+				if current, cerr := git.GetCurrentBranch(); cerr == nil && current == parentBranch {
+					remoteParent := fmt.Sprintf("%s/%s", remote, parentBranch)
+					if ferr := git.MergeFFOnly(remoteParent); ferr != nil {
+						fmt.Printf("Note: Could not fast-forward '%s': %v\n", parentBranch, ferr)
+					}
+				}
+			}
 		}
 
 		// Fetch the topic, distinguishing a benign missing ref from a fatal transport failure.
@@ -47,10 +90,14 @@ func runFetchSyncPreflight(cfg *config.Config, branchType, remote, topicBranch, 
 				fmt.Printf("Note: Remote branch for '%s' not found; skipping sync check\n", topicBranch)
 				topicRefFound = false
 				// Best-effort cleanup: the ref may already be absent, so a failure here is a
-				// note, not a reason to abort the finish.
+				// note, not a reason to abort.
 				if derr := git.DeleteRemoteTrackingRef(remote, topicBranch); derr != nil {
 					fmt.Printf("Note: Could not prune stale tracking ref for '%s': %v\n", topicBranch, derr)
 				}
+			} else if opts.fetchFailureNonFatal {
+				// Opt-in convenience fetch (delete): an unreachable remote must not block the
+				// operation. Warn and fall back to whatever tracking data already exists.
+				fmt.Printf("Note: Could not fetch topic branch '%s': %v\n", topicBranch, err)
 			} else if !force {
 				return &errors.FetchFailedError{
 					Remote: remote,
@@ -67,15 +114,29 @@ func runFetchSyncPreflight(cfg *config.Config, branchType, remote, topicBranch, 
 		if err != nil {
 			// HasTrackingBranch already confirmed a tracking branch, and when fetching, the topic
 			// fetch succeeded — so a compare failure here is unexpected (e.g. a corrupt/dangling
-			// tracking ref or a rev-list failure). Fail closed rather than merging against an
+			// tracking ref or a rev-list failure). Fail closed rather than acting against an
 			// undetermined sync status; --force skips this whole block.
 			return &errors.GitError{
 				Operation: fmt.Sprintf("determine sync status for branch '%s'", topicBranch),
 				Err:       err,
 			}
 		}
+
+		// Decide whether this status aborts. Behind/diverged always abort (remote work would be
+		// lost). Ahead aborts too, unless the caller tolerates it (delete), in which case it is a
+		// note.
+		abort := false
 		switch status {
-		case git.SyncStatusAhead, git.SyncStatusBehind, git.SyncStatusDiverged:
+		case git.SyncStatusBehind, git.SyncStatusDiverged:
+			abort = true
+		case git.SyncStatusAhead:
+			if opts.tolerateAhead {
+				fmt.Printf("Note: Local branch '%s' is %d commit(s) ahead of remote\n", topicBranch, commitCount)
+			} else {
+				abort = true
+			}
+		}
+		if abort {
 			trackingBranch, terr := git.GetTrackingBranch(topicBranch)
 			if terr != nil {
 				trackingBranch = "remote tracking branch"
@@ -87,6 +148,7 @@ func runFetchSyncPreflight(cfg *config.Config, branchType, remote, topicBranch, 
 				Status:       string(status),
 				CommitCount:  commitCount,
 				BranchType:   branchType,
+				Operation:    opts.operation,
 			}
 		}
 		// SyncStatusEqual: the topic is in sync, proceed normally. (SyncStatusNoTracking always

--- a/cmd/shorthand.go
+++ b/cmd/shorthand.go
@@ -36,23 +36,16 @@ func RegisterShorthandCommands() {
 			if err != nil {
 				return err
 			}
-			var force *bool
-			if cmd.Flags().Changed("force") {
-				f, _ := cmd.Flags().GetBool("force")
-				force = &f
-			} else if cmd.Flags().Changed("no-force") {
-				f := false
-				force = &f
-			}
-			var remote *bool
-			if cmd.Flags().Changed("remote") {
-				r, _ := cmd.Flags().GetBool("remote")
-				remote = &r
-			} else if cmd.Flags().Changed("no-remote") {
-				f := false
-				remote = &f
-			}
-			DeleteCommand(branchType, name, force, remote)
+			forceFlag, _ := cmd.Flags().GetBool("force")
+			noForceFlag, _ := cmd.Flags().GetBool("no-force")
+			force := getBoolFlag(forceFlag, noForceFlag)
+			remoteFlag, _ := cmd.Flags().GetBool("remote")
+			noRemoteFlag, _ := cmd.Flags().GetBool("no-remote")
+			remote := getBoolFlag(remoteFlag, noRemoteFlag)
+			fetchFlag, _ := cmd.Flags().GetBool("fetch")
+			noFetchFlag, _ := cmd.Flags().GetBool("no-fetch")
+			fetch := getBoolFlag(fetchFlag, noFetchFlag)
+			DeleteCommand(branchType, name, force, remote, fetch)
 			return nil
 		},
 	}
@@ -60,6 +53,8 @@ func RegisterShorthandCommands() {
 	deleteCmd.Flags().Bool("no-force", false, "Don't force delete (overrides config)")
 	deleteCmd.Flags().BoolP("remote", "r", false, "Delete remote tracking branch")
 	deleteCmd.Flags().Bool("no-remote", false, "Don't delete remote tracking branch")
+	deleteCmd.Flags().Bool("fetch", false, "Fetch from remote before deleting")
+	deleteCmd.Flags().Bool("no-fetch", false, "Don't fetch from remote before deleting")
 	rootCmd.AddCommand(deleteCmd)
 
 	// Update

--- a/cmd/topicbranch.go
+++ b/cmd/topicbranch.go
@@ -295,26 +295,10 @@ func registerBranchCommand(branchType string) {
 			noForce, _ := cmd.Flags().GetBool("no-force")
 			remote, _ := cmd.Flags().GetBool("remote")
 			noRemote, _ := cmd.Flags().GetBool("no-remote")
+			fetch, _ := cmd.Flags().GetBool("fetch")
+			noFetch, _ := cmd.Flags().GetBool("no-fetch")
 
-			// Convert force flags to a single *bool
-			var forcePtr *bool
-			if force {
-				forcePtr = &force
-			} else if noForce {
-				falseBool := false
-				forcePtr = &falseBool
-			}
-
-			// Convert remote flags to a single *bool
-			var remotePtr *bool
-			if remote {
-				remotePtr = &remote
-			} else if noRemote {
-				falseBool := false
-				remotePtr = &falseBool
-			}
-
-			DeleteCommand(branchType, args[0], forcePtr, remotePtr)
+			DeleteCommand(branchType, args[0], getBoolFlag(force, noForce), getBoolFlag(remote, noRemote), getBoolFlag(fetch, noFetch))
 			return nil
 		},
 	}
@@ -324,6 +308,8 @@ func registerBranchCommand(branchType string) {
 	deleteCmd.Flags().Bool("no-force", false, "Don't force delete the branch (overrides config)")
 	deleteCmd.Flags().BoolP("remote", "r", false, "Delete the remote tracking branch")
 	deleteCmd.Flags().Bool("no-remote", false, "Don't delete the remote tracking branch")
+	deleteCmd.Flags().Bool("fetch", false, "Fetch from remote before deleting")
+	deleteCmd.Flags().Bool("no-fetch", false, "Don't fetch from remote before deleting")
 
 	branchCmd.AddCommand(deleteCmd)
 

--- a/docs/git-flow-delete.1.md
+++ b/docs/git-flow-delete.1.md
@@ -38,6 +38,12 @@ The delete operation removes the specified topic branch from the local repositor
 **--no-remote**
 : Don't delete the remote tracking branch (default behavior)
 
+**--fetch**
+: Fetch from remote before deleting. This updates local refs so that Git can correctly detect whether the branch has been merged remotely (e.g., via a GitHub PR merge). The parent branch is fast-forwarded from its remote only when it is the branch currently checked out (`git merge --ff-only` acts on HEAD); delete auto-checks-out the parent when you delete the branch you are on, which is the common case. If the remote is unreachable the fetch failure is a non-fatal note and deletion is not blocked by the fetch itself, but the topic sync check still runs against existing local tracking data and can still abort (behind/diverged) unless **--force** is given.
+
+**--no-fetch**
+: Don't fetch from remote before deleting (overrides config). This skips only the fetch; the topic sync check still runs against existing local tracking data.
+
 ## SAFETY CHECKS
 
 By default, Git prevents deletion of branches with unmerged changes. The delete command:
@@ -65,6 +71,13 @@ git flow delete
 Delete with remote cleanup:
 ```bash
 git flow feature delete my-feature --remote
+```
+
+### Fetch Before Delete
+
+Fetch and fast-forward the parent branch before deleting, so Git can detect branches merged remotely (e.g., via a GitHub PR merge):
+```bash
+git flow feature delete my-feature --fetch
 ```
 
 ### Force Deletion
@@ -142,6 +155,12 @@ git config gitflow.hotfix.delete.force true
 ```bash
 # Enable remote deletion by default for feature branches
 git config gitflow.branch.feature.deleteRemote true
+```
+
+### Fetch Settings
+```bash
+# Always fetch before deleting feature branches
+git config gitflow.feature.delete.fetch true
 ```
 
 ## SAFETY CONSIDERATIONS

--- a/docs/gitflow-config.5.md
+++ b/docs/gitflow-config.5.md
@@ -483,6 +483,11 @@ The finish command supports extensive merge strategy configuration through comma
 : *Type*: boolean
 : *Default*: false
 
+**gitflow.*type*.delete.fetch**
+: Fetch from remote before deleting a topic branch. When enabled, updates local refs so that Git can correctly detect whether the branch has been merged remotely (e.g., via a GitHub PR merge), avoiding the need for `--force`. The parent is fast-forwarded from its remote only when it is the branch currently checked out (`git merge --ff-only` acts on HEAD); delete auto-checks-out the parent when you delete the branch you are on, which is the common case. When no remote is configured, the fetch is skipped silently. A fetch failure against an unreachable remote is a non-fatal note — deletion is not blocked by the fetch itself, but the topic sync check still runs against existing local tracking data and can still abort (behind/diverged) unless `--force` is given. `--no-fetch` skips only the fetch; it does not skip the sync check.
+: *Type*: boolean
+: *Default*: false
+
 ### Remote Push Options
 
 **gitflow.*type*.finish.push**

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -259,6 +259,10 @@ type BranchNotInSyncError struct {
 	Status       string // "ahead", "behind", or "diverged"
 	CommitCount  int
 	BranchType   string
+	// Operation names the command that tripped the sync gate ("finish" or "delete"). It tailors
+	// the action verb and the suggested `git flow <type> <op> --force` command to the caller.
+	// Empty means "finish".
+	Operation string
 }
 
 func (e *BranchNotInSyncError) Error() string {
@@ -268,6 +272,37 @@ func (e *BranchNotInSyncError) Error() string {
 	shortName := e.ShortName
 	if shortName == "" {
 		shortName = e.BranchName
+	}
+
+	// delete reuses this error via the shared preflight, but its consequences differ from
+	// finish's: deleting a local branch never rewrites the remote, so the wording and the
+	// suggested command are tailored here. delete tolerates an ahead branch, so it only ever
+	// reaches the behind/diverged cases.
+	if e.Operation == "delete" {
+		if e.Status == SyncStatusDiverged {
+			return fmt.Sprintf(`local branch '%s' has diverged from '%s' by %d commit(s).
+
+The local and remote branches each have commits the other does not.
+Deleting now would drop the local-only commits.
+
+To resolve:
+  git pull                       # reconcile with the remote first
+
+To delete anyway (dropping local-only commits):
+  git flow %s delete --force %s`,
+				e.BranchName, e.RemoteBranch, e.CommitCount, e.BranchType, shortName)
+		}
+		return fmt.Sprintf(`local branch '%s' is behind '%s' by %d commit(s).
+
+The remote branch has commits not present locally. Deleting now would
+drop the local branch before those commits are integrated.
+
+To resolve:
+  git pull                       # bring in the remote commits first
+
+To delete anyway:
+  git flow %s delete --force %s`,
+			e.BranchName, e.RemoteBranch, e.CommitCount, e.BranchType, shortName)
 	}
 
 	switch e.Status {

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -487,6 +487,17 @@ func RebaseWithOptions(targetBranch string, preserveMerges bool) error {
 	return nil
 }
 
+// MergeFFOnly attempts a fast-forward-only merge of the given branch into the current branch.
+// Returns an error if the merge cannot be fast-forwarded.
+func MergeFFOnly(branch string) error {
+	cmd := exec.Command("git", "merge", "--ff-only", branch)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("fast-forward merge of %q failed: %w: %s", branch, err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
 // MergeWithOptions merges a branch into current branch with optional no-fast-forward
 func MergeWithOptions(branchName string, noFF bool, noVerify bool) error {
 	args := []string{"merge"}

--- a/test/cmd/delete_test.go
+++ b/test/cmd/delete_test.go
@@ -1046,3 +1046,526 @@ func TestDeleteWithBaseConfigInNonLocalScopeNoWarning(t *testing.T) {
 		t.Error("Expected feature branch to be deleted")
 	}
 }
+
+// TestDeleteFeatureWithFetchFlag tests that the --fetch flag fetches before deleting.
+// Steps:
+// 1. Sets up a test repository with remote (includes git-flow init)
+// 2. Starts a feature branch
+// 3. Runs 'git flow feature delete my-feature --fetch'
+// 4. Verifies output contains "Fetching from remote"
+// 5. Verifies branch is deleted
+func TestDeleteFeatureWithFetchFlag(t *testing.T) {
+	// Setup test repository with remote
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	// Create a feature branch
+	_, err := testutil.RunGitFlow(t, dir, "feature", "start", "test-fetch")
+	if err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+
+	// Delete with --fetch flag
+	output, err := testutil.RunGitFlow(t, dir, "feature", "delete", "test-fetch", "--fetch")
+	if err != nil {
+		t.Fatalf("Failed to delete feature branch: %v\nOutput: %s", err, output)
+	}
+
+	// Verify that fetch occurred
+	if !strings.Contains(output, "Fetching from remote") {
+		t.Error("Expected fetch to occur with --fetch flag")
+	}
+
+	// Verify branch is deleted
+	if testutil.BranchExists(t, dir, "feature/test-fetch") {
+		t.Error("Expected feature branch to be deleted")
+	}
+}
+
+// TestDeleteFeatureWithFetchConfig tests that gitflow.feature.delete.fetch config triggers fetch.
+// Steps:
+// 1. Sets up a test repository with remote (includes git-flow init)
+// 2. Starts a feature branch
+// 3. Sets gitflow.feature.delete.fetch to true
+// 4. Runs 'git flow feature delete my-feature' (no flag)
+// 5. Verifies output contains "Fetching from remote"
+// 6. Verifies branch is deleted
+func TestDeleteFeatureWithFetchConfig(t *testing.T) {
+	// Setup test repository with remote
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	// Create a feature branch
+	_, err := testutil.RunGitFlow(t, dir, "feature", "start", "test-fetch-config")
+	if err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+
+	// Set fetch config
+	_, err = testutil.RunGit(t, dir, "config", "gitflow.feature.delete.fetch", "true")
+	if err != nil {
+		t.Fatalf("Failed to set config: %v", err)
+	}
+
+	// Delete without flag (should use config)
+	output, err := testutil.RunGitFlow(t, dir, "feature", "delete", "test-fetch-config")
+	if err != nil {
+		t.Fatalf("Failed to delete feature branch: %v\nOutput: %s", err, output)
+	}
+
+	// Verify that fetch occurred
+	if !strings.Contains(output, "Fetching from remote") {
+		t.Error("Expected fetch to occur with fetch config enabled")
+	}
+
+	// Verify branch is deleted
+	if testutil.BranchExists(t, dir, "feature/test-fetch-config") {
+		t.Error("Expected feature branch to be deleted")
+	}
+}
+
+// TestDeleteFeatureWithNoFetchOverridesConfig tests that --no-fetch overrides fetch config.
+// Steps:
+// 1. Sets up a test repository with remote (includes git-flow init)
+// 2. Starts a feature branch
+// 3. Sets gitflow.feature.delete.fetch to true
+// 4. Runs 'git flow feature delete my-feature --no-fetch'
+// 5. Verifies output does NOT contain "Fetching"
+// 6. Verifies branch is deleted
+func TestDeleteFeatureWithNoFetchOverridesConfig(t *testing.T) {
+	// Setup test repository with remote
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	// Create a feature branch
+	_, err := testutil.RunGitFlow(t, dir, "feature", "start", "test-no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+
+	// Set fetch config
+	_, err = testutil.RunGit(t, dir, "config", "gitflow.feature.delete.fetch", "true")
+	if err != nil {
+		t.Fatalf("Failed to set config: %v", err)
+	}
+
+	// Delete with --no-fetch flag (should override config)
+	output, err := testutil.RunGitFlow(t, dir, "feature", "delete", "test-no-fetch", "--no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to delete feature branch: %v\nOutput: %s", err, output)
+	}
+
+	// Verify that fetch did NOT occur
+	if strings.Contains(output, "Fetching") {
+		t.Error("Expected --no-fetch to override config and skip fetch")
+	}
+
+	// Verify branch is deleted
+	if testutil.BranchExists(t, dir, "feature/test-no-fetch") {
+		t.Error("Expected feature branch to be deleted")
+	}
+}
+
+// TestDeleteFeatureNoRemoteFetchSkipped tests that --fetch silently skips when no remote exists.
+// Steps:
+// 1. Sets up a test repository (no remote) and initializes git-flow with defaults
+// 2. Starts a feature branch
+// 3. Runs 'git flow feature delete my-feature --fetch'
+// 4. Verifies output does NOT contain "Fetching" (fetch skipped silently)
+// 5. Verifies no error about missing remote
+// 6. Verifies branch is deleted
+func TestDeleteFeatureNoRemoteFetchSkipped(t *testing.T) {
+	// Setup test repository without remote
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// Initialize git-flow with defaults
+	_, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+
+	// Create a feature branch
+	_, err = testutil.RunGitFlow(t, dir, "feature", "start", "test-no-remote")
+	if err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+
+	// Delete with --fetch flag (no remote configured)
+	output, err := testutil.RunGitFlow(t, dir, "feature", "delete", "test-no-remote", "--fetch")
+	if err != nil {
+		t.Fatalf("Failed to delete feature branch: %v\nOutput: %s", err, output)
+	}
+
+	// Verify fetch was skipped silently
+	if strings.Contains(output, "Fetching") {
+		t.Error("Expected fetch to be skipped silently when no remote exists")
+	}
+
+	// Verify no confusing error messages
+	if strings.Contains(output, "does not appear to be a git repository") {
+		t.Error("Expected no confusing error about missing remote")
+	}
+
+	// Verify branch is deleted
+	if testutil.BranchExists(t, dir, "feature/test-no-remote") {
+		t.Error("Expected feature branch to be deleted")
+	}
+}
+
+// setupBehindDeleteRepo sets up a repo whose local feature branch is behind its remote: it starts a
+// feature branch, commits, pushes it with tracking, then advances the remote branch from a second
+// clone so the local branch falls behind. It returns the working dir (already registered for
+// cleanup) for the test to run delete against.
+func setupBehindDeleteRepo(t *testing.T, feature string) string {
+	t.Helper()
+
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	t.Cleanup(func() { testutil.CleanupTestRepo(t, dir) })
+	t.Cleanup(func() { testutil.CleanupTestRepo(t, remoteDir) })
+
+	// Create a feature branch with a commit and push it with tracking
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", feature); err != nil {
+		t.Fatalf("Failed to start feature: %v", err)
+	}
+	if err := testutil.WriteFile(t, dir, "local.txt", "local content"); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "add", "local.txt"); err != nil {
+		t.Fatalf("Failed to add file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Local feature commit"); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "push", "--set-upstream", "origin", "feature/"+feature); err != nil {
+		t.Fatalf("Failed to push feature: %v", err)
+	}
+
+	// In a second clone, add a commit to the remote feature branch so local falls behind
+	secondDir := t.TempDir()
+	if _, err := testutil.RunGit(t, secondDir, "clone", remoteDir, "."); err != nil {
+		t.Fatalf("Failed to clone: %v", err)
+	}
+	testutil.ConfigureGitIdentity(t, secondDir)
+	if _, err := testutil.RunGit(t, secondDir, "checkout", "feature/"+feature); err != nil {
+		t.Fatalf("Failed to checkout feature in clone: %v", err)
+	}
+	if err := testutil.WriteFile(t, secondDir, "remote.txt", "remote content"); err != nil {
+		t.Fatalf("Failed to write file in clone: %v", err)
+	}
+	if _, err := testutil.RunGit(t, secondDir, "add", "remote.txt"); err != nil {
+		t.Fatalf("Failed to add file in clone: %v", err)
+	}
+	if _, err := testutil.RunGit(t, secondDir, "commit", "-m", "Remote feature commit"); err != nil {
+		t.Fatalf("Failed to commit in clone: %v", err)
+	}
+	if _, err := testutil.RunGit(t, secondDir, "push", "origin", "feature/"+feature); err != nil {
+		t.Fatalf("Failed to push from clone: %v", err)
+	}
+
+	return dir
+}
+
+// TestDeleteFeatureBehindRemoteAborts verifies the fetch/sync preflight blocks deleting a topic
+// branch that is behind its remote, and that the abort recommends the delete-specific command (not
+// finish).
+// Steps:
+// 1. Sets up a repo whose local feature branch is behind its remote
+// 2. Runs 'git flow feature delete --fetch' and expects an abort mentioning "behind"
+// 3. Confirms the error recommends 'git flow feature delete --force' and not 'finish --force'
+// 4. Confirms the branch still exists
+func TestDeleteFeatureBehindRemoteAborts(t *testing.T) {
+	dir := setupBehindDeleteRepo(t, "behind-del")
+
+	// Delete with --fetch must abort because the local branch is behind its remote
+	output, err := testutil.RunGitFlow(t, dir, "feature", "delete", "behind-del", "--fetch")
+	if err == nil {
+		t.Fatalf("Expected delete --fetch to fail when behind remote. Output: %s", output)
+	}
+	if !strings.Contains(output, "behind") {
+		t.Errorf("Expected abort message to mention 'behind'. Output: %s", output)
+	}
+	// The abort must recommend the delete command, not finish (#88 operation-aware message).
+	if !strings.Contains(output, "git flow feature delete --force") {
+		t.Errorf("Expected abort to recommend 'git flow feature delete --force'. Output: %s", output)
+	}
+	if strings.Contains(output, "finish --force") {
+		t.Errorf("Expected abort not to mention 'finish --force'. Output: %s", output)
+	}
+	if !testutil.BranchExists(t, dir, "feature/behind-del") {
+		t.Error("Expected feature branch to still exist after aborted delete")
+	}
+}
+
+// TestDeleteFeatureBehindRemoteForceOverrides verifies that --force overrides the sync gate and
+// deletes a branch that is behind its remote.
+// Steps:
+// 1. Sets up a repo whose local feature branch is behind its remote
+// 2. Runs 'git flow feature delete --fetch --force' and expects it to succeed
+// 3. Confirms the branch is deleted
+func TestDeleteFeatureBehindRemoteForceOverrides(t *testing.T) {
+	dir := setupBehindDeleteRepo(t, "behind-del-force")
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "delete", "behind-del-force", "--fetch", "--force")
+	if err != nil {
+		t.Fatalf("Expected forced delete to succeed. Output: %s\nerr: %v", output, err)
+	}
+	if testutil.BranchExists(t, dir, "feature/behind-del-force") {
+		t.Error("Expected feature branch to be deleted with --force")
+	}
+}
+
+// TestDeleteFeatureNoFetchStillAbortsWhenBehind verifies that --no-fetch skips only the fetch, not
+// the sync gate: a branch already known (via cached tracking data) to be behind still aborts.
+// Steps:
+// 1. Sets up a repo whose local feature branch is behind its remote
+// 2. Runs a plain 'git fetch' so the remote-tracking ref reflects the behind state locally
+// 3. Runs 'git flow feature delete --no-fetch' and expects an abort mentioning "behind"
+// 4. Confirms no "Fetching" line was printed (the fetch really was skipped)
+// 5. Confirms the branch still exists
+func TestDeleteFeatureNoFetchStillAbortsWhenBehind(t *testing.T) {
+	dir := setupBehindDeleteRepo(t, "no-fetch-behind")
+
+	// Update the remote-tracking ref locally without git-flow fetching, so the cached tracking
+	// data already shows the branch is behind.
+	if _, err := testutil.RunGit(t, dir, "fetch", "origin"); err != nil {
+		t.Fatalf("Failed to fetch: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "delete", "no-fetch-behind", "--no-fetch")
+	if err == nil {
+		t.Fatalf("Expected delete --no-fetch to fail when behind remote. Output: %s", output)
+	}
+	if !strings.Contains(output, "behind") {
+		t.Errorf("Expected abort message to mention 'behind'. Output: %s", output)
+	}
+	// --no-fetch must skip the fetch itself but still run the sync check.
+	if strings.Contains(output, "Fetching") {
+		t.Errorf("Expected --no-fetch to skip the fetch. Output: %s", output)
+	}
+	if !testutil.BranchExists(t, dir, "feature/no-fetch-behind") {
+		t.Error("Expected feature branch to still exist after aborted delete")
+	}
+}
+
+// TestDeleteFeatureDivergedRemoteAborts verifies the sync preflight blocks deleting a topic branch
+// that has diverged from its remote, and that the abort recommends the delete-specific command.
+// Steps:
+// 1. Sets up a repo with remote, starts a feature branch, commits, and pushes it with tracking
+// 2. In a second clone, advances the remote feature branch (remote gains a commit)
+// 3. Adds a different local commit so the branch diverges
+// 4. Runs 'git flow feature delete --fetch' and expects an abort mentioning "diverged"
+// 5. Confirms the error recommends 'git flow feature delete --force' and not 'finish --force'
+// 6. Confirms the branch still exists
+func TestDeleteFeatureDivergedRemoteAborts(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	// Create a feature branch with a commit and push it with tracking
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "diverged-del"); err != nil {
+		t.Fatalf("Failed to start feature: %v", err)
+	}
+	if err := testutil.WriteFile(t, dir, "base.txt", "base content"); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "add", "base.txt"); err != nil {
+		t.Fatalf("Failed to add file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Base feature commit"); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "push", "--set-upstream", "origin", "feature/diverged-del"); err != nil {
+		t.Fatalf("Failed to push feature: %v", err)
+	}
+
+	// In a second clone, add a commit to the remote feature branch
+	secondDir := t.TempDir()
+	if _, err := testutil.RunGit(t, secondDir, "clone", remoteDir, "."); err != nil {
+		t.Fatalf("Failed to clone: %v", err)
+	}
+	testutil.ConfigureGitIdentity(t, secondDir)
+	if _, err := testutil.RunGit(t, secondDir, "checkout", "feature/diverged-del"); err != nil {
+		t.Fatalf("Failed to checkout feature in clone: %v", err)
+	}
+	if err := testutil.WriteFile(t, secondDir, "remote.txt", "remote content"); err != nil {
+		t.Fatalf("Failed to write file in clone: %v", err)
+	}
+	if _, err := testutil.RunGit(t, secondDir, "add", "remote.txt"); err != nil {
+		t.Fatalf("Failed to add file in clone: %v", err)
+	}
+	if _, err := testutil.RunGit(t, secondDir, "commit", "-m", "Remote feature commit"); err != nil {
+		t.Fatalf("Failed to commit in clone: %v", err)
+	}
+	if _, err := testutil.RunGit(t, secondDir, "push", "origin", "feature/diverged-del"); err != nil {
+		t.Fatalf("Failed to push from clone: %v", err)
+	}
+
+	// Add a different local commit so the branch diverges from the remote
+	if err := testutil.WriteFile(t, dir, "local.txt", "local content"); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "add", "local.txt"); err != nil {
+		t.Fatalf("Failed to add file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Local feature commit"); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// Delete with --fetch must abort because the local branch has diverged
+	output, err := testutil.RunGitFlow(t, dir, "feature", "delete", "diverged-del", "--fetch")
+	if err == nil {
+		t.Fatalf("Expected delete --fetch to fail when diverged. Output: %s", output)
+	}
+	if !strings.Contains(output, "diverged") {
+		t.Errorf("Expected abort message to mention 'diverged'. Output: %s", output)
+	}
+	if !strings.Contains(output, "git flow feature delete --force") {
+		t.Errorf("Expected abort to recommend 'git flow feature delete --force'. Output: %s", output)
+	}
+	if strings.Contains(output, "finish --force") {
+		t.Errorf("Expected abort not to mention 'finish --force'. Output: %s", output)
+	}
+	if !testutil.BranchExists(t, dir, "feature/diverged-del") {
+		t.Error("Expected feature branch to still exist after aborted delete")
+	}
+}
+
+// TestDeleteFeatureAheadRemoteTolerated verifies the delete preflight tolerates a topic branch that
+// is merely ahead of its remote: unlike finish, the sync gate does not abort on ahead
+// (tolerateAhead). It prints a note and lets the operation proceed to `git branch -d`.
+//
+// Note: a branch that is genuinely ahead of its upstream cannot complete a non-force `git branch -d`
+// (Git independently refuses a branch not merged into its upstream, even when merged into HEAD), so
+// this test asserts what tolerateAhead actually governs — the sync gate does not fire — rather than
+// full deletion, which would require --force (which bypasses the sync check entirely).
+// Steps:
+//  1. Sets up a repo with remote, starts a feature branch, commits, and pushes it with tracking
+//  2. Adds a local commit that is not pushed, so the branch is ahead of its remote
+//  3. Runs 'git flow feature delete --fetch' and confirms the ahead state is tolerated (a note is
+//     printed) and the sync gate does NOT abort (no delete/finish --force recommendation)
+func TestDeleteFeatureAheadRemoteTolerated(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	// Create a feature branch with a commit and push it with tracking (in sync)
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "ahead-del"); err != nil {
+		t.Fatalf("Failed to start feature: %v", err)
+	}
+	if err := testutil.WriteFile(t, dir, "base.txt", "base content"); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "add", "base.txt"); err != nil {
+		t.Fatalf("Failed to add file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Base feature commit"); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "push", "--set-upstream", "origin", "feature/ahead-del"); err != nil {
+		t.Fatalf("Failed to push feature: %v", err)
+	}
+
+	// Add a local commit that is not pushed, so the branch is ahead of its remote
+	if err := testutil.WriteFile(t, dir, "local.txt", "local content"); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "add", "local.txt"); err != nil {
+		t.Fatalf("Failed to add file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Local unpushed commit"); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// Delete with --fetch: the sync gate must tolerate the ahead state (a note, not an abort).
+	// git branch -d itself still refuses a branch that is not merged into its upstream, so the
+	// command as a whole fails there — not at the sync gate. Asserting that failure (rather than
+	// ignoring the error) keeps this test from passing vacuously.
+	output, err := testutil.RunGitFlow(t, dir, "feature", "delete", "ahead-del", "--fetch")
+	if err == nil {
+		t.Errorf("Expected delete to fail (git branch -d refuses an ahead branch). Output: %s", output)
+	}
+	// The branch must still exist: deletion did not happen.
+	if !testutil.BranchExists(t, dir, "feature/ahead-del") {
+		t.Error("Expected feature/ahead-del to still exist after the refused delete")
+	}
+	// The sync gate must have TOLERATED ahead: it printed a note...
+	if !strings.Contains(output, "ahead of remote") {
+		t.Errorf("Expected a tolerated 'ahead of remote' note. Output: %s", output)
+	}
+	// ...and did NOT abort with a sync error (that would recommend `delete --force`).
+	if strings.Contains(output, "To delete anyway") || strings.Contains(output, "--force ahead-del") {
+		t.Errorf("Expected the sync gate not to abort on an ahead branch. Output: %s", output)
+	}
+}
+
+// TestDeleteFeatureMergedRemotely verifies the #88 scenario: a feature merged remotely (e.g. via a
+// PR) can be deleted with a non-force `git branch -d` once --fetch fast-forwards the parent.
+// Steps:
+// 1. Sets up a repo with remote, starts a feature branch, commits, and pushes it
+// 2. In a second clone, merges the feature into develop, pushes develop, deletes the remote feature
+// 3. Checks out the parent and runs 'git flow feature delete --fetch' (no --force)
+// 4. The fetch fast-forwards develop so `git branch -d` recognizes the branch as merged
+func TestDeleteFeatureMergedRemotely(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	// Create a feature branch with a commit and publish it (no upstream tracking, so
+	// `git branch -d` later falls back to checking HEAD)
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "merged-remote"); err != nil {
+		t.Fatalf("Failed to start feature: %v", err)
+	}
+	if err := testutil.WriteFile(t, dir, "feature.txt", "feature work"); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "add", "feature.txt"); err != nil {
+		t.Fatalf("Failed to add file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Feature work"); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "push", "origin", "feature/merged-remote"); err != nil {
+		t.Fatalf("Failed to push feature: %v", err)
+	}
+
+	// Simulate a remote PR merge in a second clone: merge the feature into develop, push
+	// develop, and delete the remote feature branch
+	secondDir := t.TempDir()
+	if _, err := testutil.RunGit(t, secondDir, "clone", remoteDir, "."); err != nil {
+		t.Fatalf("Failed to clone: %v", err)
+	}
+	testutil.ConfigureGitIdentity(t, secondDir)
+	if _, err := testutil.RunGit(t, secondDir, "checkout", "develop"); err != nil {
+		t.Fatalf("Failed to checkout develop in clone: %v", err)
+	}
+	if _, err := testutil.RunGit(t, secondDir, "merge", "--no-ff", "-m", "Merge feature/merged-remote", "origin/feature/merged-remote"); err != nil {
+		t.Fatalf("Failed to merge feature into develop: %v", err)
+	}
+	if _, err := testutil.RunGit(t, secondDir, "push", "origin", "develop"); err != nil {
+		t.Fatalf("Failed to push develop: %v", err)
+	}
+	if _, err := testutil.RunGit(t, secondDir, "push", "origin", "--delete", "feature/merged-remote"); err != nil {
+		t.Fatalf("Failed to delete remote feature: %v", err)
+	}
+
+	// Back in the original repo, move to the parent. Without --fetch the local develop does not
+	// yet contain the merge, so a non-force delete would refuse.
+	if _, err := testutil.RunGit(t, dir, "checkout", "develop"); err != nil {
+		t.Fatalf("Failed to checkout develop: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "delete", "merged-remote", "--fetch")
+	if err != nil {
+		t.Fatalf("Expected delete --fetch to succeed for a remotely-merged branch. Output: %s\nerr: %v", output, err)
+	}
+	if !strings.Contains(output, "Fetching from remote") {
+		t.Errorf("Expected fetch to occur. Output: %s", output)
+	}
+	if testutil.BranchExists(t, dir, "feature/merged-remote") {
+		t.Error("Expected feature branch to be deleted after fast-forwarding the parent")
+	}
+}


### PR DESCRIPTION
Adds `--fetch` / `--no-fetch` to the `delete` command (and its `git flow delete` shorthand), gated by `gitflow.<type>.delete.fetch` (default `false`). When enabled, delete fetches the parent and topic, fast-forwards the local parent from its remote, and sync-checks the topic before deleting — so a branch merged remotely (e.g. via a PR) is recognized as merged by `git branch -d`, solving the common "merged on the server but Git still thinks it has unmerged commits" case (#88).

This is the rebased and reworked form of the original PR: it now builds on the shared fetch/sync preflight introduced by #134 instead of hand-rolling its own fetch logic, so `delete` and `finish` share one mechanism.

### What it does

- `--fetch` / `--no-fetch` on `delete` and the shorthand; config key `gitflow.<type>.delete.fetch` (default `false`; resolved default → config → flag).
- Delete reuses `runFetchSyncPreflight`. The helper gains a `preflightOptions` struct whose zero value reproduces finish's strict guard, plus three opt-in knobs used by delete:
  - `ffParent` — fast-forward the local parent to its fetched remote, only when the parent is checked out, so `git branch -d` sees a remotely-merged branch as merged.
  - `tolerateAhead` — a topic merely ahead of its remote is a note, not an abort (`git branch -d` still guards genuinely unmerged work).
  - `fetchFailureNonFatal` — an unreachable remote is a warning, not fatal, since delete has no merge to protect (matching `start`).
- `BranchNotInSyncError` becomes operation-aware: a delete aborting on a behind/diverged topic gets delete-accurate wording and suggests `git flow <type> delete --force`, not finish. `finish`'s output is unchanged.

### Tests

Adds delete scenarios covering the `--fetch` flag, `delete.fetch` config, `--no-fetch` override, silent skip when no remote, the behind-remote abort and its `--force` override, diverged abort, ahead tolerance (the branch survives and the gate only notes), `--no-fetch` still applying the cached sync gate, and the merged-remotely end-to-end fast-forward case.

### Notes

- No default change: `delete.fetch` stays `false` (opt-in), consistent with `start`.
- Rebased onto current `main`; the `integrate` command (#142) and the finish preflight (#134) are untouched.

Resolves #88