### PR TITLE
Match branch names case-insensitively in config handling

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -40,6 +40,8 @@ Branch type configuration defines the **identity and process characteristics** o
 
 These properties describe *what the branch type is* — its structural role and how it participates in the workflow. They should only contain essential branch-type-relevant configuration.
 
+Branch names (the `<branchname>` subsection) are matched **case-insensitively**, mirroring Git's `core.ignorecase`. The case used when a branch is first added is preserved as its canonical form and written back verbatim; git-flow always operates on that canonical name (including the Git ref, so it is correct on case-sensitive filesystems). Any later reference — a parent, a `--starting-point`, or the target of an `edit`/`rename`/`delete` — may be given in any case and resolves to the single canonical entry. Adding or renaming to a name that differs only in case from a *different* existing branch is rejected as "already exists"; a case-only rename of a branch to itself is allowed and re-canonicalizes it. Two branch types differing only in case cannot coexist, and dotted branch names (e.g., `V10.5`) are unsupported.
+
 ### Structural Properties
 
 Define where the branch type fits in the hierarchy:

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/gittower/git-flow-next/internal/config"
 	"github.com/gittower/git-flow-next/internal/errors"
@@ -388,16 +389,20 @@ func executeConfigAddBase(name, parent, upstreamStrategy, downstreamStrategy str
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
 
-	// Check if branch name already exists
-	if _, exists := cfg.Branches[name]; exists {
-		return &errors.BranchExistsError{BranchName: name}
+	// Check if branch name already exists (case-insensitively); report the
+	// existing canonical name on collision.
+	if canonical, exists := cfg.ResolveBranchName(name); exists {
+		return &errors.BranchExistsError{BranchName: canonical}
 	}
 
-	// Validate parent exists if specified
+	// Validate parent exists if specified, resolving it to its canonical name
+	// so config and git operations use the case-preserved identity.
 	if parent != "" {
-		if _, exists := cfg.Branches[parent]; !exists {
+		canonicalParent, exists := cfg.ResolveBranchName(parent)
+		if !exists {
 			return &errors.BranchNotFoundError{BranchName: parent}
 		}
+		parent = canonicalParent
 
 		// Check for circular dependencies
 		if err := validateNoCycle(cfg, name, parent); err != nil {
@@ -472,17 +477,19 @@ func executeConfigAddTopic(name, parent, prefix, startingPoint, upstreamStrategy
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
 
-	// Check if branch name already exists
-	if _, exists := cfg.Branches[name]; exists {
-		return &errors.BranchExistsError{BranchName: name}
+	// Check if branch name already exists (case-insensitively)
+	if canonical, exists := cfg.ResolveBranchName(name); exists {
+		return &errors.BranchExistsError{BranchName: canonical}
 	}
 
-	// Validate parent exists
-	if _, exists := cfg.Branches[parent]; !exists {
+	// Validate parent exists and resolve it to its canonical name
+	canonicalParent, exists := cfg.ResolveBranchName(parent)
+	if !exists {
 		return &errors.BranchNotFoundError{BranchName: parent}
 	}
+	parent = canonicalParent
 
-	// Set defaults
+	// Set defaults (start point defaults to the canonical parent)
 	if prefix == "" {
 		prefix = name + "/"
 	}
@@ -504,10 +511,12 @@ func executeConfigAddTopic(name, parent, prefix, startingPoint, upstreamStrategy
 		return &errors.InvalidMergeStrategyError{Strategy: downstreamStrategy}
 	}
 
-	// Validate starting point exists
-	if _, exists := cfg.Branches[startingPoint]; !exists {
+	// Validate starting point exists and resolve it to its canonical name
+	canonicalStartingPoint, exists := cfg.ResolveBranchName(startingPoint)
+	if !exists {
 		return &errors.BranchNotFoundError{BranchName: startingPoint}
 	}
+	startingPoint = canonicalStartingPoint
 
 	// Create branch configuration
 	branchConfig := config.BranchConfig{
@@ -548,11 +557,13 @@ func executeConfigEditBase(name, upstreamStrategy, downstreamStrategy string, au
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
 
-	// Check if branch exists
-	branchConfig, exists := cfg.Branches[name]
+	// Resolve the branch name case-insensitively to its canonical form
+	canonicalName, exists := cfg.ResolveBranchName(name)
 	if !exists {
 		return &errors.BranchNotFoundError{BranchName: name}
 	}
+	name = canonicalName
+	branchConfig := cfg.Branches[name]
 
 	// Check if it's a base branch
 	if branchConfig.Type != string(config.BranchTypeBase) {
@@ -605,11 +616,13 @@ func executeConfigEditTopic(name, prefix, startingPoint, upstreamStrategy, downs
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
 
-	// Check if branch exists
-	branchConfig, exists := cfg.Branches[name]
+	// Resolve the branch name case-insensitively to its canonical form
+	canonicalName, exists := cfg.ResolveBranchName(name)
 	if !exists {
 		return &errors.BranchNotFoundError{BranchName: name}
 	}
+	name = canonicalName
+	branchConfig := cfg.Branches[name]
 
 	// Check if it's a topic branch
 	if branchConfig.Type != string(config.BranchTypeTopic) {
@@ -622,10 +635,11 @@ func executeConfigEditTopic(name, prefix, startingPoint, upstreamStrategy, downs
 	}
 
 	if startingPoint != "" {
-		if _, exists := cfg.Branches[startingPoint]; !exists {
+		canonicalStartingPoint, exists := cfg.ResolveBranchName(startingPoint)
+		if !exists {
 			return &errors.BranchNotFoundError{BranchName: startingPoint}
 		}
-		branchConfig.StartPoint = startingPoint
+		branchConfig.StartPoint = canonicalStartingPoint
 	}
 
 	if upstreamStrategy != "" {
@@ -677,26 +691,39 @@ func executeConfigRenameBase(oldName, newName string) error {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
 
-	// Check if old branch exists
-	branchConfig, exists := cfg.Branches[oldName]
+	// Resolve the old branch name case-insensitively to its canonical form
+	canonicalOld, exists := cfg.ResolveBranchName(oldName)
 	if !exists {
 		return &errors.BranchNotFoundError{BranchName: oldName}
 	}
+	oldName = canonicalOld
+	branchConfig := cfg.Branches[oldName]
 
 	// Check if it's a base branch
 	if branchConfig.Type != string(config.BranchTypeBase) {
 		return &errors.InvalidBranchTypeError{BranchType: branchConfig.Type}
 	}
 
-	// Check if new name already exists
-	if _, exists := cfg.Branches[newName]; exists {
-		return &errors.BranchExistsError{BranchName: newName}
+	// Reject only when the new name collides case-insensitively with a
+	// different existing branch. A case-only self-rename (newName folds to
+	// oldName) is allowed and re-canonicalizes the stored key in place.
+	if canonical, exists := cfg.ResolveBranchName(newName); exists && canonical != oldName {
+		return &errors.BranchExistsError{BranchName: canonical}
 	}
 
-	// Rename Git branch if it exists
+	// Rename Git branch if it exists (using the resolved canonical old name).
+	// A case-only rename (same fold, different case) needs the force flag on
+	// case-insensitive filesystems, where the destination folds to the same
+	// existing ref; it is safe here because we already confirmed newName does
+	// not collide with a *different* branch.
 	if err := git.BranchExists(oldName); err == nil {
-		if err := git.RenameBranch(oldName, newName); err != nil {
-			return &errors.GitError{Operation: fmt.Sprintf("rename branch '%s' to '%s'", oldName, newName), Err: err}
+		caseOnlyRename := oldName != newName && strings.EqualFold(oldName, newName)
+		renameErr := git.RenameBranch(oldName, newName)
+		if renameErr != nil && caseOnlyRename {
+			renameErr = git.RenameBranchForce(oldName, newName)
+		}
+		if renameErr != nil {
+			return &errors.GitError{Operation: fmt.Sprintf("rename branch '%s' to '%s'", oldName, newName), Err: renameErr}
 		}
 		fmt.Printf("✓ Renamed Git branch: %s → %s\n", oldName, newName)
 	}
@@ -710,13 +737,13 @@ func executeConfigRenameBase(oldName, newName string) error {
 	delete(cfg.Branches, oldName)
 	cfg.Branches[newName] = branchConfig
 
-	// Update all references to the old name
+	// Update all references to the old name (case-insensitively)
 	for name, branch := range cfg.Branches {
-		if branch.Parent == oldName {
+		if strings.EqualFold(branch.Parent, oldName) {
 			branch.Parent = newName
 			cfg.Branches[name] = branch
 		}
-		if branch.StartPoint == oldName {
+		if strings.EqualFold(branch.StartPoint, oldName) {
 			branch.StartPoint = newName
 			cfg.Branches[name] = branch
 		}
@@ -752,20 +779,31 @@ func executeConfigRenameTopic(oldName, newName string) error {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
 
-	// Check if old branch exists
-	branchConfig, exists := cfg.Branches[oldName]
+	// Resolve the old branch name case-insensitively to its canonical form
+	canonicalOld, exists := cfg.ResolveBranchName(oldName)
 	if !exists {
 		return &errors.BranchNotFoundError{BranchName: oldName}
 	}
+	oldName = canonicalOld
+	branchConfig := cfg.Branches[oldName]
 
 	// Check if it's a topic branch
 	if branchConfig.Type != string(config.BranchTypeTopic) {
 		return &errors.InvalidBranchTypeError{BranchType: branchConfig.Type}
 	}
 
-	// Check if new name already exists
-	if _, exists := cfg.Branches[newName]; exists {
-		return &errors.BranchExistsError{BranchName: newName}
+	// Reject only when the new name collides case-insensitively with a
+	// different existing branch; a case-only self-rename is allowed and
+	// re-canonicalizes the stored key in place.
+	if canonical, exists := cfg.ResolveBranchName(newName); exists && canonical != oldName {
+		return &errors.BranchExistsError{BranchName: canonical}
+	}
+
+	// Remove the old branch config section from git config (topic renames
+	// only touch config, not refs), so the old canonical subsection does not
+	// linger after the save writes the new one.
+	if err := git.UnsetConfigSection(fmt.Sprintf("gitflow.branch.%s", oldName)); err != nil {
+		return &errors.GitError{Operation: fmt.Sprintf("remove old branch config for '%s'", oldName), Err: err}
 	}
 
 	// Update configuration
@@ -797,23 +835,25 @@ func executeConfigDeleteBase(name string) error {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
 
-	// Check if branch exists
-	branchConfig, exists := cfg.Branches[name]
+	// Resolve the branch name case-insensitively to its canonical form
+	canonicalName, exists := cfg.ResolveBranchName(name)
 	if !exists {
 		return &errors.BranchNotFoundError{BranchName: name}
 	}
+	name = canonicalName
+	branchConfig := cfg.Branches[name]
 
 	// Check if it's a base branch
 	if branchConfig.Type != string(config.BranchTypeBase) {
 		return &errors.InvalidBranchTypeError{BranchType: branchConfig.Type}
 	}
 
-	// Check if other branches depend on this branch
+	// Check if other branches depend on this branch (case-insensitively)
 	for branchName, branch := range cfg.Branches {
-		if branch.Parent == name {
+		if strings.EqualFold(branch.Parent, name) {
 			return &errors.BranchHasDependentsError{BranchName: name, Dependent: branchName}
 		}
-		if branch.StartPoint == name {
+		if strings.EqualFold(branch.StartPoint, name) {
 			return &errors.BranchHasDependentsError{BranchName: name, Dependent: branchName}
 		}
 	}
@@ -852,11 +892,13 @@ func executeConfigDeleteTopic(name string) error {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
 
-	// Check if branch exists
-	branchConfig, exists := cfg.Branches[name]
+	// Resolve the branch name case-insensitively to its canonical form
+	canonicalName, exists := cfg.ResolveBranchName(name)
 	if !exists {
 		return &errors.BranchNotFoundError{BranchName: name}
 	}
+	name = canonicalName
+	branchConfig := cfg.Branches[name]
 
 	// Check if it's a topic branch
 	if branchConfig.Type != string(config.BranchTypeTopic) {

--- a/docs/git-flow-config.1.md
+++ b/docs/git-flow-config.1.md
@@ -16,6 +16,8 @@ Manage git-flow configuration for base branches and topic branch types. The **co
 
 **Topic branches** are short-living branches like feature, release, hotfix that represent units of work.
 
+Branch names are matched **case-insensitively**. The case used when a branch is first added is preserved as canonical, and any *name*, *parent*, *old-name*, or **--starting-point** argument may be given in any case to refer to it. See **gitflow-config**(5) for details and limitations.
+
 ## COMMANDS
 
 ### Listing Configuration

--- a/docs/gitflow-config.5.md
+++ b/docs/gitflow-config.5.md
@@ -120,6 +120,27 @@ Branch configuration uses the pattern: **gitflow.branch.*name*.*property***
 
 These properties define the branch type's identity and process characteristics (Layer 1). They describe *what the branch type is*, not how individual commands behave.
 
+### Branch Name Case Sensitivity
+
+Branch identities (the *name* subsection of **gitflow.branch.*name***) are matched **case-insensitively**, following the same principle as Git's own **core.ignorecase**. The original case you use when a branch is first added is preserved as its **canonical** form and written back verbatim; git-flow always operates on that canonical name — including the underlying Git ref — so operations behave correctly on case-sensitive filesystems.
+
+Any later reference to that branch may be given in any case. For example, after `git flow config add base V9_Release`, all of the following resolve to the single canonical `V9_Release` entry:
+
+```
+git flow config add base V10_Release v9_release   # parent given in lowercase
+git flow config edit base v9_RELEASE --upstream-strategy rebase
+git flow config delete base V9_release
+```
+
+Adding or renaming to a name that differs only in case from a *different* existing branch is rejected as an "already exists" condition, naming the existing canonical form. Renaming a branch to a case-only variant of *itself* (e.g., `V9_Release` → `v9_release`) is allowed and re-canonicalizes the entry in place.
+
+Property names (the last segment, e.g., **upstreamStrategy**) are case-insensitive in Git config and are always read regardless of the case they were stored in.
+
+**Limitations**:
+
+- Two branch types whose names differ only in case cannot coexist as distinct entities — they are treated as one branch identity.
+- Branch names containing dots (`.`) in the subsection (e.g., `V10.5`) are not supported, because Git splits the subsection on the dot.
+
 ### Structural Properties
 
 Define where the branch type fits in the hierarchy:

--- a/docs/gitflow-config.5.md
+++ b/docs/gitflow-config.5.md
@@ -122,7 +122,7 @@ These properties define the branch type's identity and process characteristics (
 
 ### Branch Name Case Sensitivity
 
-Branch identities (the *name* subsection of **gitflow.branch.*name***) are matched **case-insensitively**, following the same principle as Git's own **core.ignorecase**. The original case you use when a branch is first added is preserved as its **canonical** form and written back verbatim; git-flow always operates on that canonical name — including the underlying Git ref — so operations behave correctly on case-sensitive filesystems.
+Branch identities (the *name* subsection of `gitflow.branch.<name>`) are matched **case-insensitively**, following the same principle as Git's own **core.ignorecase**. The original case you use when a branch is first added is preserved as its **canonical** form and written back verbatim; git-flow always operates on that canonical name — including the underlying Git ref — so operations behave correctly on case-sensitive filesystems.
 
 Any later reference to that branch may be given in any case. For example, after `git flow config add base V9_Release`, all of the following resolve to the single canonical `V9_Release` entry:
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,23 @@ type BranchConfig struct {
 	TagPrefix          string // prefix to use for tag names
 }
 
+// ResolveBranchName resolves a branch reference to its canonical (stored) name
+// by matching case-insensitively against the configured branch identities.
+// It returns the canonical name and true on a match, or ("", false) if no
+// configured branch folds to name. An exact-case match is preferred; otherwise
+// the first case-insensitive match is returned.
+func (c *Config) ResolveBranchName(name string) (canonical string, found bool) {
+	if _, ok := c.Branches[name]; ok {
+		return name, true
+	}
+	for branchName := range c.Branches {
+		if strings.EqualFold(branchName, name) {
+			return branchName, true
+		}
+	}
+	return "", false
+}
+
 // MergeStrategy represents the strategy for merging branches
 type MergeStrategy string
 
@@ -210,8 +227,19 @@ func LoadConfig() (*Config, error) {
 	cmd.Dir = currentDir
 	output, err := cmd.Output()
 
-	// Process branch configurations from command output
+	// Process branch configurations from command output.
+	//
+	// Branch subsection names (gitflow.branch.<name>) are treated
+	// case-insensitively for identity but their original case is preserved
+	// as canonical (mirrors core.ignorecase semantics). The first-seen
+	// casing of a branch name wins as the canonical key; later properties of
+	// the same branch fold into that entry. Property names (the last segment)
+	// are legitimately case-insensitive in git config and are lowercased so
+	// the BranchConfig field lookups below match regardless of stored case.
 	branchMap := make(map[string]map[string]string)
+	// canonicalNames maps a lowercased fold key to the canonical (first-seen)
+	// branch name used as the branchMap key.
+	canonicalNames := make(map[string]string)
 
 	if err == nil {
 		lines := strings.Split(string(output), "\n")
@@ -234,7 +262,16 @@ func LoadConfig() (*Config, error) {
 				continue
 			}
 
-			branchName := strings.ToLower(keyParts[2])
+			// Preserve the original branch-name case as canonical, folding
+			// case-insensitively so all properties of the same branch land in
+			// one entry keyed by the first-seen case.
+			rawBranchName := keyParts[2]
+			foldKey := strings.ToLower(rawBranchName)
+			branchName, ok := canonicalNames[foldKey]
+			if !ok {
+				branchName = rawBranchName
+				canonicalNames[foldKey] = branchName
+			}
 			property := strings.ToLower(keyParts[3])
 
 			// Initialize branch map if needed

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -343,7 +343,24 @@ func RebaseAbort() error {
 // RenameBranch renames a branch. If oldBranch is provided, it renames that branch to newBranch.
 // If oldBranch is not provided, it renames the current branch to newBranch.
 func RenameBranch(oldBranch, newBranch string) error {
-	args := []string{"branch", "-m", oldBranch, newBranch}
+	return renameBranch(oldBranch, newBranch, false)
+}
+
+// RenameBranchForce renames a Git branch using the force flag (-M). This is
+// required for a case-only rename on case-insensitive filesystems, where the
+// destination name folds to the same existing ref and the non-forcing -m
+// refuses with "a branch named '…' already exists". Callers must confirm the
+// rename does not clobber a genuinely different branch before forcing.
+func RenameBranchForce(oldBranch, newBranch string) error {
+	return renameBranch(oldBranch, newBranch, true)
+}
+
+func renameBranch(oldBranch, newBranch string, force bool) error {
+	flag := "-m"
+	if force {
+		flag = "-M"
+	}
+	args := []string{"branch", flag, oldBranch, newBranch}
 
 	cmd := exec.Command("git", args...)
 	output, err := cmd.CombinedOutput()

--- a/test/cmd/config_test.go
+++ b/test/cmd/config_test.go
@@ -2,6 +2,7 @@ package cmd_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/gittower/git-flow-next/internal/config"
@@ -619,4 +620,808 @@ func captureConfigDeleteTopic(t *testing.T, dir string, name string) error {
 	// Run the command
 	_, err := testutil.RunGitFlow(t, dir, args...)
 	return err
+}
+
+// gitflowBranchConfig returns the output of
+// `git config --get-regexp '^gitflow\.branch\.'` for the test repo. On no
+// matches git exits non-zero and returns an empty string; the tests treat an
+// empty result as "no branch config lines" rather than a fatal error.
+func gitflowBranchConfig(t *testing.T, dir string) string {
+	output, _ := testutil.RunGit(t, dir, "config", "--get-regexp", "^gitflow\\.branch\\.")
+	return output
+}
+
+// refExists reports whether refs/heads/<branch> resolves in the test repo.
+func refExists(t *testing.T, dir string, branch string) bool {
+	_, err := testutil.RunGit(t, dir, "rev-parse", "--verify", "refs/heads/"+branch)
+	return err == nil
+}
+
+// assertContainsLine fails if none of the lines in output contains substr.
+func assertContainsLine(t *testing.T, output, substr, context string) {
+	t.Helper()
+	if !strings.Contains(output, substr) {
+		t.Errorf("%s: expected config to contain %q, got:\n%s", context, substr, output)
+	}
+}
+
+// assertNoLineContains fails if any line in output contains substr.
+func assertNoLineContains(t *testing.T, output, substr, context string) {
+	t.Helper()
+	if strings.Contains(output, substr) {
+		t.Errorf("%s: expected config to NOT contain %q, got:\n%s", context, substr, output)
+	}
+}
+
+// TestConfigAddBaseUppercaseName tests adding a base branch with an uppercase name.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Runs 'config add base V9_Release'
+// 3. Verifies gitflow.branch.V9_Release.type base is written (exact case)
+// 4. Verifies no lowercase gitflow.branch.v9_release.* variant section exists
+// 5. Verifies refs/heads/V9_Release was created
+func TestConfigAddBaseUppercaseName(t *testing.T) {
+	tempDir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "V9_Release"); err != nil {
+		t.Fatalf("Failed to add base branch V9_Release: %v", err)
+	}
+
+	cfg := gitflowBranchConfig(t, tempDir)
+	assertContainsLine(t, cfg, "gitflow.branch.V9_Release.type base", "add base uppercase")
+	assertNoLineContains(t, cfg, "gitflow.branch.v9_release.", "add base uppercase")
+	if !refExists(t, tempDir, "V9_Release") {
+		t.Errorf("Expected refs/heads/V9_Release to exist")
+	}
+}
+
+// TestConfigAddBaseExactCaseParent tests adding a base branch referencing an
+// existing uppercase parent by its exact case (the core #122 regression).
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Adds base branch V9_Release
+// 3. Runs 'config add base V10_Release V9_Release'
+// 4. Verifies success (no "does not exist" error) and the stored parent is V9_Release
+// 5. Verifies refs/heads/V10_Release was created
+func TestConfigAddBaseExactCaseParent(t *testing.T) {
+	tempDir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+	if _, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "V9_Release"); err != nil {
+		t.Fatalf("Failed to add base branch V9_Release: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "V10_Release", "V9_Release")
+	if err != nil {
+		t.Fatalf("Expected exact-case parent reference to succeed, got error: %v\nOutput: %s", err, output)
+	}
+
+	cfg := gitflowBranchConfig(t, tempDir)
+	assertContainsLine(t, cfg, "gitflow.branch.V10_Release.parent V9_Release", "exact-case parent")
+	if !refExists(t, tempDir, "V10_Release") {
+		t.Errorf("Expected refs/heads/V10_Release to exist")
+	}
+}
+
+// TestConfigAddBaseDifferentCaseParentUsesCanonicalRef tests that a different-case
+// parent reference resolves to the canonical name and the git op uses the
+// canonical ref (guards case-sensitive filesystems / Linux CI).
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Adds base branch V9_Release
+// 3. Runs 'config add base V11_Release v9_release' (lowercase parent)
+// 4. Verifies stored parent is canonical V9_Release, no v9_release section
+// 5. Verifies refs/heads/V11_Release was created (from the canonical ref)
+func TestConfigAddBaseDifferentCaseParentUsesCanonicalRef(t *testing.T) {
+	tempDir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+	if _, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "V9_Release"); err != nil {
+		t.Fatalf("Failed to add base branch V9_Release: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "V11_Release", "v9_release")
+	if err != nil {
+		t.Fatalf("Expected different-case parent reference to succeed, got error: %v\nOutput: %s", err, output)
+	}
+
+	cfg := gitflowBranchConfig(t, tempDir)
+	assertContainsLine(t, cfg, "gitflow.branch.V11_Release.parent V9_Release", "different-case parent")
+	assertNoLineContains(t, cfg, "gitflow.branch.v9_release.", "different-case parent")
+	if !refExists(t, tempDir, "V11_Release") {
+		t.Errorf("Expected refs/heads/V11_Release to exist (created from canonical ref)")
+	}
+}
+
+// TestConfigAddBaseMixedCaseParentResolves tests arbitrary mixed casing on a
+// parent reference resolves to the canonical name.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Adds base branch V9_Release
+// 3. Runs 'config add base V12_Release v9_RELEASE'
+// 4. Verifies stored parent is canonical V9_Release, no case-variant section
+func TestConfigAddBaseMixedCaseParentResolves(t *testing.T) {
+	tempDir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+	if _, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "V9_Release"); err != nil {
+		t.Fatalf("Failed to add base branch V9_Release: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "V12_Release", "v9_RELEASE")
+	if err != nil {
+		t.Fatalf("Expected mixed-case parent reference to succeed, got error: %v\nOutput: %s", err, output)
+	}
+
+	cfg := gitflowBranchConfig(t, tempDir)
+	assertContainsLine(t, cfg, "gitflow.branch.V12_Release.parent V9_Release", "mixed-case parent")
+	assertNoLineContains(t, cfg, "gitflow.branch.v9_release.", "mixed-case parent")
+	assertNoLineContains(t, cfg, "gitflow.branch.v9_RELEASE.", "mixed-case parent")
+}
+
+// TestConfigAddTopicStartingPointResolvesCaseInsensitively tests that a topic
+// --starting-point resolves case-insensitively to the canonical name.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Adds base branch V9_Release
+// 3. Runs 'config add topic candidate develop --starting-point v9_release'
+// 4. Verifies the stored start point is canonical V9_Release, no v9_release section
+func TestConfigAddTopicStartingPointResolvesCaseInsensitively(t *testing.T) {
+	tempDir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+	if _, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "V9_Release"); err != nil {
+		t.Fatalf("Failed to add base branch V9_Release: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, tempDir, "config", "add", "topic", "candidate", "develop", "--starting-point", "v9_release")
+	if err != nil {
+		t.Fatalf("Expected topic add with case-insensitive starting point to succeed, got error: %v\nOutput: %s", err, output)
+	}
+
+	cfg := gitflowBranchConfig(t, tempDir)
+	assertContainsLine(t, cfg, "gitflow.branch.candidate.startpoint V9_Release", "topic starting point")
+	assertNoLineContains(t, cfg, "gitflow.branch.v9_release.", "topic starting point")
+}
+
+// TestConfigAddTopicParentResolvesCaseInsensitively tests that a topic parent
+// resolves case-insensitively and the defaulted start point also reads canonical.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Adds base branch V9_Release
+// 3. Runs 'config add topic hotpatch v9_release --prefix hp/'
+// 4. Verifies parent is canonical V9_Release
+// 5. Verifies defaulted start point (== parent) is also canonical V9_Release
+// 6. Verifies no v9_release case-variant section exists
+func TestConfigAddTopicParentResolvesCaseInsensitively(t *testing.T) {
+	tempDir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+	if _, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "V9_Release"); err != nil {
+		t.Fatalf("Failed to add base branch V9_Release: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, tempDir, "config", "add", "topic", "hotpatch", "v9_release", "--prefix", "hp/")
+	if err != nil {
+		t.Fatalf("Expected topic add with case-insensitive parent to succeed, got error: %v\nOutput: %s", err, output)
+	}
+
+	cfg := gitflowBranchConfig(t, tempDir)
+	assertContainsLine(t, cfg, "gitflow.branch.hotpatch.parent V9_Release", "topic parent")
+	assertContainsLine(t, cfg, "gitflow.branch.hotpatch.startpoint V9_Release", "topic defaulted start point")
+	assertNoLineContains(t, cfg, "gitflow.branch.v9_release.", "topic parent")
+}
+
+// TestConfigAddTopicCaseOnlyReAddRejected tests that re-adding a topic whose name
+// differs only in case from an existing one is rejected.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Adds topic QA_Feature (prefix qa/)
+// 3. Runs 'config add topic qa_feature develop --prefix qa2/'
+// 4. Verifies the command fails with an "already exists" error naming QA_Feature
+// 5. Verifies no qa_feature section written and original QA_Feature prefix unchanged
+func TestConfigAddTopicCaseOnlyReAddRejected(t *testing.T) {
+	tempDir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+	if _, err := testutil.RunGitFlow(t, tempDir, "config", "add", "topic", "QA_Feature", "develop", "--prefix", "qa/"); err != nil {
+		t.Fatalf("Failed to add topic QA_Feature: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, tempDir, "config", "add", "topic", "qa_feature", "develop", "--prefix", "qa2/")
+	if err == nil {
+		t.Fatalf("Expected case-only re-add to fail, got success\nOutput: %s", output)
+	}
+	if !strings.Contains(output, "QA_Feature") {
+		t.Errorf("Expected error to name existing canonical 'QA_Feature', got:\n%s", output)
+	}
+
+	cfg := gitflowBranchConfig(t, tempDir)
+	assertNoLineContains(t, cfg, "gitflow.branch.qa_feature.", "case-only re-add rejected")
+	assertContainsLine(t, cfg, "gitflow.branch.QA_Feature.prefix qa/", "case-only re-add rejected (original unchanged)")
+}
+
+// TestConfigAddBaseCaseOnlyVariantRejected tests that adding a case-only variant
+// of an existing base name is rejected without mutating the existing entry.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Adds base branch V9_Release
+// 3. Runs 'config add base v9_release main'
+// 4. Verifies the command fails with an "already exists" error naming V9_Release
+// 5. Verifies no v9_release section and V9_Release still type base with no main parent
+func TestConfigAddBaseCaseOnlyVariantRejected(t *testing.T) {
+	tempDir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+	if _, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "V9_Release"); err != nil {
+		t.Fatalf("Failed to add base branch V9_Release: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "v9_release", "main")
+	if err == nil {
+		t.Fatalf("Expected case-only variant add to fail, got success\nOutput: %s", output)
+	}
+	if !strings.Contains(output, "V9_Release") {
+		t.Errorf("Expected error to name existing canonical 'V9_Release', got:\n%s", output)
+	}
+
+	cfg := gitflowBranchConfig(t, tempDir)
+	assertNoLineContains(t, cfg, "gitflow.branch.v9_release.", "case-only variant rejected")
+	assertContainsLine(t, cfg, "gitflow.branch.V9_Release.type base", "case-only variant rejected (existing intact)")
+	assertNoLineContains(t, cfg, "gitflow.branch.V9_Release.parent main", "case-only variant rejected (no partial mutation)")
+}
+
+// TestConfigEditBaseResolvesCaseInsensitively tests that editing a base branch
+// resolves the name case-insensitively to the canonical section.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Adds base branch V9_Release
+// 3. Runs 'config edit base v9_release --upstream-strategy rebase'
+// 4. Verifies gitflow.branch.V9_Release.upstreamStrategy reads rebase
+// 5. Verifies no v9_release duplicate section
+func TestConfigEditBaseResolvesCaseInsensitively(t *testing.T) {
+	tempDir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+	if _, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "V9_Release"); err != nil {
+		t.Fatalf("Failed to add base branch V9_Release: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, tempDir, "config", "edit", "base", "v9_release", "--upstream-strategy", "rebase")
+	if err != nil {
+		t.Fatalf("Expected case-insensitive edit to succeed, got error: %v\nOutput: %s", err, output)
+	}
+
+	cfg := gitflowBranchConfig(t, tempDir)
+	assertContainsLine(t, cfg, "gitflow.branch.V9_Release.upstreamstrategy rebase", "edit base case-insensitive")
+	assertNoLineContains(t, cfg, "gitflow.branch.v9_release.", "edit base case-insensitive")
+}
+
+// TestConfigEditTopicResolvesCaseInsensitively tests that editing a topic type
+// resolves the name case-insensitively.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Adds topic QA_Feature (prefix qa/)
+// 3. Runs 'config edit topic qa_feature --upstream-strategy rebase'
+// 4. Verifies gitflow.branch.QA_Feature.upstreamStrategy reads rebase
+// 5. Verifies no qa_feature case-variant section
+func TestConfigEditTopicResolvesCaseInsensitively(t *testing.T) {
+	tempDir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+	if _, err := testutil.RunGitFlow(t, tempDir, "config", "add", "topic", "QA_Feature", "develop", "--prefix", "qa/"); err != nil {
+		t.Fatalf("Failed to add topic QA_Feature: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, tempDir, "config", "edit", "topic", "qa_feature", "--upstream-strategy", "rebase")
+	if err != nil {
+		t.Fatalf("Expected case-insensitive topic edit to succeed, got error: %v\nOutput: %s", err, output)
+	}
+
+	cfg := gitflowBranchConfig(t, tempDir)
+	assertContainsLine(t, cfg, "gitflow.branch.QA_Feature.upstreamstrategy rebase", "edit topic case-insensitive")
+	assertNoLineContains(t, cfg, "gitflow.branch.qa_feature.", "edit topic case-insensitive")
+}
+
+// TestConfigDeleteBaseResolvesCaseInsensitively tests deleting a base branch by a
+// case-variant name removes the canonical section.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Adds base branch V9_Release
+// 3. Runs 'config delete base v9_release'
+// 4. Verifies the V9_Release section is fully removed (no V9_Release or v9_release lines)
+func TestConfigDeleteBaseResolvesCaseInsensitively(t *testing.T) {
+	tempDir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+	if _, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "V9_Release"); err != nil {
+		t.Fatalf("Failed to add base branch V9_Release: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, tempDir, "config", "delete", "base", "v9_release")
+	if err != nil {
+		t.Fatalf("Expected case-insensitive delete to succeed, got error: %v\nOutput: %s", err, output)
+	}
+
+	cfg := gitflowBranchConfig(t, tempDir)
+	assertNoLineContains(t, cfg, "gitflow.branch.V9_Release.", "delete base case-insensitive")
+	assertNoLineContains(t, cfg, "gitflow.branch.v9_release.", "delete base case-insensitive")
+}
+
+// TestConfigRenameBaseResolvesAndUpdatesChildren tests renaming a base branch by a
+// case-variant name resolves to canonical, updates children, and renames the ref.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Adds base V9_Release and base V10_Release with parent V9_Release
+// 3. Runs 'config rename base v9_release V9_Stable'
+// 4. Verifies V9_Release section removed, V9_Stable section present
+// 5. Verifies V10_Release.parent now reads V9_Stable
+// 6. Verifies refs/heads/V9_Stable exists and refs/heads/V9_Release does not
+func TestConfigRenameBaseResolvesAndUpdatesChildren(t *testing.T) {
+	tempDir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+	if _, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "V9_Release"); err != nil {
+		t.Fatalf("Failed to add base branch V9_Release: %v", err)
+	}
+	if _, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "V10_Release", "V9_Release"); err != nil {
+		t.Fatalf("Failed to add base branch V10_Release: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, tempDir, "config", "rename", "base", "v9_release", "V9_Stable")
+	if err != nil {
+		t.Fatalf("Expected case-insensitive rename to succeed, got error: %v\nOutput: %s", err, output)
+	}
+
+	cfg := gitflowBranchConfig(t, tempDir)
+	assertNoLineContains(t, cfg, "gitflow.branch.V9_Release.", "rename base resolves")
+	assertContainsLine(t, cfg, "gitflow.branch.V9_Stable.type base", "rename base resolves")
+	assertContainsLine(t, cfg, "gitflow.branch.V10_Release.parent V9_Stable", "rename base updates children")
+	if !refExists(t, tempDir, "V9_Stable") {
+		t.Errorf("Expected refs/heads/V9_Stable to exist after rename")
+	}
+	if refExists(t, tempDir, "V9_Release") {
+		t.Errorf("Expected refs/heads/V9_Release to be gone after rename")
+	}
+}
+
+// TestConfigRenameBaseCaseCollisionRejected tests renaming a base to a case-variant
+// of a *different* existing branch is rejected without touching config or refs.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Adds base V9_Release and base Preprod
+// 3. Runs 'config rename base Preprod v9_release'
+// 4. Verifies the command fails with an "already exists" error naming V9_Release
+// 5. Verifies both original sections and both refs are unchanged, no v9_release section
+func TestConfigRenameBaseCaseCollisionRejected(t *testing.T) {
+	tempDir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+	if _, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "V9_Release"); err != nil {
+		t.Fatalf("Failed to add base branch V9_Release: %v", err)
+	}
+	if _, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "Preprod"); err != nil {
+		t.Fatalf("Failed to add base branch Preprod: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, tempDir, "config", "rename", "base", "Preprod", "v9_release")
+	if err == nil {
+		t.Fatalf("Expected case-collision rename to fail, got success\nOutput: %s", output)
+	}
+	if !strings.Contains(output, "V9_Release") {
+		t.Errorf("Expected error to name existing canonical 'V9_Release', got:\n%s", output)
+	}
+
+	cfg := gitflowBranchConfig(t, tempDir)
+	assertContainsLine(t, cfg, "gitflow.branch.V9_Release.type base", "rename collision rejected (V9 intact)")
+	assertContainsLine(t, cfg, "gitflow.branch.Preprod.type base", "rename collision rejected (Preprod intact)")
+	assertNoLineContains(t, cfg, "gitflow.branch.v9_release.", "rename collision rejected (no variant)")
+	if !refExists(t, tempDir, "V9_Release") {
+		t.Errorf("Expected refs/heads/V9_Release to still exist")
+	}
+	if !refExists(t, tempDir, "Preprod") {
+		t.Errorf("Expected refs/heads/Preprod to still exist")
+	}
+}
+
+// TestConfigRenameBaseCaseOnlySelfRename tests a case-only self-rename
+// re-canonicalizes the entry in place.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Adds base V9_Release
+// 3. Runs 'config rename base V9_Release v9_release'
+// 4. Verifies exactly one section, now v9_release, and no V9_Release section
+func TestConfigRenameBaseCaseOnlySelfRename(t *testing.T) {
+	tempDir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+	if _, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "V9_Release"); err != nil {
+		t.Fatalf("Failed to add base branch V9_Release: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, tempDir, "config", "rename", "base", "V9_Release", "v9_release")
+	if err != nil {
+		t.Fatalf("Expected case-only self-rename to succeed, got error: %v\nOutput: %s", err, output)
+	}
+
+	cfg := gitflowBranchConfig(t, tempDir)
+	assertContainsLine(t, cfg, "gitflow.branch.v9_release.type base", "case-only self-rename")
+	assertNoLineContains(t, cfg, "gitflow.branch.V9_Release.", "case-only self-rename")
+}
+
+// TestConfigAddBaseAbsentParentErrors tests a genuinely-absent reference still errors
+// without mutating the unrelated existing entry.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Adds base V9_Release
+// 3. Runs 'config add base X NoSuchBranch'
+// 4. Verifies the command fails with a "does not exist" error for NoSuchBranch
+// 5. Verifies no X section and existing V9_Release section intact
+func TestConfigAddBaseAbsentParentErrors(t *testing.T) {
+	tempDir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+	if _, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "V9_Release"); err != nil {
+		t.Fatalf("Failed to add base branch V9_Release: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "X", "NoSuchBranch")
+	if err == nil {
+		t.Fatalf("Expected absent-parent add to fail, got success\nOutput: %s", output)
+	}
+	if !strings.Contains(output, "NoSuchBranch") {
+		t.Errorf("Expected error to name missing 'NoSuchBranch', got:\n%s", output)
+	}
+
+	cfg := gitflowBranchConfig(t, tempDir)
+	assertNoLineContains(t, cfg, "gitflow.branch.X.", "absent parent errors (no X section)")
+	assertContainsLine(t, cfg, "gitflow.branch.V9_Release.type base", "absent parent errors (V9 intact)")
+}
+
+// TestConfigNoDuplicateFromReloadRoundTrip tests that a load+save round trip does
+// not produce the #117 duplicate lowercase section.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Adds base V9_Release
+// 3. Runs 'config add base V10_Release v9_release' (triggers load+save)
+// 4. Verifies success and V10_Release created with canonical parent V9_Release
+// 5. Verifies exactly one V9 section and no duplicate v9_release section
+func TestConfigNoDuplicateFromReloadRoundTrip(t *testing.T) {
+	tempDir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+	if _, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "V9_Release"); err != nil {
+		t.Fatalf("Failed to add base branch V9_Release: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "V10_Release", "v9_release")
+	if err != nil {
+		t.Fatalf("Expected reload round-trip add to succeed, got error: %v\nOutput: %s", err, output)
+	}
+
+	cfg := gitflowBranchConfig(t, tempDir)
+	assertContainsLine(t, cfg, "gitflow.branch.V10_Release.parent V9_Release", "reload round-trip")
+	if !refExists(t, tempDir, "V10_Release") {
+		t.Errorf("Expected refs/heads/V10_Release to exist")
+	}
+	assertContainsLine(t, cfg, "gitflow.branch.V9_Release.type base", "reload round-trip (V9 present)")
+	assertNoLineContains(t, cfg, "gitflow.branch.v9_release.", "reload round-trip (#117 no duplicate)")
+}
+
+// TestConfigListShowsCanonicalCase tests that list shows canonical case and
+// renders relationships in canonical case.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Adds base V9_Release and base V10_Release with parent V9_Release
+// 3. Runs 'config list'
+// 4. Verifies output lists both names in original case
+// 5. Verifies V10's relationship renders as 'V10_Release → V9_Release'
+func TestConfigListShowsCanonicalCase(t *testing.T) {
+	tempDir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+	if _, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "V9_Release"); err != nil {
+		t.Fatalf("Failed to add base branch V9_Release: %v", err)
+	}
+	if _, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "V10_Release", "V9_Release"); err != nil {
+		t.Fatalf("Failed to add base branch V10_Release: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, tempDir, "config", "list")
+	if err != nil {
+		t.Fatalf("Expected config list to succeed, got error: %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(output, "V9_Release") {
+		t.Errorf("Expected list output to contain 'V9_Release', got:\n%s", output)
+	}
+	if !strings.Contains(output, "V10_Release → V9_Release") {
+		t.Errorf("Expected list output to render 'V10_Release → V9_Release', got:\n%s", output)
+	}
+}
+
+// TestConfigLowercaseNamesNoRegression tests that all-lowercase names still work
+// end-to-end (add, edit, delete).
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Runs 'config add base staging main'
+// 3. Runs 'config edit base staging --upstream-strategy rebase'
+// 4. Runs 'config delete base staging'
+// 5. Verifies each step succeeds; edit sets rebase; delete removes the section
+func TestConfigLowercaseNamesNoRegression(t *testing.T) {
+	tempDir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "staging", "main"); err != nil {
+		t.Fatalf("Expected add base staging to succeed, got error: %v", err)
+	}
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "config", "edit", "base", "staging", "--upstream-strategy", "rebase"); err != nil {
+		t.Fatalf("Expected edit base staging to succeed, got error: %v", err)
+	}
+	cfg := gitflowBranchConfig(t, tempDir)
+	assertContainsLine(t, cfg, "gitflow.branch.staging.upstreamstrategy rebase", "lowercase no regression (edit)")
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "config", "delete", "base", "staging"); err != nil {
+		t.Fatalf("Expected delete base staging to succeed, got error: %v", err)
+	}
+	cfg = gitflowBranchConfig(t, tempDir)
+	assertNoLineContains(t, cfg, "gitflow.branch.staging.", "lowercase no regression (delete)")
+}
+
+// TestConfigInitDefaultsUnaffected tests that default init is unaffected by the
+// case-insensitive changes.
+// Steps:
+// 1. Sets up a test repository
+// 2. Runs 'git flow init --defaults'
+// 3. Verifies standard main/develop/feature/release/hotfix config is produced
+// 4. Verifies no lowercase-variant duplicate sections appear
+func TestConfigInitDefaultsUnaffected(t *testing.T) {
+	tempDir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+
+	cfg := gitflowBranchConfig(t, tempDir)
+	assertContainsLine(t, cfg, "gitflow.branch.main.type base", "init defaults (main)")
+	assertContainsLine(t, cfg, "gitflow.branch.develop.type base", "init defaults (develop)")
+	assertContainsLine(t, cfg, "gitflow.branch.feature.type topic", "init defaults (feature)")
+	assertContainsLine(t, cfg, "gitflow.branch.release.type topic", "init defaults (release)")
+	assertContainsLine(t, cfg, "gitflow.branch.hotfix.type topic", "init defaults (hotfix)")
+}
+
+// TestConfigRenameTopicResolvesCaseInsensitively tests renaming a topic type by a
+// case-variant name resolves to canonical and carries over settings.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Adds topic QA_Feature (prefix qa/)
+// 3. Runs 'config rename topic qa_feature QA_Regression'
+// 4. Verifies QA_Feature section removed and QA_Regression present with prefix qa/
+// 5. Verifies no qa_feature case-variant section remains
+func TestConfigRenameTopicResolvesCaseInsensitively(t *testing.T) {
+	tempDir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+	if _, err := testutil.RunGitFlow(t, tempDir, "config", "add", "topic", "QA_Feature", "develop", "--prefix", "qa/"); err != nil {
+		t.Fatalf("Failed to add topic QA_Feature: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, tempDir, "config", "rename", "topic", "qa_feature", "QA_Regression")
+	if err != nil {
+		t.Fatalf("Expected case-insensitive topic rename to succeed, got error: %v\nOutput: %s", err, output)
+	}
+
+	cfg := gitflowBranchConfig(t, tempDir)
+	assertNoLineContains(t, cfg, "gitflow.branch.QA_Feature.", "rename topic resolves")
+	assertNoLineContains(t, cfg, "gitflow.branch.qa_feature.", "rename topic resolves (no variant)")
+	assertContainsLine(t, cfg, "gitflow.branch.QA_Regression.prefix qa/", "rename topic carries prefix")
+}
+
+// TestConfigDeleteTopicResolvesCaseInsensitively tests deleting a topic type by a
+// case-variant name removes the canonical section.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Adds topic QA_Feature (prefix qa/)
+// 3. Runs 'config delete topic qa_feature'
+// 4. Verifies the QA_Feature section is fully removed (no QA_Feature or qa_feature lines)
+func TestConfigDeleteTopicResolvesCaseInsensitively(t *testing.T) {
+	tempDir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+	if _, err := testutil.RunGitFlow(t, tempDir, "config", "add", "topic", "QA_Feature", "develop", "--prefix", "qa/"); err != nil {
+		t.Fatalf("Failed to add topic QA_Feature: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, tempDir, "config", "delete", "topic", "qa_feature")
+	if err != nil {
+		t.Fatalf("Expected case-insensitive topic delete to succeed, got error: %v\nOutput: %s", err, output)
+	}
+
+	cfg := gitflowBranchConfig(t, tempDir)
+	assertNoLineContains(t, cfg, "gitflow.branch.QA_Feature.", "delete topic resolves")
+	assertNoLineContains(t, cfg, "gitflow.branch.qa_feature.", "delete topic resolves")
+}
+
+// TestConfigEditTopicStartingPointResolvesCaseInsensitively tests that editing a
+// topic --starting-point resolves the value case-insensitively to canonical.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Adds base V9_Release and topic QA_Feature (prefix qa/)
+// 3. Runs 'config edit topic QA_Feature --starting-point v9_release'
+// 4. Verifies stored start point is canonical V9_Release, no v9_release section
+func TestConfigEditTopicStartingPointResolvesCaseInsensitively(t *testing.T) {
+	tempDir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, tempDir)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldDir)
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+	if _, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "V9_Release"); err != nil {
+		t.Fatalf("Failed to add base branch V9_Release: %v", err)
+	}
+	if _, err := testutil.RunGitFlow(t, tempDir, "config", "add", "topic", "QA_Feature", "develop", "--prefix", "qa/"); err != nil {
+		t.Fatalf("Failed to add topic QA_Feature: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, tempDir, "config", "edit", "topic", "QA_Feature", "--starting-point", "v9_release")
+	if err != nil {
+		t.Fatalf("Expected case-insensitive edit topic starting-point to succeed, got error: %v\nOutput: %s", err, output)
+	}
+
+	cfg := gitflowBranchConfig(t, tempDir)
+	assertContainsLine(t, cfg, "gitflow.branch.QA_Feature.startpoint V9_Release", "edit topic starting point")
+	assertNoLineContains(t, cfg, "gitflow.branch.v9_release.", "edit topic starting point")
 }

--- a/test/cmd/config_test.go
+++ b/test/cmd/config_test.go
@@ -1147,6 +1147,13 @@ func TestConfigRenameBaseCaseOnlySelfRename(t *testing.T) {
 	cfg := gitflowBranchConfig(t, tempDir)
 	assertContainsLine(t, cfg, "gitflow.branch.v9_release.type base", "case-only self-rename")
 	assertNoLineContains(t, cfg, "gitflow.branch.V9_Release.", "case-only self-rename")
+
+	// The Git ref must be re-cased too (the RenameBranchForce -M path). On a
+	// case-sensitive filesystem the old-case ref must be gone and the new-case
+	// ref present; this is the behavior the force fallback exists to provide.
+	if !refExists(t, tempDir, "v9_release") {
+		t.Errorf("Expected refs/heads/v9_release to exist after case-only self-rename")
+	}
 }
 
 // TestConfigAddBaseAbsentParentErrors tests a genuinely-absent reference still errors

--- a/test/internal/config/config_test.go
+++ b/test/internal/config/config_test.go
@@ -461,3 +461,82 @@ func TestGitFlowAVHRemoteImport(t *testing.T) {
 	// Verify git-flow-avh remote is imported
 	assert.Equal(t, "avh-remote", cfg.Remote, "git-flow-avh remote should be imported")
 }
+
+// TestLoadConfigPreservesBranchNameCase verifies LoadConfig keeps the original
+// branch-name case as the canonical key and resolves lookups case-insensitively.
+// Steps:
+//  1. Sets up a test repository
+//  2. Writes gitflow.branch.V9_Release.* config with a mixed-case subsection name
+//  3. Calls config.LoadConfig()
+//  4. Verifies the loaded config keys the branch by its exact case (V9_Release),
+//     not a lowercased variant (v9_release)
+//  5. Verifies ResolveBranchName resolves a lowercase lookup to the canonical key
+//  6. Verifies property-name lowercasing still parses (Type/UpstreamStrategy)
+func TestLoadConfigPreservesBranchNameCase(t *testing.T) {
+	// Setup
+	dir := setupTestRepo(t)
+	defer cleanupTestRepo(t, dir)
+
+	// Write a mixed-case branch subsection plus a mixed-case property name
+	configs := []struct {
+		key   string
+		value string
+	}{
+		{"gitflow.branch.V9_Release.type", "base"},
+		{"gitflow.branch.V9_Release.upstreamStrategy", "merge"},
+	}
+	for _, c := range configs {
+		cmd := exec.Command("git", "config", c.key, c.value)
+		cmd.Dir = dir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("Failed to set git config %s: %v", c.key, err)
+		}
+	}
+
+	// Set version to mark as initialized
+	cmd := exec.Command("git", "config", "gitflow.version", "1.0")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to set gitflow version: %v", err)
+	}
+
+	// Load config
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	// The canonical key must be the exact original case, not lowercased
+	if _, exists := cfg.Branches["V9_Release"]; !exists {
+		t.Errorf("Expected canonical branch key 'V9_Release' to be preserved; branches: %v", keysOf(cfg.Branches))
+	}
+	if _, exists := cfg.Branches["v9_release"]; exists {
+		t.Errorf("Did not expect a lowercased branch key 'v9_release'; branches: %v", keysOf(cfg.Branches))
+	}
+
+	// A case-insensitive lookup for a lowercase variant must resolve to the canonical key
+	canonical, found := cfg.ResolveBranchName("v9_release")
+	if !found {
+		t.Fatalf("Expected ResolveBranchName(\"v9_release\") to resolve, got not found")
+	}
+	if canonical != "V9_Release" {
+		t.Errorf("Expected resolved canonical name 'V9_Release', got '%s'", canonical)
+	}
+
+	// Property-name lowercasing must still parse the values
+	branch := cfg.Branches[canonical]
+	if branch.Type != "base" {
+		t.Errorf("Expected Type 'base', got '%s'", branch.Type)
+	}
+	if branch.UpstreamStrategy != "merge" {
+		t.Errorf("Expected UpstreamStrategy 'merge', got '%s'", branch.UpstreamStrategy)
+	}
+}
+
+func keysOf(m map[string]config.BranchConfig) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}


### PR DESCRIPTION
Matches `gitflow.branch.*` config identities case-insensitively while preserving the first-written case as canonical, fixing broken `config` subcommands and duplicate branch sections for uppercase/mixed-case branch names.

git-flow lowercased branch subsection names when reading config back (`internal/config/config.go`), desyncing the in-memory `Branches` map (keyed lowercase) from the case-preserved on-disk config. This broke every `config` subcommand for branches with uppercase letters — a mixed-case parent or start-point reference failed lookup ("does not exist"), and retrying in a different case wrote a second, lowercased `[gitflow "branch.…"]` section (the #117 duplicate).

The fix layers `core.ignorecase`-style semantics onto git-flow's config identity: `LoadConfig` now keeps the first-seen casing as the canonical map key and folds later properties of the same branch into it (property names stay lowercased, since git config variable names are legitimately case-insensitive). A new `Config.ResolveBranchName` resolver maps any user-supplied casing back to the single canonical entry. All `config` handlers (`add`/`edit`/`rename`/`delete`, base and topic) resolve every branch reference to canonical before any lookup, storage, or git call, and store canonical parent/start-point values so `SaveConfig` only ever writes canonical-case sections. The resolved canonical name — never the typed casing — is handed to `git.BranchExists`/`CreateBranch`/`RenameBranch`/`UnsetConfigSection`, which is what makes the git ref operations correct on case-sensitive filesystems (Linux CI). Adding or renaming to a name that case-folds to a *different* existing branch is rejected as "already exists" naming the canonical form, while a case-only self-rename re-canonicalizes in place. Changes touch `internal/config/config.go`, `cmd/config.go`, `internal/git/repo.go`, and the docs.

Resolves #122
Relates #117

## Remarks

- A new `git.RenameBranchForce` (`git branch -M`) backs the case-only self-rename: on case-insensitive filesystems the destination folds to the same ref and plain `-m` refuses, so the force flag is needed; callers only reach it after confirming the rename does not clobber a genuinely different branch.
- Rejected operations (case-collision add, colliding rename, absent-reference add) leave the existing canonical section untouched — collision detection happens before any `cfg` mutation/save.
- Scope is deliberately narrow to `gitflow.branch.*` config identity and the `config` subcommands. Out of scope and unchanged: distinct case-variant types as separate entities, dotted subsection names (`V10.5`, a pre-existing defect), repair of pre-existing duplicate/orphaned sections, and CLI topic-command-name / instance naming.
- The misleading `BranchNotFoundError` wording ("start point branch '%s' does not exist" even for a missing parent) was left as-is: correcting it would break an existing `start_test.go` assertion, so tests match on the missing *name* substring rather than the full phrase.

**Review focus:**
- `internal/config/config.go` — canonical-key folding in `LoadConfig` and the `ResolveBranchName` resolver.
- `cmd/config.go` — the resolve-before-use invariant across all handlers, especially the rename collision-vs-self-rename branch and the delete dependents scan.
- `internal/git/repo.go` — `RenameBranchForce` / `-M` and its safety contract.
- `test/cmd/config_test.go` — 22 command scenarios; note the canonical-ref (`git rev-parse --verify`) guards that only fail on a case-sensitive filesystem.