### PR TITLE
fix(config): Silence spurious base-config cleanup warning

### DIFF
--- a/.claude/hooks/github-post-verify.sh
+++ b/.claude/hooks/github-post-verify.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# PreToolUse hook — re-surface the GitHub posting checklist before any GitHub
+# write goes out. Non-blocking: it injects a reminder the model self-verifies
+# the body against, then the post proceeds under the normal permission flow
+# (no permissionDecision field, so existing prompts are untouched).
+#
+# Source of truth for the rules: .claude/skills/_shared/POSTING_CHECKLIST.md
+# and GITHUB_GUIDELINES.md. Keep the reminder below in sync with the checklist.
+#
+# Wired in .claude/settings.json for the mcp__github__ write tools.
+
+cat <<'JSON'
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"Posting-checklist reminder (see .claude/skills/_shared/POSTING_CHECKLIST.md). Verify this body before it posts. Mechanical, never correct to violate: no emoji; sections use h3 (###), never h1/h2; no hard-wrapped prose — one line per paragraph and list item, fenced code exempt; no AI-attribution line in the body (Co-Authored-By / 'Generated with Claude' belong on the commit trailer only); the first line does not restate the title. Tone: lead with a 1-2 sentence summary; concise, no walls of text; neutral, no gushing praise ('detailed report', 'solid change') or effusive thanks; don't restate analysis the other person already gave; a reply reads as one continuous conversation and adds only what is new; a review opens with required changes by severity, not praise or a re-summary. If any item fails, fix the body and re-post, then re-read what rendered on GitHub."}}
+JSON
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "mcp__github__(create_issue|update_issue|add_issue_comment|create_pull_request|create_pull_request_review)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/github-post-verify.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/_shared/POSTING_CHECKLIST.md
+++ b/.claude/skills/_shared/POSTING_CHECKLIST.md
@@ -1,0 +1,46 @@
+# GitHub Posting Checklist
+
+A pre-post self-verification for anything written to GitHub. Skills reference
+this document instead of restating the rules, so they stay in one place. The
+source of truth for *why* is [GITHUB_GUIDELINES.md](../../../GITHUB_GUIDELINES.md);
+this is the operational checklist a skill runs before it posts.
+
+## When to Run
+
+Immediately before any GitHub write — issue body or comment, PR description,
+PR review body or inline comment, discussion post or reply. Run it against the
+exact text about to be sent, not an earlier draft. If the text lives in an
+`.ai/` file that gets posted verbatim, verify the file.
+
+## The Check
+
+Read the drafted body once and confirm every item. If any fails, fix the text
+and re-check before posting — never post first and fix after.
+
+**Mechanical (unambiguous — a violation is always wrong):**
+
+- [ ] No emoji anywhere.
+- [ ] No h1 (`#`) or h2 (`##`) headings — sections use h3 (`###`).
+- [ ] No hard-wrapped prose — each paragraph and list item is a single line, no fixed-column breaks. (Fenced code blocks are exempt.)
+- [ ] No AI-attribution line in the body ("Generated with Claude", robot emoji, `Co-Authored-By`) — credit goes on the commit trailer only.
+- [ ] The first line does not restate the title.
+
+**Tone (judgment — read the draft as the recipient):**
+
+- [ ] Leads with a 1–2 sentence summary of what the post is about.
+- [ ] Brief and concise; no walls of text.
+- [ ] Professional and neutral; no gushing praise ("detailed report", "solid change") and no effusive thanks.
+- [ ] Does not restate analysis the other person already gave back to them.
+- [ ] For a reply in a thread: read every prior comment first (including ones under the maintainer's own account); it reads as one continuous conversation and adds only what is new.
+- [ ] For a review: opens with the required changes organized by severity, not praise or a re-summary; each point specific and actionable; says so plainly if nothing blocks merge.
+
+**Structure (type-specific — confirm the right one):**
+
+- [ ] Issue body follows [ISSUE_GUIDELINES.md](../../../ISSUE_GUIDELINES.md) (title has no type prefix, correct label, right section structure for its type).
+- [ ] PR description follows the [pull request template](../../../.github/PULL_REQUEST_TEMPLATE.md).
+
+## After Posting
+
+For posts that matter (a spec issue, a PR description, a review), re-read what
+actually rendered on GitHub — occasionally the API mangles formatting or a
+paste drops a section. Fix in place if it did not come out as intended.

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -187,7 +187,7 @@ After confirmation:
    ```bash
    gh api repos/gittower/git-flow-next/pulls/<number> -X PATCH -f body="<updated body>"
    ```
-3. Post the replies:
+3. Post the replies (verify each body against the [posting checklist](../_shared/POSTING_CHECKLIST.md) first — the PR-description PATCH and inline replies go through `gh api`, so no hook reminder fires):
    - **Inline thread replies** — reply to each inline diff comment on its own thread:
      ```bash
      gh api repos/gittower/git-flow-next/pulls/<number>/comments/<comment-id>/replies -f body="<reply>"

--- a/.claude/skills/check-prs/SKILL.md
+++ b/.claude/skills/check-prs/SKILL.md
@@ -54,7 +54,7 @@ awaiting review):
 | PR | Title | Author | Status | Days | Next action |
 |----|-------|--------|--------|------|-------------|
 | #93 | ... | @user | window lapsed | 9 | /takeover-pr 93 |
-| #95 | ... | @user | author responded | 2 | /address-review 95 or re-review |
+| #95 | ... | @user | author responded | 2 | /follow-up-review 95 |
 | #96 | ... | @user | awaiting review | 4 | /handle-pr 96 |
 ```
 

--- a/.claude/skills/create-spec/SKILL.md
+++ b/.claude/skills/create-spec/SKILL.md
@@ -95,7 +95,8 @@ Iterate until accepted.
 
 ### 6. Post to GitHub
 
-After acceptance:
+After acceptance, verify `spec.md` and any comment body against the
+[posting checklist](../_shared/POSTING_CHECKLIST.md), then:
 
 1. Create the spec issue via `mcp__github__create_issue`: title per
    ISSUE_GUIDELINES.md (imperative, specific), body from `spec.md`, labels:

--- a/.claude/skills/follow-up-review/SKILL.md
+++ b/.claude/skills/follow-up-review/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: follow-up-review
+description: Re-review an incoming PR after the author responded — scoped to the delta since the last review, verifies prior requested changes, posts after confirmation
+argument-hint: <pr-number>
+allowed-tools: Bash, Read, Write, Grep, Glob, mcp__github__get_pull_request, mcp__github__get_pull_request_files, mcp__github__get_pull_request_reviews, mcp__github__get_pull_request_comments, mcp__github__create_pull_request_review
+---
+
+# Follow-up Review
+
+Re-review an incoming pull request after the author has responded to a prior
+maintainer review. Unlike `/handle-pr` (a fresh full review), this skill is
+**round-aware**: it reconstructs what the last review requested, reads the
+author's replies, reviews only the delta since the last-reviewed commit, and
+reports each prior item as Resolved / Still open / Partially addressed — plus
+anything new introduced in the delta. Posts only after user confirmation.
+
+Use this for **every round after the first**. For the first review of an
+incoming PR, use `/handle-pr`. For addressing feedback on a PR *you authored*,
+use `/address-review`.
+
+## Arguments
+
+`/follow-up-review <pr-number>`
+
+## Workflow
+
+### Step 1: Fetch Prior Round State
+
+Fetch in parallel (owner `gittower`, repo `git-flow-next`):
+
+- PR details: `mcp__github__get_pull_request` — current HEAD SHA, head branch, base
+- Reviews: `mcp__github__get_pull_request_reviews`
+- Inline comments: `mcp__github__get_pull_request_comments`
+
+Identify the **most recent maintainer review** (the last round we posted). Record:
+
+- Its `event` (was it REQUEST_CHANGES / COMMENT / APPROVE) and `submitted_at`
+- Its `commit_id` — this is the **last-reviewed SHA**. The delta to review is
+  `lastReviewedSHA..HEAD`.
+
+If no prior maintainer review exists, stop and tell the user to run `/handle-pr`
+first — there is no round to follow up on.
+
+### Step 2: Reconstruct the Prior Asks
+
+Parse the last maintainer review (body + its inline comments) into a list of
+**requested items**, each with:
+
+- Severity (Must fix / Should fix / Nit)
+- The `file:line` (or inline thread) it was anchored to
+- The thread ID, if it was an inline diff comment (needed to check for replies)
+
+Also pull the prior local artifact if present — check `.ai/<folder>/` for the
+`pr-review-*.md` or `review-pr<number>-*.md` from the last round — and use it to
+recover any nuance the posted review compressed.
+
+### Step 3: Read the Author's Replies First
+
+Before judging anything, read what the author said. For each prior inline thread,
+check for reply comments (any author) and whether the thread is resolved. Read
+general PR conversation comments since the last review too.
+
+This matters: an author may have addressed a concern in code, or *explained why
+they didn't* ("intentional because X"). Account for the reply before you flag an
+item as still-open. If a reply makes a dismissal reasonable, note it rather than
+re-raising the same point.
+
+### Step 4: Check Out and Scope the Delta
+
+```bash
+git fetch origin <head-branch>
+git checkout <head-branch>
+```
+
+Get the delta since the last review:
+
+```bash
+git diff <lastReviewedSHA>..<HEAD> --stat
+git log <lastReviewedSHA>..<HEAD> --oneline
+```
+
+**Scope rule — delta-only.** Review the commits added since the last review, in
+the context of the prior asks. Do **not** re-scan the whole PR for pre-existing
+issues outside the delta that weren't flagged last round — re-surfacing untouched
+code as new must-fixes reads as moving goalposts to the author. New findings are
+limited to what the delta actually changed. (If you genuinely spot a serious
+pre-existing defect outside the delta, raise it to the user at the gate as an
+out-of-scope note, not as a blocking finding.)
+
+Apply **[../code-review/REVIEW_CRITERIA.md](../code-review/REVIEW_CRITERIA.md)** to the delta.
+
+### Step 5: Verdict Each Prior Ask
+
+For every item from Step 2, assign a status backed by evidence:
+
+- **Resolved** — the delta (or an author reply) fully addresses it. Cite the
+  commit SHA or the line that fixes it.
+- **Partially addressed** — some but not all of the concern is handled. Say
+  what's left.
+- **Still open** — not addressed, and the reply (if any) doesn't justify leaving
+  it. Carry its original severity forward.
+- **Withdrawn** — on reflection (often after the author's explanation) the item
+  no longer applies. Note why.
+
+### Step 6: Determine the Event
+
+- `APPROVE` — every prior Must/Should item is Resolved or Withdrawn, and the
+  delta introduces no new Must-fix. (Outstanding Nits alone don't block.)
+- `REQUEST_CHANGES` — any prior Must-fix is Still open / Partially addressed, or
+  the delta introduces a new Must-fix.
+- `COMMENT` — no blocking items, but Should-fix items remain open or the delta
+  adds non-blocking findings.
+
+### Step 7: Write the Follow-up Draft
+
+Determine the output folder (reuse the existing one from prior rounds):
+
+```bash
+# Extract issue number from branch name (feature/42-x -> 42); prefer the
+# existing .ai/issue-<number>-* folder, else .ai/pr-<number>/
+HEAD_SHA=$(gh pr view <number> --json headRefOid --jq '.headRefOid' | cut -c1-7)
+```
+
+Write to `.ai/<folder>/followup-review-<HEAD_SHA>.md` using this format — the
+frontmatter matches `/pr-review` so `/post-review` can consume it directly:
+
+````markdown
+---
+pr: <number>
+event: <APPROVE|COMMENT|REQUEST_CHANGES>
+round: <N>
+since: <lastReviewedSHA-short>
+---
+
+<Opening: one or two sentences. State the round and that this reviews the delta
+since <since>. Lead with what still blocks merge, or say plainly that the prior
+items are addressed and nothing new blocks. No generic praise. See GITHUB_GUIDELINES.md.>
+
+**Since last round**
+
+| Prior item | Severity | Status | Evidence |
+|------------|----------|--------|----------|
+| <short desc> — `file:line` | must fix | Resolved | `<sha>` |
+| <short desc> — `file:line` | should fix | Still open | not addressed |
+| <short desc> — `file:line` | nit | Withdrawn | intentional per author reply |
+
+**Still Open**
+- <item> — `file:line` — <what remains>
+
+**New in this round**
+- <finding introduced by the delta> — `file:line` — <brief explanation>
+
+## Inline Comments
+
+### `<file>:<line>`
+<Comment body — concise, actionable. Only on lines visible in the delta diff.>
+````
+
+**Format rules:**
+- Only include sections that have content. If everything is resolved, the
+  "Still Open" and "New in this round" sections are omitted — the table carries it.
+- For an **APPROVE**, the opening must explicitly confirm the prior items landed
+  (e.g. "All three round-1 must-fix items addressed — `<sha>`, `<sha>`, `<sha>`;
+  nothing new blocks merge."), not a blind clean-approval.
+- Tone/style per [GITHUB_GUIDELINES.md](../../../GITHUB_GUIDELINES.md) — concise,
+  no emojis, no checkboxes, no hard-wrapping. This is posted publicly.
+- Inline comment headers use the exact `### \`file:line\`` form for parseability.
+
+### Step 8: Confirmation Gate
+
+Present to the user in one block:
+
+- Event (APPROVE / COMMENT / REQUEST_CHANGES) and why
+- The "Since last round" table
+- The full draft body and inline comments
+- Any out-of-scope pre-existing issues noticed (as notes, not findings)
+
+Wait for confirmation. The user may re-verdict items, downgrade/upgrade the
+event, or decide not to post.
+
+### Step 9: Post
+
+On confirmation, post via the `/post-review` pattern (read
+`.claude/skills/post-review/SKILL.md`), passing the draft path explicitly:
+parse the frontmatter for `pr` and `event`, use the body up to `## Inline
+Comments` as the review body, map inline comments to delta diff lines, and post
+with `mcp__github__create_pull_request_review` (include `commit_id` = HEAD SHA).
+Verify the body against the [posting checklist](../_shared/POSTING_CHECKLIST.md) first.
+
+### Step 10: Report
+
+- Posted review URL and event type
+- Counts: prior items resolved / still open / new findings
+- If REQUEST_CHANGES: the CONTRIBUTING.md response window restarts — `/check-prs`
+  tracks it; the next author response is another `/follow-up-review <number>`
+
+## Notes
+
+- Delta-only by design: each round reviews `lastReviewedSHA..HEAD`, so successive
+  `followup-review-<sha>.md` artifacts accumulate side by side and stay correlated
+  with the PR state they reviewed — mirroring `/address-review`'s per-SHA plans.
+- Read author replies before flagging (Step 3) — this is what makes the round feel
+  like a conversation rather than a re-run.
+- Reviewer role only. `/address-review` is the author-side counterpart (implement
+  feedback on your own PR); do not confuse the two.

--- a/.claude/skills/gh-issue/SKILL.md
+++ b/.claude/skills/gh-issue/SKILL.md
@@ -24,6 +24,7 @@ Create a new GitHub issue for the gittower/git-flow-next repository.
 4. **Create the Issue**
    - Determine type and apply `bug` or `enhancement` label per ISSUE_GUIDELINES.md
    - Write title and body following ISSUE_GUIDELINES.md conventions
+   - Verify the body against the [posting checklist](../_shared/POSTING_CHECKLIST.md) before creating
    - Use `mcp__github__create_issue` to create on gittower/git-flow-next
 
 5. **Report Result**

--- a/.claude/skills/handle-pr/SKILL.md
+++ b/.claude/skills/handle-pr/SKILL.md
@@ -13,7 +13,10 @@ GitHub review draft, posted only after user confirmation. Internal and
 external PRs are treated the same.
 
 For later rounds — after the author responds to a posted review — use
-`/address-review <number>` instead.
+`/follow-up-review <number>` instead (it is round-aware: it verifies the prior
+requested changes against the delta and reads the author's replies).
+`/address-review` is the author-side counterpart, for feedback on a PR *you*
+authored — not for re-reviewing an incoming PR.
 
 ## Arguments
 

--- a/.claude/skills/health-audit/SKILL.md
+++ b/.claude/skills/health-audit/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: health-audit
+description: Internal codebase health audit — checks docs, skills, architecture/duplication, coding-guidelines, and tests for drift. Runs all areas by default, or one named area. Writes per-area reports to .ai/health-audit-<date>/.
+argument-hint: "[area: docs | skills | architecture | guidelines | tests] (omit for all)"
+allowed-tools: Bash, Read, Write, Glob, Grep, Task
+---
+
+# Health Audit
+
+Sanity-check the codebase for the drift that accumulates in an AI-maintained
+repo: docs falling out of sync with commands, skills referencing moved files,
+copy-paste helpers, guideline violations, test-convention drift. Each area is
+audited by an independent subagent grounded in its **truth source** (the code,
+or a specific guideline doc), so findings are concrete and low-noise.
+
+Read-only against the codebase: the audit never edits source, posts, or opens
+issues. It only reports. Findings are meant to feed the normal pipelines
+(`/gh-issue` → `/resolve-issue`, or direct doc fixes).
+
+## Arguments
+
+`/health-audit [area]`
+
+- No argument → run **all five areas** in parallel, then write a `SUMMARY.md`.
+- One `area` → run only that area. Valid slugs (also the report filenames):
+  `docs`, `skills`, `architecture`, `guidelines`, `tests`.
+
+## Areas and truth sources
+
+| Slug | Audits | Truth source |
+|------|--------|--------------|
+| `docs` | manpages vs actual flags/config/commands | `cmd/*.go`, config keys, `version/` |
+| `skills` | stale refs, overlap, doc-consistency of `.claude/skills/` | the skill files + root guideline docs |
+| `architecture` | duplication, layering, dead/parallel code | `ARCHITECTURE.md`, `CODING_GUIDELINES.md`, source |
+| `guidelines` | coding-guideline compliance | `CODING_GUIDELINES.md`, CLAUDE.md "Code Conventions" |
+| `tests` | build/test pass, coverage gaps, convention drift | `TESTING_GUIDELINES.md`, CLAUDE.md testing sections |
+
+## Instructions
+
+### 1. Resolve scope and output dir
+
+Get today's date and pick the areas to run:
+
+```bash
+date +%Y-%m-%d
+```
+
+- If an argument was given, validate it against the five slugs (reject anything
+  else with the valid list) and run only that one.
+- Otherwise run all five.
+
+The output directory is `.ai/health-audit-<today>/`. Create it. `.ai/` is
+gitignored, so nothing here gets committed. If the dir already exists (a re-run
+same day), overwrite the area files being regenerated; leave others intact.
+
+### 2. Run each area as a subagent
+
+Launch one `Task`/subagent **per selected area, in parallel** (all in one
+message when running several). Each subagent gets the matching prompt below,
+**prefixed** with this shared preamble:
+
+> You are auditing the git-flow-next repo (Go CLI implementing the git-flow
+> branching model) at the repository root. This is an AI-maintained repo; the
+> risk you are hunting is **drift**, not catastrophic breakage. Respect the
+> project's stated pragmatic, anti-over-engineering philosophy (CLAUDE.md): do
+> NOT flag long functions, many-parameter signatures, or "missing" abstraction
+> layers — those are explicitly acceptable. Only report REAL issues with
+> concrete `file:line` evidence. When in doubt, lean toward NOT flagging and
+> mark it low severity. Read the relevant guideline doc FIRST so you check
+> against the project's actual rules, not generic opinions.
+>
+> Write your findings to `.ai/health-audit-<today>/<slug>.md` (create nothing
+> else). Format: a top `# <Area> — <date>` heading, then findings as a bullet
+> list where each is `**[high|med|low]**` + one-line description + `file:line`
+> references + the concrete mismatch. Group trivially-clean sub-checks into a
+> single "Clean:" bullet. End with a one-sentence **Verdict**. Return to me
+> only a 3–6 line digest: the count by severity and your highest-severity
+> findings — not the full file.
+
+Then the per-area body:
+
+**`docs`** — Check manpages in `docs/*.md` against the code:
+1. Every command in `cmd/*.go`: do its flags (long AND short) match
+   `docs/git-flow-<cmd>.1.md`? Find flags in code missing from docs, and
+   documented flags that no longer exist.
+2. Config keys: every `gitflow.*` key read/written in `internal/config` and
+   `cmd/` — documented in `docs/gitflow-config.5.md` (or a per-command
+   manpage)? Any documented key the code no longer uses?
+3. Commands with no manpage at all, or manpages for removed commands, and
+   broken `git-flow-*(1)` cross-references.
+4. Recently-added commands (publish, rename, track, checkout) — verify doc
+   coverage (CLAUDE.md makes doc updates MANDATORY for command changes).
+5. `version/version.go` vs `cmd/version.go` — do the version constants match?
+   Skip stylistic/wording nitpicks.
+
+**`skills`** — Check `.claude/skills/` (and any `.claude/commands/`):
+1. STALE REFERENCES: grep each skill for referenced files, paths, skill names,
+   and doc names; verify each target exists. Report dangling references.
+2. OVERLAP: genuinely adjacent skills (e.g. the review family, `gh-issue` vs
+   any global `create-github-issue`, `scan-repo` vs `sync-repo-status`) — is
+   the boundary documented, or ambiguous? Don't flag skills that legitimately
+   differ.
+3. CONSISTENCY: any skill instructing something that contradicts
+   `GITHUB_GUIDELINES.md`, `COMMIT_GUIDELINES.md`, `ISSUE_GUIDELINES.md`, or
+   `DEV_WORKFLOW.md`.
+4. Skills referenced in `DEV_WORKFLOW.md`/`CLAUDE.md` that don't exist, and
+   skills that exist but are referenced nowhere (orphans / undocumented
+   relative to peers).
+
+**`architecture`** — Read `ARCHITECTURE.md` and `CODING_GUIDELINES.md` first,
+then audit `cmd/` and `internal/`:
+1. TRUE DUPLICATION: near-identical logic blocks in 2+ places that could share
+   a helper (flag parsing, config-precedence resolution, conflict/merge-state
+   handling, validation, hook-context construction). Give every copy's
+   `file:line`.
+2. LAYERING: CLAUDE.md requires all Git ops go through `internal/git`. Find
+   `exec.Command("git", ...)` calls that bypass the wrapper (note if in `cmd/`
+   vs read-only `internal/` — the former is worse).
+3. Three-layer config precedence (branch-type def → command config → CLI
+   flags) — implemented consistently, or does one command resolve differently?
+4. Dead code (exported symbols with no non-test caller; unused files) and
+   parallel implementations (two functions doing the same job under different
+   names).
+   Lean away from flagging acceptable repetition; call it out only when it has
+   caused, or is likely to cause, real divergence.
+
+**`guidelines`** — Read `CODING_GUIDELINES.md` + CLAUDE.md "Code Conventions"
+first; check compliance with the project's stated MUST/ALWAYS/NEVER rules:
+1. ERROR HANDLING: custom typed errors from `internal/errors` used; specific
+   exit codes per condition; typed errors actually satisfy the `errors.Error`
+   interface. Find bare `fmt.Errorf`/`errors.New` where a typed error is
+   expected, and exit codes that diverge from the documented set.
+2. GIT INTEGRATION: git through `internal/git`; graceful conflict handling;
+   **uncommitted-changes check before mutating operations**.
+3. COMMAND IMPLEMENTATION: consistent Cobra structure; the "validate git-flow
+   is initialized" preamble on every command except `init`; long AND short
+   flags; input validation; examples/usage present.
+4. Any other explicit rule in `CODING_GUIDELINES.md`, checked against code.
+
+**`tests`** — Read `TESTING_GUIDELINES.md` first, then:
+1. Run `go build ./...` and `go test ./...` (allow several minutes;
+   `test/cmd` alone can take ~6 min). Report the exact result — pass, or the
+   failing package + short error. State what you ran.
+2. COVERAGE: each `cmd/*.go` command has a `test/cmd/*_test.go`? List missing
+   or obviously thin ones (trivial commands like `version` are acceptable).
+3. CONVENTIONS: init repos with `git flow init --defaults`; use `testutil`
+   helpers (`SetupTestRepo`, `RunGitFlow`) rather than rolling their own;
+   "one test case per function" for integration scenarios (table-driven is
+   allowed only for pure functions); error-checked `os.Chdir` restore.
+4. Flaky/skipped: `t.Skip` (legit platform guards vs real skips), timing/
+   network/ordering dependence, TODO stubs.
+5. Dead or duplicated `testutil` helpers.
+
+### 3. Write SUMMARY.md (full runs only)
+
+When all five areas ran, after the subagents finish, read the five area files
+and write `.ai/health-audit-<today>/SUMMARY.md`:
+
+```markdown
+# Repo Health Audit — <date>
+
+<2–3 sentences: overall state, is the build/tests green, how much is drift vs real bugs.>
+
+## Top priorities
+<The handful of high-severity items across all areas, each one line with file:line and which area file has detail.>
+
+## By area
+| Area | high | med | low | Verdict |
+|------|------|-----|-----|---------|
+| docs | .. | .. | .. | <one line> |
+| ... |
+
+## Suggested next actions
+<Group into: ship-before-release fixes, quick doc syncs, opportunistic consolidation, housekeeping. Each item → the pipeline that handles it (/gh-issue, direct edit, etc.).>
+```
+
+On a single-area run, skip `SUMMARY.md`.
+
+### 4. Report to user
+
+In the conversation: state the output dir, give the severity counts per area
+(or the one area), and list the top priorities in fix order. Do NOT dump the
+full reports — point to the files. Close by offering the obvious next step
+(file the high-severity items as issues, or fix the cheap doc drift directly).

--- a/.claude/skills/post-review/SKILL.md
+++ b/.claude/skills/post-review/SKILL.md
@@ -153,7 +153,7 @@ For **Format B** (code-review): compose the review body per [GITHUB_GUIDELINES.m
 - Include severity sections (Must Fix, Should Fix, Nit) that survived filtering, as clean bullet lists
 - Do NOT include the "Passed", "Summary", "Recommendations", or "Ready for PR?" sections
 
-Do not append any AI-attribution line to the review body (no "Generated with Claude" line, no emoji) — AI credit is via `Co-Authored-By` commit trailers only. See [GITHUB_GUIDELINES.md](../../../GITHUB_GUIDELINES.md).
+Do not append any AI-attribution line to the review body (no "Generated with Claude" line, no emoji) — AI credit is via `Co-Authored-By` commit trailers only. Before posting, verify the review body and inline comments against the [posting checklist](../_shared/POSTING_CHECKLIST.md). See [GITHUB_GUIDELINES.md](../../../GITHUB_GUIDELINES.md).
 
 **Inline comments** (the `comments` array):
 

--- a/.claude/skills/pr-summary/SKILL.md
+++ b/.claude/skills/pr-summary/SKILL.md
@@ -47,11 +47,13 @@ Generate a pull request summary based on branch changes.
 
 4. **Validate Format**
 
-   Before presenting the create command, check `pr_summary.md` against
-   `.github/PULL_REQUEST_TEMPLATE.md`. A PR body is a **GitHub-only
-   artifact** — it never enters git history, so unlike commit messages it is
-   not caught by code review. This step is that missing gate. Reject and
-   rewrite the summary if any of these fail:
+   Before presenting the create command, run `pr_summary.md` through the
+   [posting checklist](../_shared/POSTING_CHECKLIST.md) (mechanical + tone),
+   then check it against `.github/PULL_REQUEST_TEMPLATE.md`. A PR body is a
+   **GitHub-only artifact** — it never enters git history, so unlike commit
+   messages it is not caught by code review, and it posts via `gh` so no hook
+   reminder fires. This step is that missing gate. Reject and rewrite the
+   summary if any of these fail:
 
    - **First line** is a single-sentence TL;DR (what + why), not a heading
    - **Details paragraph** follows it, covering what changed and key areas

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -141,8 +141,7 @@ After confirmation, in this order:
   their real numbers exist before the reply references them. Substitute the
   `#NEW`/`#NEW2` placeholders in the draft reply (and in `triage.md`) with the
   assigned numbers.
-- Post the reply (`mcp__github__add_issue_comment`; for discussions, the
-  `addDiscussionComment` GraphQL mutation with the discussion `id`)
+- Verify the reply against the [posting checklist](../_shared/POSTING_CHECKLIST.md), then post it (`mcp__github__add_issue_comment`; for discussions, the `addDiscussionComment` GraphQL mutation with the discussion `id` — discussions post via `gh api`, so no hook reminder fires there)
 - Apply labels / close via `mcp__github__update_issue` as decided
   (duplicates: close with `state_reason: "not_planned"` after the reply
   links the original)

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -160,7 +160,7 @@ func performDelete(branchType, name, fullBranchName string, branchConfig config.
 
 	// Clean up base branch configuration
 	configKey := fmt.Sprintf("gitflow.branch.%s.base", fullBranchName)
-	if err := git.UnsetConfig(configKey); err != nil {
+	if err := git.UnsetConfigIfPresent(configKey); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: Failed to clean up base config: %v\n", err)
 	}
 

--- a/cmd/finish.go
+++ b/cmd/finish.go
@@ -773,7 +773,7 @@ func handleDeleteBranchStep(cfg *config.Config, state *mergestate.MergeState, re
 	// Clean up base branch configuration if branch was deleted
 	if !keepLocal {
 		configKey := fmt.Sprintf("gitflow.branch.%s.base", state.FullBranchName)
-		if err := git.UnsetConfig(configKey); err != nil {
+		if err := git.UnsetConfigIfPresent(configKey); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: Failed to clean up base config: %v\n", err)
 		}
 	}

--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -135,15 +135,20 @@ func UnsetConfig(key string) error {
 }
 
 // UnsetConfigIfPresent unsets a Git config value, treating a confirmed-absent
-// key as a no-op. A key that is not set (git config --get exits 1) returns nil
-// silently. Any other failure — including a multi-value key that plain --unset
-// refuses (exit 5) or a genuine read/write error — is surfaced as an error.
+// key as a no-op. A key that is not set in local config (git config --local
+// --get exits 1) returns nil silently. Any other failure — including a
+// multi-value key that plain --unset refuses (exit 5) or a genuine read/write
+// error — is surfaced as an error.
 func UnsetConfigIfPresent(key string) error {
-	// Detect absence precisely: `git config --get` exits 1 when the key is
-	// absent. Do NOT match on --unset exit 5, which also means "multi-value".
-	err := exec.Command("git", "config", "--get", key).Run()
+	// Detect absence precisely and in the scope that gets cleaned: `git config
+	// --local --get` exits 1 when the key is absent from local config. UnsetConfig
+	// below unsets local only, so probing merged config (local+global+system)
+	// would wrongly treat a global/system-only value as present and fall through
+	// to a local --unset that finds nothing and errors. Do NOT match on --unset
+	// exit 5, which also means "multi-value".
+	err := exec.Command("git", "config", "--local", "--get", key).Run()
 	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
-		return nil // key not present: nothing to clean up
+		return nil // key not present in local config: nothing to clean up
 	}
 	// Present, multi-value, or read error: attempt the unset so real
 	// failures (multi-value, read-only) still surface to the caller.

--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -134,6 +134,22 @@ func UnsetConfig(key string) error {
 	return nil
 }
 
+// UnsetConfigIfPresent unsets a Git config value, treating a confirmed-absent
+// key as a no-op. A key that is not set (git config --get exits 1) returns nil
+// silently. Any other failure — including a multi-value key that plain --unset
+// refuses (exit 5) or a genuine read/write error — is surfaced as an error.
+func UnsetConfigIfPresent(key string) error {
+	// Detect absence precisely: `git config --get` exits 1 when the key is
+	// absent. Do NOT match on --unset exit 5, which also means "multi-value".
+	err := exec.Command("git", "config", "--get", key).Run()
+	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+		return nil // key not present: nothing to clean up
+	}
+	// Present, multi-value, or read error: attempt the unset so real
+	// failures (multi-value, read-only) still surface to the caller.
+	return UnsetConfig(key)
+}
+
 // GetConfigWithScope gets a Git config value at a specific scope.
 // For ConfigScopeDefault, reads merged config (git's standard behavior).
 // For specific scopes, reads only from that scope.

--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -134,15 +134,15 @@ func UnsetConfig(key string) error {
 	return nil
 }
 
-// UnsetConfigIfPresent unsets a Git config value, treating a confirmed-absent
-// key as a no-op. A key that is not set in local config (git config --local
-// --get exits 1) returns nil silently. Any other failure — including a
-// multi-value key that plain --unset refuses (exit 5) or a genuine read/write
-// error — is surfaced as an error.
+// UnsetConfigIfPresent unsets a Git config value in local config, treating a
+// confirmed-absent key as a no-op. A key that is not set in local config (git
+// config --local --get exits 1) returns nil silently. Any other failure —
+// including a multi-value key that --unset refuses (exit 5) or a genuine
+// read/write error — is surfaced as an error.
 func UnsetConfigIfPresent(key string) error {
 	// Detect absence precisely and in the scope that gets cleaned: `git config
-	// --local --get` exits 1 when the key is absent from local config. UnsetConfig
-	// below unsets local only, so probing merged config (local+global+system)
+	// --local --get` exits 1 when the key is absent from local config. The unset
+	// below is local-scoped too, so probing merged config (local+global+system)
 	// would wrongly treat a global/system-only value as present and fall through
 	// to a local --unset that finds nothing and errors. Do NOT match on --unset
 	// exit 5, which also means "multi-value".
@@ -150,9 +150,9 @@ func UnsetConfigIfPresent(key string) error {
 	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
 		return nil // key not present in local config: nothing to clean up
 	}
-	// Present, multi-value, or read error: attempt the unset so real
-	// failures (multi-value, read-only) still surface to the caller.
-	return UnsetConfig(key)
+	// Present, multi-value, or read error: attempt the unset in the same local
+	// scope we probed so real failures (multi-value, read-only) still surface.
+	return UnsetConfigWithScope(key, ConfigScopeLocal, "")
 }
 
 // GetConfigWithScope gets a Git config value at a specific scope.

--- a/test/cmd/delete_test.go
+++ b/test/cmd/delete_test.go
@@ -880,3 +880,103 @@ func TestDeleteFeatureBranchRemoteNoRemoteError(t *testing.T) {
 		t.Error("Expected feature/test-feature branch to still exist after failed delete --remote")
 	}
 }
+
+// TestDeleteWithMissingBaseConfigNoWarning tests that deleting a feature branch
+// whose base config was never stored locally (a collaborator checked out a
+// published branch instead of starting it) does not print a spurious base-config
+// cleanup warning.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Creates a feature branch (which stores base config)
+// 3. Removes the base config to simulate a checked-out (not started) branch
+// 4. Deletes the feature branch
+// 5. Verifies no cleanup warning is printed and the branch is deleted
+func TestDeleteWithMissingBaseConfigNoWarning(t *testing.T) {
+	// Setup
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// Initialize git-flow with defaults
+	output, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+
+	// Create feature branch (stores base config)
+	output, err = testutil.RunGitFlow(t, dir, "feature", "start", "missing-base")
+	if err != nil {
+		t.Fatalf("Failed to start feature branch: %v\nOutput: %s", err, output)
+	}
+
+	// Remove the base config to simulate a checked-out (not started) branch
+	_, err = testutil.RunGit(t, dir, "config", "--unset", "gitflow.branch.feature/missing-base.base")
+	if err != nil {
+		t.Fatalf("Failed to unset base config: %v", err)
+	}
+
+	// Delete the feature branch
+	output, err = testutil.RunGitFlow(t, dir, "feature", "delete", "missing-base")
+	if err != nil {
+		t.Fatalf("Failed to delete feature branch: %v\nOutput: %s", err, output)
+	}
+
+	// Verify no spurious cleanup warning was printed
+	if strings.Contains(output, "Warning: Failed to clean up base config") {
+		t.Errorf("Expected no base-config cleanup warning, but got:\n%s", output)
+	}
+
+	// Verify branch is deleted
+	if testutil.BranchExists(t, dir, "feature/missing-base") {
+		t.Error("Expected feature branch to be deleted")
+	}
+}
+
+// TestDeleteWithMultiValueBaseConfigWarns tests that deleting a feature branch
+// whose base config key holds multiple values still prints the cleanup warning,
+// because a multi-value key is a genuine failure that --unset cannot resolve and
+// must not be silently swallowed like a missing key.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Creates a feature branch (which stores base config)
+// 3. Adds a second value to the base config key
+// 4. Deletes the feature branch
+// 5. Verifies the cleanup warning is printed and the branch is still deleted
+func TestDeleteWithMultiValueBaseConfigWarns(t *testing.T) {
+	// Setup
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// Initialize git-flow with defaults
+	output, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+
+	// Create feature branch (stores base config)
+	output, err = testutil.RunGitFlow(t, dir, "feature", "start", "multi-base")
+	if err != nil {
+		t.Fatalf("Failed to start feature branch: %v\nOutput: %s", err, output)
+	}
+
+	// Add a second value so the key becomes multi-value
+	_, err = testutil.RunGit(t, dir, "config", "--add", "gitflow.branch.feature/multi-base.base", "other-base")
+	if err != nil {
+		t.Fatalf("Failed to add second base config value: %v", err)
+	}
+
+	// Delete the feature branch
+	output, err = testutil.RunGitFlow(t, dir, "feature", "delete", "multi-base")
+	if err != nil {
+		t.Fatalf("Failed to delete feature branch: %v\nOutput: %s", err, output)
+	}
+
+	// Verify the cleanup warning is still printed for a genuine failure
+	if !strings.Contains(output, "Warning: Failed to clean up base config") {
+		t.Errorf("Expected base-config cleanup warning for multi-value key, but got:\n%s", output)
+	}
+
+	// Verify branch is still deleted (warning is non-fatal)
+	if testutil.BranchExists(t, dir, "feature/multi-base") {
+		t.Error("Expected feature branch to be deleted")
+	}
+}

--- a/test/cmd/delete_test.go
+++ b/test/cmd/delete_test.go
@@ -1,6 +1,7 @@
 package cmd_test
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -977,6 +978,71 @@ func TestDeleteWithMultiValueBaseConfigWarns(t *testing.T) {
 
 	// Verify branch is still deleted (warning is non-fatal)
 	if testutil.BranchExists(t, dir, "feature/multi-base") {
+		t.Error("Expected feature branch to be deleted")
+	}
+}
+
+// TestDeleteWithBaseConfigInNonLocalScopeNoWarning tests that deleting a feature
+// branch whose base config key is absent from local config but present only in a
+// non-local scope (global) does not print a spurious cleanup warning. The
+// presence probe must be scoped to local config — the same scope the unset
+// operates on — so a global-only value is not mistaken for a local key that then
+// fails to unset.
+// Steps:
+// 1. Isolates the global config to a temp file so the real global config is untouched
+// 2. Sets up a test repository and initializes git-flow with defaults
+// 3. Creates a feature branch (which stores the base config locally)
+// 4. Unsets the local base key to simulate a branch not started locally
+// 5. Adds the base key to the global scope only
+// 6. Deletes the feature branch
+// 7. Verifies no cleanup warning is printed and the branch is deleted
+func TestDeleteWithBaseConfigInNonLocalScopeNoWarning(t *testing.T) {
+	// Isolate the global config to a temp file so nothing touches the
+	// developer's real global config. RunGit/RunGitFlow exec inheriting
+	// os.Environ(), so the subprocess sees this override.
+	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(t.TempDir(), "global-gitconfig"))
+
+	// Setup
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// Initialize git-flow with defaults
+	output, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+
+	// Create feature branch (stores base config locally)
+	output, err = testutil.RunGitFlow(t, dir, "feature", "start", "scoped-base")
+	if err != nil {
+		t.Fatalf("Failed to start feature branch: %v\nOutput: %s", err, output)
+	}
+
+	// Remove the local base key to simulate a branch not started locally
+	_, err = testutil.RunGit(t, dir, "config", "--local", "--unset", "gitflow.branch.feature/scoped-base.base")
+	if err != nil {
+		t.Fatalf("Failed to unset local base config: %v", err)
+	}
+
+	// Add the base key to the global scope only (lands in the isolated GIT_CONFIG_GLOBAL file)
+	_, err = testutil.RunGit(t, dir, "config", "--global", "--add", "gitflow.branch.feature/scoped-base.base", "develop")
+	if err != nil {
+		t.Fatalf("Failed to add global base config: %v", err)
+	}
+
+	// Delete the feature branch
+	output, err = testutil.RunGitFlow(t, dir, "feature", "delete", "scoped-base")
+	if err != nil {
+		t.Fatalf("Failed to delete feature branch: %v\nOutput: %s", err, output)
+	}
+
+	// Verify no spurious cleanup warning was printed
+	if strings.Contains(output, "Warning: Failed to clean up base config") {
+		t.Errorf("Expected no base-config cleanup warning, but got:\n%s", output)
+	}
+
+	// Verify branch is deleted
+	if testutil.BranchExists(t, dir, "feature/scoped-base") {
 		t.Error("Expected feature branch to be deleted")
 	}
 }

--- a/test/cmd/finish_test.go
+++ b/test/cmd/finish_test.go
@@ -1362,3 +1362,199 @@ func TestFinishCleansUpBaseBranch(t *testing.T) {
 		t.Error("Expected feature branch to be deleted after finish")
 	}
 }
+
+// TestFinishWithMissingBaseConfigNoWarning tests that finishing a feature branch
+// whose base config was never stored locally (a collaborator checked out a
+// published branch instead of starting it) does not print a spurious base-config
+// cleanup warning, and that the merge itself still happens.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Creates a feature branch and adds a commit
+// 3. Removes the base config to simulate a checked-out (not started) branch
+// 4. Finishes the feature branch
+// 5. Verifies no cleanup warning is printed, the branch is deleted, and the
+//    commit was merged into develop
+func TestFinishWithMissingBaseConfigNoWarning(t *testing.T) {
+	// Setup
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// Initialize git-flow with defaults
+	output, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+
+	// Create feature branch (stores base config)
+	output, err = testutil.RunGitFlow(t, dir, "feature", "start", "missing-base")
+	if err != nil {
+		t.Fatalf("Failed to start feature branch: %v\nOutput: %s", err, output)
+	}
+
+	// Add a commit on the feature branch
+	if err := testutil.WriteFile(t, dir, "missing-base.txt", "feature content"); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+	_, err = testutil.RunGit(t, dir, "add", "missing-base.txt")
+	if err != nil {
+		t.Fatalf("Failed to add file: %v", err)
+	}
+	_, err = testutil.RunGit(t, dir, "commit", "-m", "Add missing-base test file")
+	if err != nil {
+		t.Fatalf("Failed to commit file: %v", err)
+	}
+
+	// Remove the base config to simulate a checked-out (not started) branch
+	_, err = testutil.RunGit(t, dir, "config", "--unset", "gitflow.branch.feature/missing-base.base")
+	if err != nil {
+		t.Fatalf("Failed to unset base config: %v", err)
+	}
+
+	// Finish the feature branch
+	output, err = testutil.RunGitFlow(t, dir, "feature", "finish", "missing-base")
+	if err != nil {
+		t.Fatalf("Failed to finish feature branch: %v\nOutput: %s", err, output)
+	}
+
+	// Verify no spurious cleanup warning was printed
+	if strings.Contains(output, "Warning: Failed to clean up base config") {
+		t.Errorf("Expected no base-config cleanup warning, but got:\n%s", output)
+	}
+
+	// Verify branch is deleted
+	if testutil.BranchExists(t, dir, "feature/missing-base") {
+		t.Error("Expected feature branch to be deleted after finish")
+	}
+
+	// Verify the finish actually merged the commit into develop
+	_, err = testutil.RunGit(t, dir, "checkout", "develop")
+	if err != nil {
+		t.Fatalf("Failed to checkout develop: %v", err)
+	}
+	content := testutil.ReadFile(t, dir, "missing-base.txt")
+	if content != "feature content" {
+		t.Errorf("Expected missing-base.txt to be merged into develop, got content '%s'", content)
+	}
+}
+
+// TestFinishKeepLocalPreservesBaseConfig tests that finishing a feature branch
+// with --keeplocal skips base-config cleanup entirely, leaving both the local
+// branch and its base config untouched.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Creates a feature branch and adds a commit
+// 3. Finishes the feature branch with --keeplocal
+// 4. Verifies the local branch is kept and the base config is preserved
+func TestFinishKeepLocalPreservesBaseConfig(t *testing.T) {
+	// Setup
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// Initialize git-flow with defaults
+	output, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+
+	// Create feature branch (stores base config)
+	output, err = testutil.RunGitFlow(t, dir, "feature", "start", "keeplocal-base")
+	if err != nil {
+		t.Fatalf("Failed to start feature branch: %v\nOutput: %s", err, output)
+	}
+
+	// Add a commit on the feature branch
+	if err := testutil.WriteFile(t, dir, "keeplocal.txt", "feature content"); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+	_, err = testutil.RunGit(t, dir, "add", "keeplocal.txt")
+	if err != nil {
+		t.Fatalf("Failed to add file: %v", err)
+	}
+	_, err = testutil.RunGit(t, dir, "commit", "-m", "Add keeplocal test file")
+	if err != nil {
+		t.Fatalf("Failed to commit file: %v", err)
+	}
+
+	// Finish the feature branch with --keeplocal
+	output, err = testutil.RunGitFlow(t, dir, "feature", "finish", "keeplocal-base", "--keeplocal")
+	if err != nil {
+		t.Fatalf("Failed to finish feature branch: %v\nOutput: %s", err, output)
+	}
+
+	// Verify the local branch is kept
+	if !testutil.BranchExists(t, dir, "feature/keeplocal-base") {
+		t.Error("Expected feature branch to be kept with --keeplocal")
+	}
+
+	// Verify the base config is preserved (cleanup block skipped entirely)
+	value, err := testutil.RunGit(t, dir, "config", "--get", "gitflow.branch.feature/keeplocal-base.base")
+	if err != nil {
+		t.Errorf("Expected base config to be preserved with --keeplocal, but --get failed: %v", err)
+	}
+	if strings.TrimSpace(value) == "" {
+		t.Errorf("Expected base config to hold a value, got empty")
+	}
+}
+
+// TestFinishWithMultiValueBaseConfigWarns tests that finishing a feature branch
+// whose base config key holds multiple values still prints the cleanup warning.
+// The finish call site warns through a code path independent of delete, so the
+// "genuine failure still warns" contract is guarded here separately.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Creates a feature branch and adds a commit
+// 3. Adds a second value to the base config key
+// 4. Finishes the feature branch
+// 5. Verifies the cleanup warning is printed and the branch is still finished
+func TestFinishWithMultiValueBaseConfigWarns(t *testing.T) {
+	// Setup
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// Initialize git-flow with defaults
+	output, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+
+	// Create feature branch (stores base config)
+	output, err = testutil.RunGitFlow(t, dir, "feature", "start", "multi-base")
+	if err != nil {
+		t.Fatalf("Failed to start feature branch: %v\nOutput: %s", err, output)
+	}
+
+	// Add a commit on the feature branch
+	if err := testutil.WriteFile(t, dir, "multi-base.txt", "feature content"); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+	_, err = testutil.RunGit(t, dir, "add", "multi-base.txt")
+	if err != nil {
+		t.Fatalf("Failed to add file: %v", err)
+	}
+	_, err = testutil.RunGit(t, dir, "commit", "-m", "Add multi-base test file")
+	if err != nil {
+		t.Fatalf("Failed to commit file: %v", err)
+	}
+
+	// Add a second value so the key becomes multi-value
+	_, err = testutil.RunGit(t, dir, "config", "--add", "gitflow.branch.feature/multi-base.base", "other-base")
+	if err != nil {
+		t.Fatalf("Failed to add second base config value: %v", err)
+	}
+
+	// Finish the feature branch
+	output, err = testutil.RunGitFlow(t, dir, "feature", "finish", "multi-base")
+	if err != nil {
+		t.Fatalf("Failed to finish feature branch: %v\nOutput: %s", err, output)
+	}
+
+	// Verify the cleanup warning is still printed for a genuine failure
+	if !strings.Contains(output, "Warning: Failed to clean up base config") {
+		t.Errorf("Expected base-config cleanup warning for multi-value key, but got:\n%s", output)
+	}
+
+	// Verify branch is still finished and deleted (warning is non-fatal)
+	if testutil.BranchExists(t, dir, "feature/multi-base") {
+		t.Error("Expected feature branch to be deleted after finish")
+	}
+}

--- a/test/cmd/finish_test.go
+++ b/test/cmd/finish_test.go
@@ -1368,12 +1368,12 @@ func TestFinishCleansUpBaseBranch(t *testing.T) {
 // published branch instead of starting it) does not print a spurious base-config
 // cleanup warning, and that the merge itself still happens.
 // Steps:
-// 1. Sets up a test repository and initializes git-flow with defaults
-// 2. Creates a feature branch and adds a commit
-// 3. Removes the base config to simulate a checked-out (not started) branch
-// 4. Finishes the feature branch
-// 5. Verifies no cleanup warning is printed, the branch is deleted, and the
-//    commit was merged into develop
+//  1. Sets up a test repository and initializes git-flow with defaults
+//  2. Creates a feature branch and adds a commit
+//  3. Removes the base config to simulate a checked-out (not started) branch
+//  4. Finishes the feature branch
+//  5. Verifies no cleanup warning is printed, the branch is deleted, and the
+//     commit was merged into develop
 func TestFinishWithMissingBaseConfigNoWarning(t *testing.T) {
 	// Setup
 	dir := testutil.SetupTestRepo(t)


### PR DESCRIPTION
Stops `feature delete` and `feature finish` from printing a spurious `Warning: Failed to clean up base config` when the per-branch base key was never stored locally.

The `gitflow.branch.<name>.base` key is written to local config by `feature start`, but it is never shared when a branch is published — a collaborator who checks out a published branch (instead of starting it) has no such key. The cleanup step previously ran `git config --unset` unconditionally, which exits non-zero on an absent key and surfaced as a warning. This adds a `git.UnsetConfigIfPresent` helper that treats a confirmed-absent local key as a silent no-op while still surfacing genuine failures (multi-value keys that `--unset` refuses, read/write errors). Both cleanup call sites in `cmd/delete.go` and `cmd/finish.go` switch to it; `UnsetConfig` (used by `ClearConfig`) is left unchanged. Changes touch `internal/git/config.go`, `cmd/delete.go`, and `cmd/finish.go`.

Resolves #133

## Remarks

- The presence probe uses `git config --local --get`, matching the local scope that `--unset` actually cleans. A key present only in global/system config no longer produces a spurious warning (it is absent from the scope being cleaned).
- Genuine failures still warn: a multi-value key is present, so the helper falls through to `--unset`, which fails and reports as before.
- No docs changes — no command, flag, or config surface changed; the behavior only becomes quieter.

**Review focus:**
- `internal/git/config.go` — `UnsetConfigIfPresent`: exit-1-from-`--local --get` is the absence signal; everything else falls through to `UnsetConfig`
- `test/cmd/delete_test.go`, `test/cmd/finish_test.go` — 5 scenario tests + 1 non-local-scope regression test, alongside 2 pre-existing cleanup regression guards