### PR TITLE
feat(start): Derive branch name from version filter

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -37,26 +37,32 @@ func start(branchType string, name string, base string, shouldFetch *bool) error
 		return &errors.NotInitializedError{}
 	}
 
-	// Validate inputs
-	if name == "" {
-		return &errors.EmptyBranchNameError{}
-	}
-
 	// Get git directory for hooks and filters
 	gitDir, err := git.GetGitDir()
 	if err != nil {
 		return &errors.GitError{Operation: "get git directory", Err: err}
 	}
 
-	// Apply version filter for any branch type
-	// The filter script (filter-flow-{branchType}-start-version) decides what to do
+	// Apply version filter for any branch type. The filter script
+	// (filter-flow-{branchType}-start-version) decides what to do; when no name
+	// was provided, it runs with an empty version argument and may supply one.
 	filteredName, err := hooks.RunVersionFilter(gitDir, branchType, name)
 	if err != nil {
 		return &errors.GitError{Operation: "run version filter", Err: err}
 	}
 	if filteredName != name {
-		fmt.Printf("Version filter changed '%s' to '%s'\n", name, filteredName)
+		if name == "" {
+			fmt.Printf("Version filter derived name '%s'\n", filteredName)
+		} else {
+			fmt.Printf("Version filter changed '%s' to '%s'\n", name, filteredName)
+		}
 		name = filteredName
+	}
+
+	// Fall back to the empty-name error only when neither an explicit name nor a
+	// version filter supplied one.
+	if name == "" {
+		return &errors.EmptyBranchNameError{}
 	}
 
 	// Get configuration

--- a/cmd/topicbranch.go
+++ b/cmd/topicbranch.go
@@ -73,7 +73,7 @@ func registerBranchCommand(branchType string) {
 		Short:   fmt.Sprintf("Start a new %s branch", branchType),
 		Long:    fmt.Sprintf("Start a new %s branch from the appropriate base branch or specified base", branchType),
 		Example: fmt.Sprintf("  git flow %s start my-new-feature\n  git flow %s start emergency-fix abc123def", branchType, branchType),
-		Args:    cobra.RangeArgs(1, 2),
+		Args:    cobra.RangeArgs(0, 2),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get fetch flag values
 			fetch, _ := cmd.Flags().GetBool("fetch")
@@ -89,6 +89,13 @@ func registerBranchCommand(branchType string) {
 				shouldFetch = &f
 			}
 
+			// Get name argument if provided; when omitted, the version filter
+			// may supply it (see start()).
+			var name string
+			if len(args) > 0 {
+				name = args[0]
+			}
+
 			// Get base argument if provided
 			var base string
 			if len(args) > 1 {
@@ -96,7 +103,7 @@ func registerBranchCommand(branchType string) {
 			}
 
 			// Call the generic start command with the branch type, name, base, and fetch flags
-			StartCommand(branchType, args[0], base, shouldFetch)
+			StartCommand(branchType, name, base, shouldFetch)
 		},
 	}
 

--- a/docs/git-flow-start.1.md
+++ b/docs/git-flow-start.1.md
@@ -6,7 +6,7 @@ git-flow-start - Create and checkout topic branches
 
 ## SYNOPSIS
 
-**git-flow** *topic* **start** *name* [*base*] [*options*]
+**git-flow** *topic* **start** [*name*] [*base*] [*options*]
 
 ## DESCRIPTION
 
@@ -20,7 +20,7 @@ The new branch is created from the configured starting point for the topic branc
 : The topic branch type (feature, release, hotfix, support, or any configured custom type)
 
 *name*
-: Name of the new topic branch (without the prefix - that's added automatically)
+: Name of the new topic branch (without the prefix - that's added automatically). Optional: when omitted, git-flow runs the `filter-flow-<type>-start-version` filter with an empty version argument and uses its trimmed output as the branch name. If no such filter is configured or it yields no output, the command fails with `branch name cannot be empty`.
 
 *base*
 : Optional base commit, tag, or branch to start from instead of the configured starting point
@@ -75,6 +75,13 @@ git flow release start 1.2.0
 Start a hotfix:
 ```bash
 git flow hotfix start critical-security-fix
+```
+
+### Deriving the Name from a Version Filter
+
+Start a release without a name, letting the configured `filter-flow-release-start-version` filter supply the version:
+```bash
+git flow release start
 ```
 
 ### Custom Starting Points

--- a/docs/gitflow-hooks.7.md
+++ b/docs/gitflow-hooks.7.md
@@ -71,6 +71,8 @@ Where:
 
 Version filters receive the version as the first argument (`$1`) and should output the modified version to stdout.
 
+When `git flow <type> start` is run without a name argument, the version filter still fires — with an empty `$1` — and its trimmed output becomes the branch name. This lets a filter derive the version itself (for example from the latest tag). If no version filter is configured, or the filter produces no output, the command fails with `branch name cannot be empty`.
+
 **Example: Add 'v' prefix to versions**
 
 ```bash

--- a/test/cmd/hooks_filters_test.go
+++ b/test/cmd/hooks_filters_test.go
@@ -377,7 +377,10 @@ func TestStartNoFilterNoNameReturnsEmptyNameError(t *testing.T) {
 		t.Errorf("Expected business-layer error, not Cobra arg-count error, got: %s", output)
 	}
 
-	refs, _ := testutil.RunGit(t, dir, "for-each-ref", "--format=%(refname:short)", "refs/heads/release/")
+	refs, err := testutil.RunGit(t, dir, "for-each-ref", "--format=%(refname:short)", "refs/heads/release/")
+	if err != nil {
+		t.Fatalf("for-each-ref failed: %v", err)
+	}
 	if strings.TrimSpace(refs) != "" {
 		t.Errorf("Expected no release branch to be created, got refs: %s", refs)
 	}
@@ -423,7 +426,10 @@ exit 0
 		t.Errorf("Expected output to contain 'branch name cannot be empty', got: %s", output)
 	}
 
-	refs, _ := testutil.RunGit(t, dir, "for-each-ref", "--format=%(refname:short)", "refs/heads/release/")
+	refs, err := testutil.RunGit(t, dir, "for-each-ref", "--format=%(refname:short)", "refs/heads/release/")
+	if err != nil {
+		t.Fatalf("for-each-ref failed: %v", err)
+	}
 	if strings.TrimSpace(refs) != "" {
 		t.Errorf("Expected no release branch to be created, got refs: %s", refs)
 	}
@@ -531,7 +537,10 @@ func TestStartFeatureNoFilterNoNameReturnsEmptyNameError(t *testing.T) {
 		t.Errorf("Expected output to contain 'branch name cannot be empty', got: %s", output)
 	}
 
-	refs, _ := testutil.RunGit(t, dir, "for-each-ref", "--format=%(refname:short)", "refs/heads/feature/")
+	refs, err := testutil.RunGit(t, dir, "for-each-ref", "--format=%(refname:short)", "refs/heads/feature/")
+	if err != nil {
+		t.Fatalf("for-each-ref failed: %v", err)
+	}
 	if strings.TrimSpace(refs) != "" {
 		t.Errorf("Expected no feature branch to be created, got refs: %s", refs)
 	}
@@ -562,7 +571,10 @@ func TestStartTooManyArgsRejected(t *testing.T) {
 		t.Errorf("Expected Cobra arg-count error containing 'accepts between', got: %s", output)
 	}
 
-	refs, _ := testutil.RunGit(t, dir, "for-each-ref", "--format=%(refname:short)", "refs/heads/release/")
+	refs, err := testutil.RunGit(t, dir, "for-each-ref", "--format=%(refname:short)", "refs/heads/release/")
+	if err != nil {
+		t.Fatalf("for-each-ref failed: %v", err)
+	}
 	if strings.TrimSpace(refs) != "" {
 		t.Errorf("Expected no release branch to be created, got refs: %s", refs)
 	}
@@ -613,7 +625,10 @@ exit 1
 		t.Errorf("Expected Git error, not empty-name fallback, got: %s", output)
 	}
 
-	refs, _ := testutil.RunGit(t, dir, "for-each-ref", "--format=%(refname:short)", "refs/heads/release/")
+	refs, err := testutil.RunGit(t, dir, "for-each-ref", "--format=%(refname:short)", "refs/heads/release/")
+	if err != nil {
+		t.Fatalf("for-each-ref failed: %v", err)
+	}
 	if strings.TrimSpace(refs) != "" {
 		t.Errorf("Expected no release branch to be created, got refs: %s", refs)
 	}

--- a/test/cmd/hooks_filters_test.go
+++ b/test/cmd/hooks_filters_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gittower/git-flow-next/internal/errors"
 	"github.com/gittower/git-flow-next/test/testutil"
 )
 
@@ -293,6 +294,328 @@ fi
 	// Verify original name branch was NOT created
 	if testutil.BranchExists(t, dir, "release/1.0.0") {
 		t.Error("release/1.0.0 should not exist - filter should have changed it to v1.0.0")
+	}
+}
+
+// TestStartDerivesVersionFromFilterWhenNameOmitted tests that a no-argument
+// start runs the version filter (with an empty version argument) and uses its
+// trimmed output as the branch name for a release branch.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Installs filter-flow-release-start-version that echoes "1.4.0" only when its $1 is empty
+// 3. Runs 'git flow release start' with no name and no base
+// 4. Verifies exit 0 and output contains "Created branch 'release/1.4.0' from 'develop'"
+// 5. Verifies branch release/1.4.0 exists (filter-derived name from empty $1)
+func TestStartDerivesVersionFromFilterWhenNameOmitted(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	_, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+
+	// Filter echoes 1.4.0 only when the version argument ($1) is empty,
+	// proving it was invoked with an empty version by the no-arg start.
+	script := `#!/bin/sh
+VERSION="$1"
+if [ -z "$VERSION" ]; then
+    echo "1.4.0"
+fi
+`
+	createHookScript(t, dir, "filter-flow-release-start-version", script)
+
+	output, err := testutil.RunGitFlow(t, dir, "release", "start")
+	if err != nil {
+		t.Fatalf("Expected release start to succeed, got error: %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(output, "Created branch 'release/1.4.0' from 'develop'") {
+		t.Errorf("Expected output to contain \"Created branch 'release/1.4.0' from 'develop'\", got: %s", output)
+	}
+
+	if !testutil.BranchExists(t, dir, "release/1.4.0") {
+		t.Error("Expected release/1.4.0 branch to exist (derived from version filter)")
+	}
+}
+
+// TestStartNoFilterNoNameReturnsEmptyNameError tests that a no-argument start
+// with no version filter falls back to the business-layer empty-name error
+// rather than the Cobra arg-count error.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults (no filter installed)
+// 2. Runs 'git flow release start' with no args
+// 3. Verifies non-zero exit with code ExitCodeInvalidInput (2)
+// 4. Verifies output contains "branch name cannot be empty" and NOT "accepts between"
+// 5. Verifies no release branch was created (refs/heads/release/ is empty)
+func TestStartNoFilterNoNameReturnsEmptyNameError(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	_, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "release", "start")
+	if err == nil {
+		t.Fatalf("Expected release start with no name to fail, but it succeeded\nOutput: %s", output)
+	}
+
+	if exitErr, ok := err.(*testutil.ExitError); ok {
+		if exitErr.ExitCode != int(errors.ExitCodeInvalidInput) {
+			t.Errorf("Expected exit code %d, got %d", errors.ExitCodeInvalidInput, exitErr.ExitCode)
+		}
+	} else {
+		t.Errorf("Expected *testutil.ExitError, got %T", err)
+	}
+
+	if !strings.Contains(output, "branch name cannot be empty") {
+		t.Errorf("Expected output to contain 'branch name cannot be empty', got: %s", output)
+	}
+	if strings.Contains(output, "accepts between") {
+		t.Errorf("Expected business-layer error, not Cobra arg-count error, got: %s", output)
+	}
+
+	refs, _ := testutil.RunGit(t, dir, "for-each-ref", "--format=%(refname:short)", "refs/heads/release/")
+	if strings.TrimSpace(refs) != "" {
+		t.Errorf("Expected no release branch to be created, got refs: %s", refs)
+	}
+}
+
+// TestStartFilterReturnsEmptyReturnsEmptyNameError tests that a no-argument
+// start with a filter that produces no output falls back to the empty-name error.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Installs filter-flow-release-start-version that prints nothing and exits 0
+// 3. Runs 'git flow release start' with no args
+// 4. Verifies non-zero exit with code ExitCodeInvalidInput (2)
+// 5. Verifies output contains "branch name cannot be empty"
+// 6. Verifies no release branch was created (refs/heads/release/ is empty)
+func TestStartFilterReturnsEmptyReturnsEmptyNameError(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	_, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+
+	script := `#!/bin/sh
+exit 0
+`
+	createHookScript(t, dir, "filter-flow-release-start-version", script)
+
+	output, err := testutil.RunGitFlow(t, dir, "release", "start")
+	if err == nil {
+		t.Fatalf("Expected release start with empty filter output to fail, but it succeeded\nOutput: %s", output)
+	}
+
+	if exitErr, ok := err.(*testutil.ExitError); ok {
+		if exitErr.ExitCode != int(errors.ExitCodeInvalidInput) {
+			t.Errorf("Expected exit code %d, got %d", errors.ExitCodeInvalidInput, exitErr.ExitCode)
+		}
+	} else {
+		t.Errorf("Expected *testutil.ExitError, got %T", err)
+	}
+
+	if !strings.Contains(output, "branch name cannot be empty") {
+		t.Errorf("Expected output to contain 'branch name cannot be empty', got: %s", output)
+	}
+
+	refs, _ := testutil.RunGit(t, dir, "for-each-ref", "--format=%(refname:short)", "refs/heads/release/")
+	if strings.TrimSpace(refs) != "" {
+		t.Errorf("Expected no release branch to be created, got refs: %s", refs)
+	}
+}
+
+// TestStartExplicitNameNoFilter tests that an explicit name with no filter
+// installed creates the branch unchanged and prints no filter-change message.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults (no filter installed)
+// 2. Runs 'git flow release start 1.0.0'
+// 3. Verifies exit 0 and output contains "Created branch 'release/1.0.0' from 'develop'"
+// 4. Verifies branch release/1.0.0 exists
+// 5. Verifies output does NOT contain "Version filter changed"
+func TestStartExplicitNameNoFilter(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	_, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "release", "start", "1.0.0")
+	if err != nil {
+		t.Fatalf("Expected release start to succeed, got error: %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(output, "Created branch 'release/1.0.0' from 'develop'") {
+		t.Errorf("Expected output to contain \"Created branch 'release/1.0.0' from 'develop'\", got: %s", output)
+	}
+	if !testutil.BranchExists(t, dir, "release/1.0.0") {
+		t.Error("Expected release/1.0.0 branch to exist")
+	}
+	if strings.Contains(output, "Version filter changed") {
+		t.Errorf("Expected no version filter message, got: %s", output)
+	}
+}
+
+// TestStartDerivesVersionFromFilterHotfix tests that no-argument start version
+// derivation is generic across branch types, using hotfix (start point main).
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Installs filter-flow-hotfix-start-version that echoes "2.0.1"
+// 3. Runs 'git flow hotfix start' with no args
+// 4. Verifies exit 0 and output contains "Created branch 'hotfix/2.0.1' from 'main'"
+// 5. Verifies branch hotfix/2.0.1 exists (derived name, hotfix start point main)
+func TestStartDerivesVersionFromFilterHotfix(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	_, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+
+	script := `#!/bin/sh
+echo "2.0.1"
+`
+	createHookScript(t, dir, "filter-flow-hotfix-start-version", script)
+
+	output, err := testutil.RunGitFlow(t, dir, "hotfix", "start")
+	if err != nil {
+		t.Fatalf("Expected hotfix start to succeed, got error: %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(output, "Created branch 'hotfix/2.0.1' from 'main'") {
+		t.Errorf("Expected output to contain \"Created branch 'hotfix/2.0.1' from 'main'\", got: %s", output)
+	}
+	if !testutil.BranchExists(t, dir, "hotfix/2.0.1") {
+		t.Error("Expected hotfix/2.0.1 branch to exist (derived from version filter)")
+	}
+}
+
+// TestStartFeatureNoFilterNoNameReturnsEmptyNameError tests that a feature type
+// with no version filter and no argument still yields the empty-name error.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults (no feature filter)
+// 2. Runs 'git flow feature start' with no args
+// 3. Verifies non-zero exit with code ExitCodeInvalidInput (2)
+// 4. Verifies output contains "branch name cannot be empty"
+// 5. Verifies no feature branch was created (refs/heads/feature/ is empty)
+func TestStartFeatureNoFilterNoNameReturnsEmptyNameError(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	_, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "start")
+	if err == nil {
+		t.Fatalf("Expected feature start with no name to fail, but it succeeded\nOutput: %s", output)
+	}
+
+	if exitErr, ok := err.(*testutil.ExitError); ok {
+		if exitErr.ExitCode != int(errors.ExitCodeInvalidInput) {
+			t.Errorf("Expected exit code %d, got %d", errors.ExitCodeInvalidInput, exitErr.ExitCode)
+		}
+	} else {
+		t.Errorf("Expected *testutil.ExitError, got %T", err)
+	}
+
+	if !strings.Contains(output, "branch name cannot be empty") {
+		t.Errorf("Expected output to contain 'branch name cannot be empty', got: %s", output)
+	}
+
+	refs, _ := testutil.RunGit(t, dir, "for-each-ref", "--format=%(refname:short)", "refs/heads/feature/")
+	if strings.TrimSpace(refs) != "" {
+		t.Errorf("Expected no feature branch to be created, got refs: %s", refs)
+	}
+}
+
+// TestStartTooManyArgsRejected tests that relaxing the lower arg bound to zero
+// still caps the upper bound at two, rejecting three positional arguments.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Runs 'git flow release start 1.0.0 develop extra' (three positional args)
+// 3. Verifies non-zero exit and output contains "accepts between" (Cobra arg-count error)
+// 4. Verifies no release branch was created (refs/heads/release/ is empty)
+func TestStartTooManyArgsRejected(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	_, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "release", "start", "1.0.0", "develop", "extra")
+	if err == nil {
+		t.Fatalf("Expected release start with three args to fail, but it succeeded\nOutput: %s", output)
+	}
+
+	if !strings.Contains(output, "accepts between") {
+		t.Errorf("Expected Cobra arg-count error containing 'accepts between', got: %s", output)
+	}
+
+	refs, _ := testutil.RunGit(t, dir, "for-each-ref", "--format=%(refname:short)", "refs/heads/release/")
+	if strings.TrimSpace(refs) != "" {
+		t.Errorf("Expected no release branch to be created, got refs: %s", refs)
+	}
+}
+
+// TestStartFilterNonZeroExitReturnsGitError tests that a version filter which
+// fails (non-zero exit) surfaces a Git error, not the empty-name fallback,
+// proving the filter runs before the moved empty-name guard.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Installs filter-flow-release-start-version that writes to stderr and exits 1
+// 3. Runs 'git flow release start' with no args
+// 4. Verifies non-zero exit with code ExitCodeGitError (3), not ExitCodeInvalidInput (2)
+// 5. Verifies output contains "version filter" and NOT "branch name cannot be empty"
+// 6. Verifies no release branch was created (refs/heads/release/ is empty)
+func TestStartFilterNonZeroExitReturnsGitError(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	_, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+
+	script := `#!/bin/sh
+echo "filter boom" >&2
+exit 1
+`
+	createHookScript(t, dir, "filter-flow-release-start-version", script)
+
+	output, err := testutil.RunGitFlow(t, dir, "release", "start")
+	if err == nil {
+		t.Fatalf("Expected release start with failing filter to fail, but it succeeded\nOutput: %s", output)
+	}
+
+	if exitErr, ok := err.(*testutil.ExitError); ok {
+		if exitErr.ExitCode != int(errors.ExitCodeGitError) {
+			t.Errorf("Expected exit code %d, got %d", errors.ExitCodeGitError, exitErr.ExitCode)
+		}
+	} else {
+		t.Errorf("Expected *testutil.ExitError, got %T", err)
+	}
+
+	if !strings.Contains(output, "version filter") {
+		t.Errorf("Expected output to contain 'version filter', got: %s", output)
+	}
+	if strings.Contains(output, "branch name cannot be empty") {
+		t.Errorf("Expected Git error, not empty-name fallback, got: %s", output)
+	}
+
+	refs, _ := testutil.RunGit(t, dir, "for-each-ref", "--format=%(refname:short)", "refs/heads/release/")
+	if strings.TrimSpace(refs) != "" {
+		t.Errorf("Expected no release branch to be created, got refs: %s", refs)
 	}
 }
 


### PR DESCRIPTION
Restores git-flow-avh parity so that `git flow <type> start` with no name argument runs the configured version filter and uses its output as the branch name.

Previously two validation layers rejected the empty argument before the filter could run: the Cobra `RangeArgs(1, 2)` floor on the generic `start` subcommand, and an early empty-name guard in `start()`. This relaxes the CLI floor to `RangeArgs(0, 2)` (keeping the two-argument upper bound) and reads the name defensively in `cmd/topicbranch.go`, then moves the empty-name check in `cmd/start.go` to after `hooks.RunVersionFilter` runs. The filter now fires with an empty `$1` when no name is given and its trimmed stdout becomes the branch name; `EmptyBranchNameError` is the fallback only when no filter is configured or it yields nothing. The fix lives in the single generic registration path, so it applies to every topic type (feature/release/hotfix/support/custom). Changes touch `cmd/topicbranch.go`, `cmd/start.go`, the `docs/git-flow-start.1.md` and `docs/gitflow-hooks.7.md` manpages, and add `test/cmd/hooks_filters_test.go` coverage for all eight spec scenarios.

Resolves #132

## Remarks

- No new CLI syntax: positional parsing is unchanged (one arg = name, two = name then base), so supplying a base while omitting the name remains out of scope.
- Error identity is preserved — the fallback stays `EmptyBranchNameError` (exit code 2), now surfaced from the business layer instead of Cobra's arg-count error.
- When the filter derives a name from empty input, the status line reads `Version filter derived name '<name>'` rather than the `changed '' to '<name>'` wording used for explicit-name rewrites.

**Review focus:**
- `cmd/start.go:49-65` - guard ordering relative to the version filter and the empty-input message branch
- `test/cmd/hooks_filters_test.go` - scenario coverage, including the assertion that the no-filter path returns the business-layer error, not the Cobra arg-count error