### PR TITLE
Make test suite self-sufficient for CI

### DIFF
--- a/TESTING_GUIDELINES.md
+++ b/TESTING_GUIDELINES.md
@@ -465,6 +465,16 @@ For detailed examples of these anti-patterns and their solutions, see [GIT_TEST_
 
 ## Test Execution Methods
 
+### Test Binary
+
+The `test/cmd` integration tests execute the git-flow binary as a subprocess. `TestMain` (in `test/cmd/main_test.go`) builds a fresh binary into a temporary directory via `testutil.BuildGitFlow()` before any test runs, so `go test ./...` is self-sufficient — no manual build step is required, and tests can never silently run against a stale binary.
+
+To test a specific prebuilt binary instead (e.g. a release artifact), set the `GIT_FLOW_PATH` environment variable:
+
+```bash
+GIT_FLOW_PATH=/path/to/git-flow go test ./test/cmd/
+```
+
 ### CRITICAL: Use Test Helpers, Not Bash Piping
 
 **IMPORTANT**: When running git-flow commands that require interactive input, always use the `runGitFlowWithInput` helper function instead of bash piping.
@@ -501,9 +511,8 @@ output, err := runGitFlowWithInput(t, dir, input, "init")
 All test helper functions must set `cmd.Dir` to the test repository directory:
 
 ```go
-func runGitFlow(t *testing.T, dir string, args ...string) (string, error) {
-    gitFlowPath, _ := filepath.Abs(filepath.Join("..", "..", "git-flow"))
-    cmd := exec.Command(gitFlowPath, args...)
+func RunGitFlow(t *testing.T, dir string, args ...string) (string, error) {
+    cmd := exec.Command(gitFlowPath, args...)  // Binary built by TestMain
     cmd.Dir = dir  // CRITICAL: Always set working directory
     // ...
 }

--- a/test/cmd/finish_retention_test.go
+++ b/test/cmd/finish_retention_test.go
@@ -3,7 +3,6 @@ package cmd_test
 import (
 	"bytes"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -170,10 +169,7 @@ func TestFinishFeatureBranchKeepLocal(t *testing.T) {
 	}
 
 	// Get path to the git-flow binary
-	gitFlowPath, err := filepath.Abs(filepath.Join("..", "..", "git-flow"))
-	if err != nil {
-		t.Fatalf("Failed to get absolute path to git-flow: %v", err)
-	}
+	gitFlowPath := testutil.GitFlowPath()
 
 	// Finish the feature branch with keeplocal option
 	cmd := exec.Command(gitFlowPath, "feature", "finish", "keep-local-test", "--keeplocal")
@@ -270,10 +266,7 @@ func TestFinishFeatureBranchKeepRemote(t *testing.T) {
 	}
 
 	// Get path to the git-flow binary
-	gitFlowPath, err := filepath.Abs(filepath.Join("..", "..", "git-flow"))
-	if err != nil {
-		t.Fatalf("Failed to get absolute path to git-flow: %v", err)
-	}
+	gitFlowPath := testutil.GitFlowPath()
 
 	// Finish the feature branch with keepremote option
 	cmd := exec.Command(gitFlowPath, "feature", "finish", "keep-remote-test", "--keepremote")

--- a/test/cmd/finish_sync_test.go
+++ b/test/cmd/finish_sync_test.go
@@ -50,6 +50,7 @@ func TestFinishFeatureBranchBehindRemote(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to clone: %v", err)
 	}
+	testutil.ConfigureGitIdentity(t, secondDir)
 
 	_, err = testutil.RunGit(t, secondDir, "checkout", "feature/test-behind")
 	if err != nil {
@@ -221,6 +222,7 @@ func TestFinishFeatureBranchDivergedFromRemote(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to clone: %v", err)
 	}
+	testutil.ConfigureGitIdentity(t, secondDir)
 
 	_, err = testutil.RunGit(t, secondDir, "checkout", "feature/test-diverged")
 	if err != nil {
@@ -376,6 +378,7 @@ func TestFinishFeatureBranchForceBypassesRemoteCheck(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to clone: %v", err)
 	}
+	testutil.ConfigureGitIdentity(t, secondDir)
 
 	_, err = testutil.RunGit(t, secondDir, "checkout", "feature/test-force")
 	if err != nil {
@@ -509,6 +512,7 @@ func TestFinishContinueSkipsRemoteCheck(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to clone: %v", err)
 	}
+	testutil.ConfigureGitIdentity(t, secondDir)
 
 	_, err = testutil.RunGit(t, secondDir, "checkout", "feature/test-continue-remote")
 	if err != nil {
@@ -665,6 +669,7 @@ func TestFinishFetchFailsButSyncCheckStillRuns(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to clone: %v", err)
 	}
+	testutil.ConfigureGitIdentity(t, secondDir)
 
 	_, err = testutil.RunGit(t, secondDir, "checkout", "feature/test-fetch-fail")
 	if err != nil {

--- a/test/cmd/finish_tags_test.go
+++ b/test/cmd/finish_tags_test.go
@@ -46,11 +46,7 @@ func TestFinishFeatureWithTag(t *testing.T) {
 		t.Fatalf("Failed to commit file: %v", err)
 	}
 
-	// Get path to the git-flow binary
-	gitFlowPath, err := filepath.Abs(filepath.Join("..", "..", "git-flow"))
-	if err != nil {
-		t.Fatalf("Failed to get absolute path to git-flow: %v", err)
-	}
+	gitFlowPath := testutil.GitFlowPath()
 
 	// Run git-flow directly with exec.Command to get full control over arguments
 	cmd := exec.Command(gitFlowPath, "feature", "finish", "tagged-feature", "--tag")
@@ -111,11 +107,7 @@ func TestFinishReleaseWithCustomTag(t *testing.T) {
 		t.Fatalf("Failed to commit file: %v", err)
 	}
 
-	// Get path to the git-flow binary
-	gitFlowPath, err := filepath.Abs(filepath.Join("..", "..", "git-flow"))
-	if err != nil {
-		t.Fatalf("Failed to get absolute path to git-flow: %v", err)
-	}
+	gitFlowPath := testutil.GitFlowPath()
 
 	// Run git-flow directly
 	cmd := exec.Command(gitFlowPath, "release", "finish", "1.2.0", "--tagname", "v1.2.0-beta")
@@ -188,11 +180,7 @@ func TestFinishReleaseWithCustomMessage(t *testing.T) {
 	// Custom message for the tag
 	customMessage := "This is release 1.3.0"
 
-	// Get path to the git-flow binary
-	gitFlowPath, err := filepath.Abs(filepath.Join("..", "..", "git-flow"))
-	if err != nil {
-		t.Fatalf("Failed to get absolute path to git-flow: %v", err)
-	}
+	gitFlowPath := testutil.GitFlowPath()
 
 	// Run git-flow directly
 	cmd := exec.Command(gitFlowPath, "release", "finish", "1.3.0", "--message", customMessage)
@@ -253,11 +241,7 @@ func TestFinishReleaseWithNoTag(t *testing.T) {
 		t.Fatalf("Failed to commit file: %v", err)
 	}
 
-	// Get path to the git-flow binary
-	gitFlowPath, err := filepath.Abs(filepath.Join("..", "..", "git-flow"))
-	if err != nil {
-		t.Fatalf("Failed to get absolute path to git-flow: %v", err)
-	}
+	gitFlowPath := testutil.GitFlowPath()
 
 	// Run git-flow directly
 	cmd := exec.Command(gitFlowPath, "release", "finish", "1.4.0", "--notag")
@@ -333,11 +317,7 @@ func TestFinishReleaseWithMessageFile(t *testing.T) {
 		t.Fatalf("Failed to create tag message file: %v", err)
 	}
 
-	// Get path to the git-flow binary
-	gitFlowPath, err := filepath.Abs(filepath.Join("..", "..", "git-flow"))
-	if err != nil {
-		t.Fatalf("Failed to get absolute path to git-flow: %v", err)
-	}
+	gitFlowPath := testutil.GitFlowPath()
 
 	// Run git-flow directly
 	cmd := exec.Command(gitFlowPath, "release", "finish", "1.5.0", "--messagefile", tagMessageFilePath)
@@ -581,11 +561,7 @@ func TestFinishNotagFromCLI(t *testing.T) {
 		t.Fatalf("Failed to commit file: %v", err)
 	}
 
-	// Get path to the git-flow binary
-	gitFlowPath, err := filepath.Abs(filepath.Join("..", "..", "git-flow"))
-	if err != nil {
-		t.Fatalf("Failed to get absolute path to git-flow: %v", err)
-	}
+	gitFlowPath := testutil.GitFlowPath()
 
 	// Finish with --notag to override the config
 	cmd := exec.Command(gitFlowPath, "release", "finish", "2.1.0", "--notag")

--- a/test/cmd/init_test.go
+++ b/test/cmd/init_test.go
@@ -49,11 +49,7 @@ func setupGitFlowAVH(t *testing.T, dir string) {
 
 // runGitFlow runs the git-flow command with the given arguments
 func runGitFlow(t *testing.T, dir string, args ...string) (string, error) {
-	// Get path to the git-flow binary
-	gitFlowPath, err := filepath.Abs(filepath.Join("..", "..", "git-flow"))
-	if err != nil {
-		t.Fatalf("Failed to get absolute path to git-flow: %v", err)
-	}
+	gitFlowPath := testutil.GitFlowPath()
 
 	// Run the git-flow command
 	cmd := exec.Command(gitFlowPath, args...)
@@ -61,7 +57,7 @@ func runGitFlow(t *testing.T, dir string, args ...string) (string, error) {
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	err = cmd.Run()
+	err := cmd.Run()
 
 	// Return the combined output
 	return stdout.String() + stderr.String(), err
@@ -69,11 +65,7 @@ func runGitFlow(t *testing.T, dir string, args ...string) (string, error) {
 
 // runGitFlowWithInput runs the git-flow command with the given arguments and input
 func runGitFlowWithInput(t *testing.T, dir string, input string, args ...string) (string, error) {
-	// Get path to the git-flow binary
-	gitFlowPath, err := filepath.Abs(filepath.Join("..", "..", "git-flow"))
-	if err != nil {
-		t.Fatalf("Failed to get absolute path to git-flow: %v", err)
-	}
+	gitFlowPath := testutil.GitFlowPath()
 
 	// Run the git-flow command
 	cmd := exec.Command(gitFlowPath, args...)
@@ -147,17 +139,14 @@ func getGitConfigFromFile(t *testing.T, filePath string, key string) string {
 
 // runGitFlowWithEnv runs git-flow with custom environment variables.
 func runGitFlowWithEnv(t *testing.T, dir string, env []string, args ...string) (string, error) {
-	gitFlowPath, err := filepath.Abs(filepath.Join("..", "..", "git-flow"))
-	if err != nil {
-		t.Fatalf("Failed to get absolute path to git-flow: %v", err)
-	}
+	gitFlowPath := testutil.GitFlowPath()
 	cmd := exec.Command(gitFlowPath, args...)
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(), env...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	err = cmd.Run()
+	err := cmd.Run()
 	return stdout.String() + stderr.String(), err
 }
 

--- a/test/cmd/main_test.go
+++ b/test/cmd/main_test.go
@@ -1,0 +1,23 @@
+package cmd_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// TestMain builds the git-flow binary before running the command tests so
+// they never execute a stale or missing binary. Set GIT_FLOW_PATH to test a
+// specific prebuilt binary instead.
+func TestMain(m *testing.M) {
+	cleanup, err := testutil.BuildGitFlow()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to build git-flow binary: %v\n", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}

--- a/test/internal/git/repo_test.go
+++ b/test/internal/git/repo_test.go
@@ -445,6 +445,7 @@ func TestCompareBranchWithRemoteBehind(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to clone: %v", err)
 	}
+	testutil.ConfigureGitIdentity(t, secondDir)
 
 	_, err = testutil.RunGit(t, secondDir, "checkout", "feature/test")
 	if err != nil {
@@ -531,6 +532,7 @@ func TestCompareBranchWithRemoteDiverged(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to clone: %v", err)
 	}
+	testutil.ConfigureGitIdentity(t, secondDir)
 
 	_, err = testutil.RunGit(t, secondDir, "checkout", "feature/test")
 	if err != nil {
@@ -611,6 +613,7 @@ func TestFetchBranch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to clone: %v", err)
 	}
+	testutil.ConfigureGitIdentity(t, secondDir)
 
 	testutil.WriteFile(t, secondDir, "remote-change.txt", "remote content")
 	_, err = testutil.RunGit(t, secondDir, "add", "remote-change.txt")

--- a/test/testutil/git.go
+++ b/test/testutil/git.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -28,6 +29,46 @@ func init() {
 		wd = filepath.Join(wd, "..", "..")
 	}
 	gitFlowPath = filepath.Join(wd, "git-flow")
+}
+
+// BuildGitFlow compiles the git-flow binary into a temporary directory and
+// points RunGitFlow at it, so tests never execute a stale or missing binary.
+// If the GIT_FLOW_PATH environment variable is set, no build is performed and
+// that binary is used instead. The returned cleanup function removes the
+// temporary directory. Intended to be called from TestMain in packages that
+// execute the git-flow binary.
+func BuildGitFlow() (func(), error) {
+	if os.Getenv("GIT_FLOW_PATH") != "" {
+		return func() {}, nil
+	}
+
+	tmpDir, err := os.MkdirTemp("", "git-flow-test-bin-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temporary directory: %w", err)
+	}
+
+	binary := filepath.Join(tmpDir, "git-flow")
+	if runtime.GOOS == "windows" {
+		binary += ".exe"
+	}
+
+	// Build by module path so this works from any package directory
+	cmd := exec.Command("go", "build", "-o", binary, "github.com/gittower/git-flow-next")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		os.RemoveAll(tmpDir)
+		return nil, fmt.Errorf("failed to build git-flow: %w\nOutput: %s", err, output)
+	}
+
+	gitFlowPath = binary
+	return func() { os.RemoveAll(tmpDir) }, nil
+}
+
+// GitFlowPath returns the path of the git-flow binary under test. Use this
+// instead of resolving the binary path manually, so tests run the binary
+// built by TestMain (or the GIT_FLOW_PATH override).
+func GitFlowPath() string {
+	return gitFlowPath
 }
 
 // RunGit runs a git command in the specified directory and returns its output

--- a/test/testutil/git.go
+++ b/test/testutil/git.go
@@ -71,6 +71,22 @@ func GitFlowPath() string {
 	return gitFlowPath
 }
 
+// ConfigureGitIdentity sets the git user identity in a repository so commits
+// work on machines without a global git configuration (e.g. CI runners).
+// SetupTestRepo does this automatically; call this for repositories created
+// by other means, such as clones.
+func ConfigureGitIdentity(t *testing.T, dir string) {
+	t.Helper()
+	_, err := RunGit(t, dir, "config", "user.name", "Test User")
+	if err != nil {
+		t.Fatalf("Failed to configure Git user name: %v", err)
+	}
+	_, err = RunGit(t, dir, "config", "user.email", "test@example.com")
+	if err != nil {
+		t.Fatalf("Failed to configure Git user email: %v", err)
+	}
+}
+
 // RunGit runs a git command in the specified directory and returns its output
 func RunGit(t *testing.T, dir string, args ...string) (string, error) {
 	cmd := exec.Command("git", args...)


### PR DESCRIPTION
Makes the test suite self-sufficient so `go test ./...` passes locally and on CI without a manually prebuilt binary, fixing the failures present since the CI workflow was added.

The CI workflow has never had a green run, for two independent reasons. First, the `test/cmd` integration tests execute a prebuilt `git-flow` binary from the repository root that nothing built — CI failed every cmd test with `fork/exec: no such file or directory`, and local runs could silently test a stale binary. A new `TestMain` in `test/cmd` now compiles a fresh binary into a temporary directory via `testutil.BuildGitFlow()` before any test runs; `GIT_FLOW_PATH` skips the build to test a specific binary instead, and the eleven tests that resolved `../../git-flow` by hand now use the new `testutil.GitFlowPath()` accessor. Second, eight tests (the remote comparison and fetch tests from #106 plus the finish sync-check tests) clone a second working copy and commit in it without configuring a git identity, which fails on runners without a global git config ("empty ident name not allowed") — a new `testutil.ConfigureGitIdentity()` helper now applies the same identity `SetupTestRepo` uses after every clone. The new behavior is documented in `TESTING_GUIDELINES.md`.

## Remarks

- No workflow changes needed: `ci.yml` works as-is once the suite builds its own binary. The existing `go build ./...` step remains useful as a compile check.
- Verified by running the full suite with the repository-root binary removed (the CI condition) — all packages pass. The identity failure cannot be reproduced on macOS (git derives an ident from the OS user); CI is the verifier for that half.
- Building to a temporary directory rather than the repository root keeps the developer's manually built `./git-flow` untouched and works in parallel worktrees.

**Review focus:**
- `test/testutil/git.go` - `BuildGitFlow()` build-by-module-path approach and the `GIT_FLOW_PATH` escape hatch
- `test/cmd/init_test.go` - the local helpers previously declared `err` via the removed path resolution; declarations were adjusted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
