### PR TITLE
Fix hooks and filters on Windows

### DIFF
--- a/docs/gitflow-hooks.7.md
+++ b/docs/gitflow-hooks.7.md
@@ -294,8 +294,10 @@ fi
 ## CREATING HOOK SCRIPTS
 
 1. Create the script in the hooks directory (default: `.git/hooks/`) with the appropriate name
-2. Make the script executable: `chmod +x <hooks-dir>/<script-name>`
+2. Make the script executable: `chmod +x <hooks-dir>/<script-name>` (Unix/macOS only — not needed on Windows)
 3. Test the script manually before relying on it
+
+**Windows note:** On Windows, NTFS does not track Unix permission bits. Git-flow considers any existing hook file as executable, matching Git for Windows behavior. No `chmod` step is needed.
 
 ### Tips
 

--- a/docs/gitflow-hooks.7.md
+++ b/docs/gitflow-hooks.7.md
@@ -297,7 +297,7 @@ fi
 2. Make the script executable: `chmod +x <hooks-dir>/<script-name>` (Unix/macOS only — not needed on Windows)
 3. Test the script manually before relying on it
 
-**Windows note:** On Windows, NTFS does not track Unix permission bits. Git-flow considers any existing hook file as executable, matching Git for Windows behavior. No `chmod` step is needed.
+**Windows note:** On Windows, NTFS does not track Unix permission bits, so no `chmod` step is needed. Hook scripts are executed via `sh` (shipped with Git for Windows), so shell scripts with a shebang work the same as on Unix/macOS.
 
 ### Tips
 

--- a/internal/hooks/filters.go
+++ b/internal/hooks/filters.go
@@ -9,6 +9,16 @@ import (
 	"strings"
 )
 
+// scriptCommand creates an exec.Cmd for running a hook/filter script.
+// On Windows, scripts are executed via "sh" (shipped with Git for Windows),
+// since exec.Command cannot run shell scripts directly on Windows.
+func scriptCommand(path string, args ...string) *exec.Cmd {
+	if runtime.GOOS == "windows" {
+		return exec.Command("sh", append([]string{path}, args...)...)
+	}
+	return exec.Command(path, args...)
+}
+
 // RunVersionFilter executes a version filter for the given branch type and returns the modified version.
 // The filter script name is: filter-flow-{branchType}-start-version
 // If the filter does not exist or is not executable, the original version is returned.
@@ -79,12 +89,15 @@ func isExecutable(path string) bool {
 	if err != nil {
 		return false
 	}
+	return isExecutableFileInfo(info)
+}
 
+// isExecutableFileInfo checks if a file is executable given its FileInfo.
+// On Windows, any non-directory file is considered executable.
+func isExecutableFileInfo(info os.FileInfo) bool {
 	if runtime.GOOS == "windows" {
 		return !info.IsDir()
 	}
-
-	// Check if file is executable (any execute bit set)
 	return info.Mode()&0111 != 0
 }
 
@@ -108,7 +121,7 @@ func buildFilterEnv(ctx FilterContext) []string {
 
 // runFilter executes a filter script with input as argument.
 func runFilter(scriptPath string, input string, env []string, repoRoot string) (string, error) {
-	cmd := exec.Command(scriptPath, input)
+	cmd := scriptCommand(scriptPath, input)
 
 	if env != nil {
 		cmd.Env = env
@@ -130,7 +143,7 @@ func runFilter(scriptPath string, input string, env []string, repoRoot string) (
 
 // runFilterWithArgs executes a filter script with arguments.
 func runFilterWithArgs(scriptPath string, args []string, env []string, repoRoot string) (string, error) {
-	cmd := exec.Command(scriptPath, args...)
+	cmd := scriptCommand(scriptPath, args...)
 
 	if env != nil {
 		cmd.Env = env

--- a/internal/hooks/filters.go
+++ b/internal/hooks/filters.go
@@ -9,11 +9,16 @@ import (
 	"strings"
 )
 
+// isWindows controls how hook/filter scripts are located and executed. It is a
+// package var (rather than an inline runtime.GOOS check) so tests can exercise
+// both platform branches on any host.
+var isWindows = runtime.GOOS == "windows"
+
 // scriptCommand creates an exec.Cmd for running a hook/filter script.
 // On Windows, scripts are executed via "sh" (shipped with Git for Windows),
 // since exec.Command cannot run shell scripts directly on Windows.
 func scriptCommand(path string, args ...string) *exec.Cmd {
-	if runtime.GOOS == "windows" {
+	if isWindows {
 		return exec.Command("sh", append([]string{path}, args...)...)
 	}
 	return exec.Command(path, args...)
@@ -95,7 +100,7 @@ func isExecutable(path string) bool {
 // isExecutableFileInfo checks if a file is executable given its FileInfo.
 // On Windows, any non-directory file is considered executable.
 func isExecutableFileInfo(info os.FileInfo) bool {
-	if runtime.GOOS == "windows" {
+	if isWindows {
 		return !info.IsDir()
 	}
 	return info.Mode()&0111 != 0

--- a/internal/hooks/filters.go
+++ b/internal/hooks/filters.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -71,10 +72,16 @@ func RunTagMessageFilter(gitDir string, branchType string, ctx FilterContext) (s
 }
 
 // isExecutable checks if a file exists and is executable.
+// On Windows, NTFS doesn't store Unix permission bits, so any existing
+// non-directory file is considered executable (matching Git for Windows behavior).
 func isExecutable(path string) bool {
 	info, err := os.Stat(path)
 	if err != nil {
 		return false
+	}
+
+	if runtime.GOOS == "windows" {
+		return !info.IsDir()
 	}
 
 	// Check if file is executable (any execute bit set)

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -119,17 +119,15 @@ func runHook(gitDir string, phase HookPhase, branchType string, action HookActio
 	hooksDir := getHooksDir(gitDir)
 	hookPath := filepath.Join(hooksDir, hookName)
 
-	// Check if hook exists
-	_, err := os.Stat(hookPath)
+	// Check if hook exists and is executable
+	info, err := os.Stat(hookPath)
 	if os.IsNotExist(err) {
 		return HookResult{Executed: false}
 	}
 	if err != nil {
 		return HookResult{Executed: false, Error: err}
 	}
-
-	// Check if executable
-	if !isExecutable(hookPath) {
+	if !isExecutableFileInfo(info) {
 		return HookResult{Executed: false}
 	}
 
@@ -140,7 +138,7 @@ func runHook(gitDir string, phase HookPhase, branchType string, action HookActio
 	args := BuildHookArgs(action, ctx)
 
 	// Execute hook with arguments
-	cmd := exec.Command(hookPath, args...)
+	cmd := scriptCommand(hookPath, args...)
 	cmd.Env = env
 	cmd.Dir = filepath.Dir(gitDir) // Repository root
 

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -120,7 +120,7 @@ func runHook(gitDir string, phase HookPhase, branchType string, action HookActio
 	hookPath := filepath.Join(hooksDir, hookName)
 
 	// Check if hook exists
-	info, err := os.Stat(hookPath)
+	_, err := os.Stat(hookPath)
 	if os.IsNotExist(err) {
 		return HookResult{Executed: false}
 	}
@@ -129,8 +129,7 @@ func runHook(gitDir string, phase HookPhase, branchType string, action HookActio
 	}
 
 	// Check if executable
-	if info.Mode()&0111 == 0 {
-		// Not executable, skip silently
+	if !isExecutable(hookPath) {
 		return HookResult{Executed: false}
 	}
 

--- a/internal/hooks/platform_test.go
+++ b/internal/hooks/platform_test.go
@@ -1,0 +1,150 @@
+package hooks
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// setWindows overrides the isWindows platform seam for the duration of a test
+// and returns a function that restores the previous value. This lets tests
+// exercise the Windows-specific branches on any host (CI runs Linux only).
+func setWindows(v bool) func() {
+	old := isWindows
+	isWindows = v
+	return func() { isWindows = old }
+}
+
+// TestScriptCommandWindows verifies that on Windows scripts are routed through
+// "sh" with the script path as the first argument. Assertions are on cmd.Args
+// (the logical argv), not cmd.Path, so the test does not require sh on PATH.
+func TestScriptCommandWindows(t *testing.T) {
+	defer setWindows(true)()
+
+	cmd := scriptCommand("/hooks/foo.sh", "1.0.0", "message")
+
+	want := []string{"sh", "/hooks/foo.sh", "1.0.0", "message"}
+	if !reflect.DeepEqual(cmd.Args, want) {
+		t.Errorf("scriptCommand args = %v, want %v", cmd.Args, want)
+	}
+}
+
+// TestScriptCommandUnix verifies that on Unix the script is invoked directly.
+func TestScriptCommandUnix(t *testing.T) {
+	defer setWindows(false)()
+
+	cmd := scriptCommand("/hooks/foo.sh", "1.0.0", "message")
+
+	want := []string{"/hooks/foo.sh", "1.0.0", "message"}
+	if !reflect.DeepEqual(cmd.Args, want) {
+		t.Errorf("scriptCommand args = %v, want %v", cmd.Args, want)
+	}
+}
+
+// TestIsExecutableFileInfoWindows verifies that on Windows any non-directory
+// file is treated as executable (NTFS has no Unix permission bits), while
+// directories are not.
+func TestIsExecutableFileInfoWindows(t *testing.T) {
+	defer setWindows(true)()
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "hook")
+	if err := os.WriteFile(file, []byte("#!/bin/sh\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	fileInfo, err := os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isExecutableFileInfo(fileInfo) {
+		t.Error("non-executable (0644) file should be executable on Windows")
+	}
+
+	dirInfo, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if isExecutableFileInfo(dirInfo) {
+		t.Error("directory should never be executable on Windows")
+	}
+}
+
+// TestIsExecutableFileInfoUnix verifies that on Unix executability is decided
+// by the file mode's execute bits.
+func TestIsExecutableFileInfoUnix(t *testing.T) {
+	defer setWindows(false)()
+
+	dir := t.TempDir()
+	nonExec := filepath.Join(dir, "plain")
+	exec := filepath.Join(dir, "runnable")
+	if err := os.WriteFile(nonExec, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(exec, []byte("x"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	nonExecInfo, err := os.Stat(nonExec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if isExecutableFileInfo(nonExecInfo) {
+		t.Error("0644 file should not be executable on Unix")
+	}
+
+	execInfo, err := os.Stat(exec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isExecutableFileInfo(execInfo) {
+		t.Error("0755 file should be executable on Unix")
+	}
+}
+
+// TestScriptCommandWindowsRoundTrip runs a non-executable (0644) script through
+// the Windows code path on the host to prove the two PR changes work together:
+// the file is eligible under Windows executability rules, and routing it through
+// "sh" actually executes it. Because the file lacks the execute bit, a direct
+// exec would fail with a permission error on Unix — so success here confirms the
+// script ran via sh, not by direct execution. This gives real end-to-end
+// confidence for the Windows path while running on the Linux CI runner.
+func TestScriptCommandWindowsRoundTrip(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available on PATH")
+	}
+	defer setWindows(true)()
+
+	dir := t.TempDir()
+	script := filepath.Join(dir, "filter")
+	// 0644: readable but NOT executable — can only run via `sh <script>`.
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho \"filtered-$1\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(script)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isExecutableFileInfo(info) {
+		t.Fatal("script should be considered executable under Windows rules")
+	}
+
+	out, err := scriptCommand(script, "1.2.3").Output()
+	if err != nil {
+		t.Fatalf("running non-executable script via sh failed: %v", err)
+	}
+	if got, want := string(out), "filtered-1.2.3\n"; got != want {
+		t.Errorf("script output = %q, want %q", got, want)
+	}
+
+	// Negative control: on the Unix path the same 0644 file cannot be executed
+	// directly, confirming the two branches genuinely differ in behavior.
+	restore := setWindows(false)
+	defer restore()
+	if _, err := scriptCommand(script, "1.2.3").Output(); err == nil {
+		t.Error("expected direct execution of a non-executable file to fail on Unix path")
+	}
+}

--- a/test/internal/hooks/filters_test.go
+++ b/test/internal/hooks/filters_test.go
@@ -3,6 +3,7 @@ package hooks_test
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -110,6 +111,9 @@ func TestVersionFilterNonExistentReturnsOriginal(t *testing.T) {
 
 // TestVersionFilterNonExecutableSkipped tests that non-executable filter is skipped.
 func TestVersionFilterNonExecutableSkipped(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not distinguish executable permissions via file mode bits")
+	}
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 
@@ -278,6 +282,9 @@ func TestTagMessageFilterNonExistentReturnsOriginal(t *testing.T) {
 
 // TestTagMessageFilterNonExecutableSkipped tests that non-executable filter is skipped.
 func TestTagMessageFilterNonExecutableSkipped(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not distinguish executable permissions via file mode bits")
+	}
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 

--- a/test/internal/hooks/hooks_test.go
+++ b/test/internal/hooks/hooks_test.go
@@ -3,6 +3,7 @@ package hooks_test
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -118,6 +119,9 @@ func TestPreHookNonExistent(t *testing.T) {
 
 // TestPreHookNonExecutable tests that non-executable pre-hook is skipped.
 func TestPreHookNonExecutable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not distinguish executable permissions via file mode bits")
+	}
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 


### PR DESCRIPTION
Fixes hooks and filters silently failing on Windows due to Unix-only executable permission checks.

The executable check (`info.Mode()&0111`) relies on Unix file mode bits that don't exist on NTFS, causing all hooks and filters to be skipped every time on Windows. The fix makes `isExecutable()` platform-aware: on Windows, any existing non-directory file is treated as executable, matching Git for Windows behavior. Unix behavior is unchanged.

Additionally, hook and filter scripts are now executed via `sh` on Windows (shipped with Git for Windows), since `exec.Command` cannot run shell scripts directly on Windows — the same approach Git itself uses.

Changes touch `internal/hooks/filters.go`, `internal/hooks/hooks.go`, tests, and `docs/gitflow-hooks.7.md`.

Closes #85

## Remarks

- The `isExecutable()` helper in `filters.go` is now shared by both hooks and filters
- Non-executable hook/filter tests are skipped on Windows since NTFS can't distinguish permission bits
- `scriptCommand()` helper wraps `exec.Command` to invoke scripts via `sh` on Windows
- Duplicate `os.Stat` call in `runHook` eliminated by splitting into `isExecutable` (path) and `isExecutableFileInfo` (FileInfo) variants
- Approach matches how Git for Windows itself handles hook executability and execution