### PR TITLE
build: Add windows/arm64 support and portability fallbacks

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -87,7 +87,10 @@ if command -v zip >/dev/null 2>&1; then
     (cd "$BUILD_DIR" && zip "${PACKAGE_NAME}-${VERSION}-windows-386.zip" "${BINARY_NAME}-${VERSION}-windows-386.exe")
     (cd "$BUILD_DIR" && zip "${PACKAGE_NAME}-${VERSION}-windows-arm64.zip" "${BINARY_NAME}-${VERSION}-windows-arm64.exe")
 else
-    echo "Warning: zip command not found, skipping Windows archives"
+    echo "Warning: zip command not found, falling back to tar.gz for Windows"
+    tar czf "$BUILD_DIR/${PACKAGE_NAME}-${VERSION}-windows-amd64.tar.gz" -C "$BUILD_DIR" "${BINARY_NAME}-${VERSION}-windows-amd64.exe"
+    tar czf "$BUILD_DIR/${PACKAGE_NAME}-${VERSION}-windows-386.tar.gz" -C "$BUILD_DIR" "${BINARY_NAME}-${VERSION}-windows-386.exe"
+    tar czf "$BUILD_DIR/${PACKAGE_NAME}-${VERSION}-windows-arm64.tar.gz" -C "$BUILD_DIR" "${BINARY_NAME}-${VERSION}-windows-arm64.exe"
 fi
 
 # Generate checksums

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -95,6 +95,12 @@ fi
 
 # Generate checksums
 echo "Generating checksums..."
-(cd "$BUILD_DIR" && shasum -a 256 * > "${PACKAGE_NAME}-${VERSION}-checksums.txt")
+if command -v shasum >/dev/null 2>&1; then
+    (cd "$BUILD_DIR" && shasum -a 256 * > "${PACKAGE_NAME}-${VERSION}-checksums.txt")
+elif command -v sha256sum >/dev/null 2>&1; then
+    (cd "$BUILD_DIR" && sha256sum * > "${PACKAGE_NAME}-${VERSION}-checksums.txt")
+else
+    echo "Warning: Neither shasum nor sha256sum found, skipping checksums"
+fi
 
 echo "Build complete! Artifacts are in the $BUILD_DIR directory" 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -43,6 +43,8 @@ echo "Building windows/amd64..."
 CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -trimpath -ldflags "${BUILD_FLAGS}" -o "$BUILD_DIR/${BINARY_NAME}-${VERSION}-windows-amd64.exe" main.go
 echo "Building windows/386..."
 CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -trimpath -ldflags "${BUILD_FLAGS}" -o "$BUILD_DIR/${BINARY_NAME}-${VERSION}-windows-386.exe" main.go
+echo "Building windows/arm64..."
+CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build -trimpath -ldflags "${BUILD_FLAGS}" -o "$BUILD_DIR/${BINARY_NAME}-${VERSION}-windows-arm64.exe" main.go
 
 # Verify all binaries were created
 echo "Verifying binaries..."
@@ -50,7 +52,7 @@ MISSING_BINARIES=()
 
 for binary in "${BINARY_NAME}-${VERSION}-darwin-amd64" "${BINARY_NAME}-${VERSION}-darwin-arm64" \
               "${BINARY_NAME}-${VERSION}-linux-amd64" "${BINARY_NAME}-${VERSION}-linux-arm64" "${BINARY_NAME}-${VERSION}-linux-386" \
-              "${BINARY_NAME}-${VERSION}-windows-amd64.exe" "${BINARY_NAME}-${VERSION}-windows-386.exe"; do
+              "${BINARY_NAME}-${VERSION}-windows-amd64.exe" "${BINARY_NAME}-${VERSION}-windows-386.exe" "${BINARY_NAME}-${VERSION}-windows-arm64.exe"; do
     if [[ ! -f "$BUILD_DIR/$binary" ]]; then
         MISSING_BINARIES+=("$binary")
     fi
@@ -83,6 +85,7 @@ echo "Creating windows archives..."
 if command -v zip >/dev/null 2>&1; then
     (cd "$BUILD_DIR" && zip "${PACKAGE_NAME}-${VERSION}-windows-amd64.zip" "${BINARY_NAME}-${VERSION}-windows-amd64.exe")
     (cd "$BUILD_DIR" && zip "${PACKAGE_NAME}-${VERSION}-windows-386.zip" "${BINARY_NAME}-${VERSION}-windows-386.exe")
+    (cd "$BUILD_DIR" && zip "${PACKAGE_NAME}-${VERSION}-windows-arm64.zip" "${BINARY_NAME}-${VERSION}-windows-arm64.exe")
 else
     echo "Warning: zip command not found, skipping Windows archives"
 fi


### PR DESCRIPTION
Adds a `windows/arm64` release target and makes `scripts/build.sh` more portable in minimal environments like Git Bash.

The original single change is split into three focused commits per COMMIT_GUIDELINES.md:

- `build: Add windows/arm64 build target`
- `build: Fall back to tar.gz when zip unavailable`
- `build: Add sha256sum fallback for checksum generation`

The net change is identical to the original PR.

This PR supersedes #92 by @evilbaschdi, whose work is included with `Co-authored-by` attribution on each commit. It applies the changes requested in review: commit-message conventions and separating the three concerns.

## Remarks

- The tar.gz fallback for Windows is a compatibility measure for environments without `zip`; `.zip` remains the default when available.

## Review focus

- `scripts/build.sh` — windows/arm64 target, zip→tar.gz fallback, shasum→sha256sum fallback