### PR TITLE
fix(init): Fail fast when git identity is missing

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -228,6 +228,25 @@ func initFlow(useDefaults, createBranches, force bool, preset string, custom boo
 		cfg = config.ApplyOverrides(cfg, overrides)
 	}
 
+	// Fail fast if an initial commit would be created but no git identity is
+	// configured — otherwise `git commit --allow-empty` fails with exit 128
+	// after config/marker have already been written (see issue #131).
+	if createBranches {
+		hasCommits, err := git.HasCommits()
+		if err != nil {
+			return &errors.GitError{Operation: "check repository commits", Err: err}
+		}
+		if !hasCommits {
+			ok, err := git.HasUserIdentity()
+			if err != nil {
+				return &errors.GitError{Operation: "check git user identity", Err: err}
+			}
+			if !ok {
+				return &errors.MissingUserIdentityError{}
+			}
+		}
+	}
+
 	// Save configuration with the appropriate scope
 	if err := config.SaveConfigWithScope(cfg, scope, scopeFile); err != nil {
 		return &errors.GitError{Operation: "save configuration", Err: err}

--- a/docs/git-flow-init.1.md
+++ b/docs/git-flow-init.1.md
@@ -261,6 +261,9 @@ By default, git-flow stores configuration in the repository's **.git/config** fi
 **3**
 : Invalid preset or configuration options
 
+**6**
+: A required precondition failed — for example, the repository has no commits and branch creation is requested but no git identity (**user.name** and **user.email**) is configured
+
 ## SEE ALSO
 
 **git-flow**(1), **git-flow-config**(1), **gitflow-config**(5)
@@ -271,6 +274,7 @@ By default, git-flow stores configuration in the repository's **.git/config** fi
 - In interactive mode without **--force**, users are prompted for confirmation before reconfiguring
 - Existing branches are preserved during initialization
 - When initializing a repository with no existing commits, **git-flow init** creates an empty initial commit to enable branch creation. No files are added to the working directory
+- Creating that initial commit requires a configured git identity. When the repository has no commits and branch creation is requested, **git-flow init** verifies that both **user.name** and **user.email** are set (in local, global, or system config) before writing any configuration. If the identity is missing, init fails fast with an actionable error (exit status **6**) and leaves the repository untouched, so it can be re-run after configuring the identity. Repositories that already have commits, or runs with **--no-create-branches**, do not require an identity
 - Compatible with repositories previously initialized with git-flow-avh
 - Configuration scope options (**--local**, **--global**, **--system**, **--file**) only affect the **init** command. All other git-flow commands (start, finish, update, etc.) always read from merged config using Git's standard precedence (local > global > system)
 - When checking initialization status without an explicit scope flag, git-flow checks merged config and reports which scope the configuration was found in

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -311,3 +311,16 @@ func (e *AlreadyInitializedError) Error() string {
 func (e *AlreadyInitializedError) ExitCode() ExitCode {
 	return ExitCodeValidationError
 }
+
+// MissingUserIdentityError indicates git user.name/user.email are not configured
+type MissingUserIdentityError struct{}
+
+func (e *MissingUserIdentityError) Error() string {
+	return "git user identity is not configured. Set it before running git flow init:\n" +
+		"  git config --global user.name \"Your Name\"\n" +
+		"  git config --global user.email \"you@example.com\""
+}
+
+func (e *MissingUserIdentityError) ExitCode() ExitCode {
+	return ExitCodeValidationError
+}

--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -32,6 +32,40 @@ func GetConfig(key string) (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
+// HasUserIdentity reports whether both user.name and user.email are configured
+// and non-empty in git's merged/effective config (local > global > system),
+// matching what `git commit` would see. It returns false without error when a
+// key is simply unset (git config --get exits with status 1), and propagates
+// any other failure (e.g. not in a repository) to the caller.
+func HasUserIdentity() (bool, error) {
+	for _, key := range []string{"user.name", "user.email"} {
+		value, found, err := readConfigValue(key)
+		if err != nil {
+			return false, err
+		}
+		if !found || strings.TrimSpace(value) == "" {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// readConfigValue reads a single git config value from the merged/effective
+// scope. It distinguishes an unset key (git config --get exits with status 1)
+// from an unexpected failure: an unset key returns ("", false, nil), while any
+// other error is returned to the caller.
+func readConfigValue(key string) (value string, found bool, err error) {
+	cmd := exec.Command("git", "config", "--get", key)
+	output, runErr := cmd.Output()
+	if runErr != nil {
+		if exitErr, ok := runErr.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("failed to get git config %s: %w", key, runErr)
+	}
+	return strings.TrimSpace(string(output)), true, nil
+}
+
 // GetConfigAllValues gets all values for a multi-value Git config key
 func GetConfigAllValues(key string) ([]string, error) {
 	return GetConfigAllValuesInDir("", key)

--- a/test/cmd/init_test.go
+++ b/test/cmd/init_test.go
@@ -1241,7 +1241,7 @@ func TestInitEmptyRepoDoesNotCreateReadme(t *testing.T) {
 	}
 }
 
-// setupPlainRepo creates a bare git repository with no commits and no
+// setupPlainRepo creates a plain git repository with no commits and no
 // configured identity. Unlike testutil.SetupEmptyTestRepo it does NOT set
 // user.name/user.email, so it is suitable for the identity-precondition tests.
 func setupPlainRepo(t *testing.T) string {
@@ -1257,7 +1257,7 @@ func setupPlainRepo(t *testing.T) string {
 // ambient global/system configuration (including a developer's ~/.gitconfig
 // identity), so identity tests observe only what the repo itself configures.
 func isolatedConfigEnv() []string {
-	return []string{"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null"}
+	return []string{"GIT_CONFIG_GLOBAL=" + os.DevNull, "GIT_CONFIG_SYSTEM=" + os.DevNull}
 }
 
 // exitCodeOf extracts the process exit code from the error returned by
@@ -1454,7 +1454,7 @@ func TestInitSucceedsWithIdentityOnFreshRepo(t *testing.T) {
 	if _, err := testutil.RunGit(t, dir, "config", "--file", globalConfigFile, "user.email", "a@b.c"); err != nil {
 		t.Fatalf("Failed to seed global user.email: %v", err)
 	}
-	env := []string{"GIT_CONFIG_GLOBAL=" + globalConfigFile, "GIT_CONFIG_SYSTEM=/dev/null"}
+	env := []string{"GIT_CONFIG_GLOBAL=" + globalConfigFile, "GIT_CONFIG_SYSTEM=" + os.DevNull}
 
 	output, err := runGitFlowWithEnv(t, dir, env, "init", "--defaults")
 	if err != nil {

--- a/test/cmd/init_test.go
+++ b/test/cmd/init_test.go
@@ -1329,14 +1329,14 @@ func TestInitFailsWithoutIdentityShowsActionableError(t *testing.T) {
 // identity) writes no git-flow config or branches, so a second run behaves
 // identically instead of wrongly reporting 'already configured'.
 // Steps:
-// 1. Creates a plain repo with no commits and no identity (setupPlainRepo)
-// 2. Runs 'git flow init --preset gitlab' with isolated config (first run)
-// 3. Verifies the first run fails with exit code 6 for the identity reason
-// 4. Verifies no gitflow.* local config exists after the failed run
-// 5. Verifies no base branches (main, develop, production, staging) exist
-// 6. Runs 'git flow init --preset gitlab' again (second run)
-// 7. Verifies the second run also fails with exit code 6 and the same message,
-//    and never reports 'already initialized'/'already configured'
+//  1. Creates a plain repo with no commits and no identity (setupPlainRepo)
+//  2. Runs 'git flow init --preset gitlab' with isolated config (first run)
+//  3. Verifies the first run fails with exit code 6 for the identity reason
+//  4. Verifies no gitflow.* local config exists after the failed run
+//  5. Verifies no base branches (main, develop, production, staging) exist
+//  6. Runs 'git flow init --preset gitlab' again (second run)
+//  7. Verifies the second run also fails with exit code 6 and the same message,
+//     and never reports 'already initialized'/'already configured'
 func TestInitWithoutIdentityLeavesNoState(t *testing.T) {
 	dir := setupPlainRepo(t)
 	env := isolatedConfigEnv()

--- a/test/cmd/init_test.go
+++ b/test/cmd/init_test.go
@@ -1240,3 +1240,345 @@ func TestInitEmptyRepoDoesNotCreateReadme(t *testing.T) {
 		t.Error("Expected no README.md file in working directory, but it exists")
 	}
 }
+
+// setupPlainRepo creates a bare git repository with no commits and no
+// configured identity. Unlike testutil.SetupEmptyTestRepo it does NOT set
+// user.name/user.email, so it is suitable for the identity-precondition tests.
+func setupPlainRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if _, err := testutil.RunGit(t, dir, "init", "--initial-branch=main"); err != nil {
+		t.Fatalf("Failed to initialize plain git repository: %v", err)
+	}
+	return dir
+}
+
+// isolatedConfigEnv returns environment variables that isolate git from any
+// ambient global/system configuration (including a developer's ~/.gitconfig
+// identity), so identity tests observe only what the repo itself configures.
+func isolatedConfigEnv() []string {
+	return []string{"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null"}
+}
+
+// exitCodeOf extracts the process exit code from the error returned by
+// runGitFlowWithEnv/runGitFlow (a raw *exec.ExitError). It fails the test if
+// err is nil or is not an *exec.ExitError.
+func exitCodeOf(t *testing.T, err error) int {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("Expected a non-nil error carrying an exit code, got nil")
+	}
+	if ee, ok := err.(*exec.ExitError); ok {
+		return ee.ExitCode()
+	}
+	t.Fatalf("Expected *exec.ExitError, got %T: %v", err, err)
+	return 0
+}
+
+// gitflowConfigKeysLocal returns the local gitflow.* config keys/values as a
+// raw string. An empty result means no gitflow.* config exists. The regex is
+// passed as a bare argv argument (no shell quoting) since RunGit uses
+// exec.Command directly.
+func gitflowConfigKeysLocal(t *testing.T, dir string) string {
+	t.Helper()
+	// A no-match exit (status 1) yields a non-nil error and empty output.
+	out, _ := testutil.RunGit(t, dir, "config", "--local", "--get-regexp", `^gitflow\.`)
+	return strings.TrimSpace(out)
+}
+
+// TestInitFailsWithoutIdentityShowsActionableError tests that git flow init on
+// a fresh repository with no configured identity fails fast with an actionable
+// error and exit code 6 instead of an opaque git failure.
+// Steps:
+// 1. Creates a plain repo with no commits and no identity (setupPlainRepo)
+// 2. Runs 'git flow init --preset gitlab' with isolated global/system config
+// 3. Verifies the command fails with exit code 6
+// 4. Verifies the output names both user.name and user.email
+// 5. Verifies the output shows both 'git config --global' suggested commands
+// 6. Verifies the output does NOT contain the opaque 'exit status 128'
+// 7. Verifies the output contains 'git user identity is not configured'
+func TestInitFailsWithoutIdentityShowsActionableError(t *testing.T) {
+	dir := setupPlainRepo(t)
+	env := isolatedConfigEnv()
+
+	output, err := runGitFlowWithEnv(t, dir, env, "init", "--preset", "gitlab")
+	if code := exitCodeOf(t, err); code != 6 {
+		t.Fatalf("Expected exit code 6, got %d\nOutput: %s", code, output)
+	}
+	if !strings.Contains(output, "user.name") {
+		t.Errorf("Expected output to mention 'user.name', got: %s", output)
+	}
+	if !strings.Contains(output, "user.email") {
+		t.Errorf("Expected output to mention 'user.email', got: %s", output)
+	}
+	if !strings.Contains(output, "git config --global user.name") {
+		t.Errorf("Expected output to contain 'git config --global user.name', got: %s", output)
+	}
+	if !strings.Contains(output, "git config --global user.email") {
+		t.Errorf("Expected output to contain 'git config --global user.email', got: %s", output)
+	}
+	if strings.Contains(output, "exit status 128") {
+		t.Errorf("Expected output to NOT contain 'exit status 128', got: %s", output)
+	}
+	if !strings.Contains(output, "git user identity is not configured") {
+		t.Errorf("Expected output to contain 'git user identity is not configured', got: %s", output)
+	}
+}
+
+// TestInitWithoutIdentityLeavesNoState tests that a failed init (missing
+// identity) writes no git-flow config or branches, so a second run behaves
+// identically instead of wrongly reporting 'already configured'.
+// Steps:
+// 1. Creates a plain repo with no commits and no identity (setupPlainRepo)
+// 2. Runs 'git flow init --preset gitlab' with isolated config (first run)
+// 3. Verifies the first run fails with exit code 6 for the identity reason
+// 4. Verifies no gitflow.* local config exists after the failed run
+// 5. Verifies no base branches (main, develop, production, staging) exist
+// 6. Runs 'git flow init --preset gitlab' again (second run)
+// 7. Verifies the second run also fails with exit code 6 and the same message,
+//    and never reports 'already initialized'/'already configured'
+func TestInitWithoutIdentityLeavesNoState(t *testing.T) {
+	dir := setupPlainRepo(t)
+	env := isolatedConfigEnv()
+
+	output1, err1 := runGitFlowWithEnv(t, dir, env, "init", "--preset", "gitlab")
+	if code := exitCodeOf(t, err1); code != 6 {
+		t.Fatalf("Expected first run to exit 6, got %d\nOutput: %s", code, output1)
+	}
+	if !strings.Contains(output1, "git user identity is not configured") {
+		t.Fatalf("Expected first run to fail for the identity reason, got: %s", output1)
+	}
+
+	// No gitflow.* config should have been written.
+	if keys := gitflowConfigKeysLocal(t, dir); keys != "" {
+		t.Errorf("Expected no gitflow.* local config after failed run, got: %s", keys)
+	}
+	for _, key := range []string{"gitflow.version", "gitflow.initialized"} {
+		if v := getGitConfigWithScope(t, dir, key, "local"); v != "" {
+			t.Errorf("Expected %s to be absent after failed run, got: %s", key, v)
+		}
+	}
+
+	// No base branches should have been created.
+	for _, branch := range []string{"main", "develop", "production", "staging"} {
+		if branchExists(t, dir, branch) {
+			t.Errorf("Expected branch %q to NOT exist after failed run", branch)
+		}
+	}
+
+	// Re-run must be identical in kind: another exit-6 identity error, never
+	// a spurious "already configured".
+	output2, err2 := runGitFlowWithEnv(t, dir, env, "init", "--preset", "gitlab")
+	if code := exitCodeOf(t, err2); code != 6 {
+		t.Fatalf("Expected second run to exit 6, got %d\nOutput: %s", code, output2)
+	}
+	if !strings.Contains(output2, "git user identity is not configured") {
+		t.Errorf("Expected second run to report the identity error, got: %s", output2)
+	}
+	if strings.Contains(output2, "already initialized") || strings.Contains(output2, "already configured") {
+		t.Errorf("Expected second run to NOT report 'already configured', got: %s", output2)
+	}
+}
+
+// TestInitFailsWithOnlyUserNameSet tests that init still fails when only
+// user.name is configured but user.email is missing.
+// Steps:
+// 1. Creates a plain repo with no commits (setupPlainRepo)
+// 2. Sets only local user.name (email left unset)
+// 3. Runs 'git flow init --defaults' with isolated global/system config
+// 4. Verifies the command fails with exit code 6
+// 5. Verifies the output mentions the missing user.email and the identity error
+func TestInitFailsWithOnlyUserNameSet(t *testing.T) {
+	dir := setupPlainRepo(t)
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "user.name", "A"); err != nil {
+		t.Fatalf("Failed to set local user.name: %v", err)
+	}
+	env := isolatedConfigEnv()
+
+	output, err := runGitFlowWithEnv(t, dir, env, "init", "--defaults")
+	if code := exitCodeOf(t, err); code != 6 {
+		t.Fatalf("Expected exit code 6, got %d\nOutput: %s", code, output)
+	}
+	if !strings.Contains(output, "user.email") {
+		t.Errorf("Expected output to mention 'user.email', got: %s", output)
+	}
+	if !strings.Contains(output, "git user identity is not configured") {
+		t.Errorf("Expected output to contain 'git user identity is not configured', got: %s", output)
+	}
+}
+
+// TestInitFailsWithOnlyUserEmailSet tests that init still fails when only
+// user.email is configured but user.name is missing.
+// Steps:
+// 1. Creates a plain repo with no commits (setupPlainRepo)
+// 2. Sets only local user.email (name left unset)
+// 3. Runs 'git flow init --defaults' with isolated global/system config
+// 4. Verifies the command fails with exit code 6
+// 5. Verifies the output mentions the missing user.name and the identity error
+func TestInitFailsWithOnlyUserEmailSet(t *testing.T) {
+	dir := setupPlainRepo(t)
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "user.email", "a@b.c"); err != nil {
+		t.Fatalf("Failed to set local user.email: %v", err)
+	}
+	env := isolatedConfigEnv()
+
+	output, err := runGitFlowWithEnv(t, dir, env, "init", "--defaults")
+	if code := exitCodeOf(t, err); code != 6 {
+		t.Fatalf("Expected exit code 6, got %d\nOutput: %s", code, output)
+	}
+	if !strings.Contains(output, "user.name") {
+		t.Errorf("Expected output to mention 'user.name', got: %s", output)
+	}
+	if !strings.Contains(output, "git user identity is not configured") {
+		t.Errorf("Expected output to contain 'git user identity is not configured', got: %s", output)
+	}
+}
+
+// TestInitSucceedsWithIdentityOnFreshRepo tests that init on a fresh repo
+// succeeds when the identity is configured in the global scope (the common
+// ~/.gitconfig case), acting as a regression guard for the empty-repo path.
+// Steps:
+// 1. Creates a plain repo with no commits and no local identity (setupPlainRepo)
+// 2. Seeds a writable temp global config file with user.name and user.email
+// 3. Runs 'git flow init --defaults' with that global config and isolated system
+// 4. Verifies the command succeeds
+// 5. Verifies main and develop base branches were created
+// 6. Verifies the repo is marked initialized (gitflow.initialized/version)
+func TestInitSucceedsWithIdentityOnFreshRepo(t *testing.T) {
+	dir := setupPlainRepo(t)
+
+	globalConfigFile := filepath.Join(t.TempDir(), "gitconfig-global")
+	if _, err := testutil.RunGit(t, dir, "config", "--file", globalConfigFile, "user.name", "A"); err != nil {
+		t.Fatalf("Failed to seed global user.name: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "--file", globalConfigFile, "user.email", "a@b.c"); err != nil {
+		t.Fatalf("Failed to seed global user.email: %v", err)
+	}
+	env := []string{"GIT_CONFIG_GLOBAL=" + globalConfigFile, "GIT_CONFIG_SYSTEM=/dev/null"}
+
+	output, err := runGitFlowWithEnv(t, dir, env, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Expected success, got error: %v\nOutput: %s", err, output)
+	}
+	if !branchExists(t, dir, "main") {
+		t.Error("Expected 'main' branch to exist")
+	}
+	if !branchExists(t, dir, "develop") {
+		t.Error("Expected 'develop' branch to exist")
+	}
+	if v := getGitConfigWithScope(t, dir, "gitflow.initialized", "local"); v != "true" {
+		t.Errorf("Expected gitflow.initialized to be 'true', got: %s", v)
+	}
+	if v := getGitConfigWithScope(t, dir, "gitflow.version", "local"); v != "1.0" {
+		t.Errorf("Expected gitflow.version to be '1.0', got: %s", v)
+	}
+}
+
+// TestInitSucceedsWithExistingCommitsWithoutIdentity tests that init succeeds
+// without an identity when the repo already has commits, since no initial
+// commit needs to be created.
+// Steps:
+// 1. Creates a plain repo (setupPlainRepo)
+// 2. Sets a temporary local identity, creates a commit, then unsets the identity
+// 3. Runs 'git flow init --defaults' with isolated global/system config
+// 4. Verifies the command succeeds (identity check is skipped when HasCommits)
+// 5. Verifies base branches exist and the repo is marked initialized
+func TestInitSucceedsWithExistingCommitsWithoutIdentity(t *testing.T) {
+	dir := setupPlainRepo(t)
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "user.name", "Temp"); err != nil {
+		t.Fatalf("Failed to set temp user.name: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "user.email", "temp@example.com"); err != nil {
+		t.Fatalf("Failed to set temp user.email: %v", err)
+	}
+	if err := testutil.WriteFile(t, dir, "README.md", "# Test"); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "add", "README.md"); err != nil {
+		t.Fatalf("Failed to git add: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Initial commit"); err != nil {
+		t.Fatalf("Failed to git commit: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "--unset", "user.name"); err != nil {
+		t.Fatalf("Failed to unset user.name: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "--unset", "user.email"); err != nil {
+		t.Fatalf("Failed to unset user.email: %v", err)
+	}
+	env := isolatedConfigEnv()
+
+	output, err := runGitFlowWithEnv(t, dir, env, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Expected success with existing commits, got error: %v\nOutput: %s", err, output)
+	}
+	if !branchExists(t, dir, "main") {
+		t.Error("Expected 'main' branch to exist")
+	}
+	if !branchExists(t, dir, "develop") {
+		t.Error("Expected 'develop' branch to exist")
+	}
+	if v := getGitConfigWithScope(t, dir, "gitflow.initialized", "local"); v != "true" {
+		t.Errorf("Expected gitflow.initialized to be 'true', got: %s", v)
+	}
+}
+
+// TestInitSucceedsWithLocalIdentityOnly tests that a local identity satisfies
+// the precondition even when the global/system scopes are isolated (empty).
+// Steps:
+// 1. Creates a plain repo with no commits (setupPlainRepo)
+// 2. Sets local user.name and user.email
+// 3. Runs 'git flow init --defaults' with isolated global/system config
+// 4. Verifies the command succeeds (merged-scope identity read sees the local)
+// 5. Verifies base branches exist and the repo is marked initialized
+func TestInitSucceedsWithLocalIdentityOnly(t *testing.T) {
+	dir := setupPlainRepo(t)
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "user.name", "Local User"); err != nil {
+		t.Fatalf("Failed to set local user.name: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "user.email", "local@example.com"); err != nil {
+		t.Fatalf("Failed to set local user.email: %v", err)
+	}
+	env := isolatedConfigEnv()
+
+	output, err := runGitFlowWithEnv(t, dir, env, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Expected success with local identity, got error: %v\nOutput: %s", err, output)
+	}
+	if !branchExists(t, dir, "main") {
+		t.Error("Expected 'main' branch to exist")
+	}
+	if !branchExists(t, dir, "develop") {
+		t.Error("Expected 'develop' branch to exist")
+	}
+	if v := getGitConfigWithScope(t, dir, "gitflow.initialized", "local"); v != "true" {
+		t.Errorf("Expected gitflow.initialized to be 'true', got: %s", v)
+	}
+}
+
+// TestInitNoCreateBranchesSkipsIdentityCheck tests that --no-create-branches
+// skips the identity precondition, since no initial commit is created.
+// Steps:
+// 1. Creates a plain repo with no commits and no identity (setupPlainRepo)
+// 2. Runs 'git flow init --defaults --no-create-branches' with isolated config
+// 3. Verifies the command succeeds despite the missing identity
+// 4. Verifies no base branches (main, develop) were created
+// 5. Verifies configuration was still written (gitflow.version == '1.0')
+func TestInitNoCreateBranchesSkipsIdentityCheck(t *testing.T) {
+	dir := setupPlainRepo(t)
+	env := isolatedConfigEnv()
+
+	output, err := runGitFlowWithEnv(t, dir, env, "init", "--defaults", "--no-create-branches")
+	if err != nil {
+		t.Fatalf("Expected success with --no-create-branches, got error: %v\nOutput: %s", err, output)
+	}
+	if branchExists(t, dir, "main") {
+		t.Error("Expected 'main' branch to NOT exist")
+	}
+	if branchExists(t, dir, "develop") {
+		t.Error("Expected 'develop' branch to NOT exist")
+	}
+	if v := getGitConfigWithScope(t, dir, "gitflow.version", "local"); v != "1.0" {
+		t.Errorf("Expected gitflow.version to be '1.0', got: %s", v)
+	}
+}

--- a/test/cmd/init_test.go
+++ b/test/cmd/init_test.go
@@ -1582,3 +1582,37 @@ func TestInitNoCreateBranchesSkipsIdentityCheck(t *testing.T) {
 		t.Errorf("Expected gitflow.version to be '1.0', got: %s", v)
 	}
 }
+
+// TestInitWithEmptyIdentityValue tests that an explicitly-configured but
+// empty/whitespace-only identity value counts as "not configured", per the
+// spec's Technical Notes (an empty value must be treated the same as an unset
+// key). This exercises the whitespace branch that a key-not-found error alone
+// does not reach.
+// Steps:
+//  1. Creates a plain repo with no commits and no identity (setupPlainRepo)
+//  2. Sets local user.name to a whitespace-only value and user.email to a
+//     valid address, so failure is attributable to the empty name
+//  3. Runs 'git flow init --defaults' with isolated global/system config
+//  4. Verifies the command fails with exit code 6
+//  5. Verifies the output mentions user.name and the identity error
+func TestInitWithEmptyIdentityValue(t *testing.T) {
+	dir := setupPlainRepo(t)
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "user.name", "   "); err != nil {
+		t.Fatalf("Failed to set local whitespace user.name: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "user.email", "a@b.c"); err != nil {
+		t.Fatalf("Failed to set local user.email: %v", err)
+	}
+	env := isolatedConfigEnv()
+
+	output, err := runGitFlowWithEnv(t, dir, env, "init", "--defaults")
+	if code := exitCodeOf(t, err); code != 6 {
+		t.Fatalf("Expected exit code 6, got %d\nOutput: %s", code, output)
+	}
+	if !strings.Contains(output, "user.name") {
+		t.Errorf("Expected output to mention 'user.name', got: %s", output)
+	}
+	if !strings.Contains(output, "git user identity is not configured") {
+		t.Errorf("Expected output to contain 'git user identity is not configured', got: %s", output)
+	}
+}


### PR DESCRIPTION
Makes `git flow init` fail fast with an actionable error when the repository has no commits and no git identity is configured, instead of crashing deep in branch creation with a raw `exit status 128` after config has already been written.

On a fresh repository, `init` needs to create an empty initial commit to enable branch creation, which requires `user.name` and `user.email`. Previously the identity was never checked up front: config and the init marker were written first, then `git commit --allow-empty` failed with exit 128, leaving a half-initialized repo where a re-run wrongly reported "already configured". This adds a precondition check in `initFlow` (`cmd/init.go`), gated on the same condition that triggers the initial-commit path (`createBranches` and no existing commits), that runs before any mutation. A new `git.HasUserIdentity()` helper (`internal/git/config.go`) reads both keys from git's merged config so local/global/system precedence matches what `git commit` sees, treating an unset key or empty value as "not configured" while propagating other failures. When the identity is missing, init returns the new `MissingUserIdentityError` (`internal/errors/errors.go`) with exit code 6, naming both keys and showing the `git config --global` commands to run. The manpage (`docs/git-flow-init.1.md`) documents the precondition and the new exit code. Because the check precedes every write, the leftover-state problem is avoided entirely for this case.

Resolves #131

## Remarks

- The check is skipped when the repo already has commits or when `--no-create-branches` is used, since no initial commit is created in those paths.
- Both `user.name` and `user.email` are required; only one being set still fails.

**Review focus:**
- `internal/git/config.go` - `HasUserIdentity` / `readConfigValue`: distinguishing an unset key (exit 1) from a genuine error, and reading merged scope so a local-only identity is honored
- `cmd/init.go` - placement of the check before `SaveConfigWithScope`/`MarkRepoInitializedWithScope`