### PR TITLE
feat(finish): Push branches and tag after finish

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -160,6 +160,8 @@ The finish command supports per-branch-type configuration:
 | `keeplocal` | Keep local branch | `true`, `false` | `false` |
 | `force-delete` | Force delete branch | `true`, `false` | `false` |
 | `fetch` | Fetch before operation | `true`, `false` | `false` |
+| `push` | Push finished branches to remote | `true`, `false` | `false` |
+| `pushtag` | Push created tag to remote | `true`, `false` | Follows `push` |
 
 #### Examples
 
@@ -176,7 +178,21 @@ gitflow.release.finish.signingkey=ABC123DEF
 
 # Keep hotfix branches locally after finish
 gitflow.hotfix.finish.keeplocal=true
+
+# Push finished release branches and the created tag to the remote
+gitflow.release.finish.push=true
+
+# Push the created tag even when branches are not pushed
+gitflow.release.finish.pushtag=true
 ```
+
+When `push` is enabled, finish pushes the target/parent branch and each
+auto-updated child base branch to the remote (`gitflow.remote`, default
+`origin`) as a final stage, then the created tag. `pushtag` follows the
+resolved `push` value unless set explicitly, letting you decouple the tag push
+from the branch push. A missing remote skips the push with a note (finish still
+succeeds); a rejected non-fast-forward push is a hard error, leaving the
+already-completed local finish intact.
 
 ### Update Command Options
 

--- a/cmd/finish.go
+++ b/cmd/finish.go
@@ -80,8 +80,8 @@ const (
 // =============================================================================
 
 // FinishCommand is the implementation of the finish command for topic branches
-func FinishCommand(branchType string, name string, continueOp bool, abortOp bool, force bool, tagOptions *config.TagOptions, retentionOptions *config.BranchRetentionOptions, mergeOptions *config.MergeStrategyOptions, fetch *bool, noVerify *bool) {
-	if err := executeFinish(branchType, name, continueOp, abortOp, force, tagOptions, retentionOptions, mergeOptions, fetch, noVerify); err != nil {
+func FinishCommand(branchType string, name string, continueOp bool, abortOp bool, force bool, tagOptions *config.TagOptions, retentionOptions *config.BranchRetentionOptions, mergeOptions *config.MergeStrategyOptions, fetch *bool, noVerify *bool, push *bool, pushTag *bool) {
+	if err := executeFinish(branchType, name, continueOp, abortOp, force, tagOptions, retentionOptions, mergeOptions, fetch, noVerify, push, pushTag); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -98,7 +98,7 @@ func FinishCommand(branchType string, name string, continueOp bool, abortOp bool
 // =============================================================================
 
 // executeFinish performs the actual branch finishing logic and returns any errors
-func executeFinish(branchType string, name string, continueOp bool, abortOp bool, force bool, tagOptions *config.TagOptions, retentionOptions *config.BranchRetentionOptions, mergeOptions *config.MergeStrategyOptions, fetch *bool, noVerify *bool) error {
+func executeFinish(branchType string, name string, continueOp bool, abortOp bool, force bool, tagOptions *config.TagOptions, retentionOptions *config.BranchRetentionOptions, mergeOptions *config.MergeStrategyOptions, fetch *bool, noVerify *bool, push *bool, pushTag *bool) error {
 	// Get configuration early
 	cfg, err := config.LoadConfig()
 	if err != nil {
@@ -130,7 +130,7 @@ func executeFinish(branchType string, name string, continueOp bool, abortOp bool
 
 		if continueOp {
 			// Resolve options for continue operation
-			resolvedOptions := config.ResolveFinishOptions(cfg, state.BranchType, state.BranchName, tagOptions, retentionOptions, mergeOptions, fetch, noVerify)
+			resolvedOptions := config.ResolveFinishOptions(cfg, state.BranchType, state.BranchName, tagOptions, retentionOptions, mergeOptions, fetch, noVerify, push, pushTag)
 			return handleContinue(cfg, state, stateBranchConfig, resolvedOptions, mergeOptions)
 		}
 
@@ -172,7 +172,7 @@ func executeFinish(branchType string, name string, continueOp bool, abortOp bool
 			fmt.Printf("1. Merge it into '%s' using the %s strategy\n", branchConfig.Parent, branchConfig.UpstreamStrategy)
 
 			// Resolve options early for confirmation dialog
-			resolvedOptions := config.ResolveFinishOptions(cfg, branchType, shortName, tagOptions, retentionOptions, mergeOptions, fetch, noVerify)
+			resolvedOptions := config.ResolveFinishOptions(cfg, branchType, shortName, tagOptions, retentionOptions, mergeOptions, fetch, noVerify, push, pushTag)
 
 			if resolvedOptions.ShouldTag {
 				fmt.Printf("2. Create a tag '%s'\n", resolvedOptions.TagName)
@@ -199,7 +199,7 @@ func executeFinish(branchType string, name string, continueOp bool, abortOp bool
 	}
 
 	// Resolve all options once before starting operations
-	resolvedOptions := config.ResolveFinishOptions(cfg, branchType, shortName, tagOptions, retentionOptions, mergeOptions, fetch, noVerify)
+	resolvedOptions := config.ResolveFinishOptions(cfg, branchType, shortName, tagOptions, retentionOptions, mergeOptions, fetch, noVerify, push, pushTag)
 
 	// Perform fetch if enabled (only on initial finish, not continue)
 	if resolvedOptions.ShouldFetch && git.RemoteExists(cfg.Remote) {
@@ -243,10 +243,10 @@ func executeFinish(branchType string, name string, continueOp bool, abortOp bool
 	}
 
 	// Regular finish command flow
-	return finishBranch(cfg, branchType, name, branchConfig, tagOptions, retentionOptions, mergeOptions, fetch, noVerify)
+	return finishBranch(cfg, branchType, name, branchConfig, tagOptions, retentionOptions, mergeOptions, fetch, noVerify, push, pushTag)
 }
 
-func finishBranch(cfg *config.Config, branchType string, name string, branchConfig config.BranchConfig, tagOptions *config.TagOptions, retentionOptions *config.BranchRetentionOptions, mergeOptions *config.MergeStrategyOptions, fetch *bool, noVerify *bool) error {
+func finishBranch(cfg *config.Config, branchType string, name string, branchConfig config.BranchConfig, tagOptions *config.TagOptions, retentionOptions *config.BranchRetentionOptions, mergeOptions *config.MergeStrategyOptions, fetch *bool, noVerify *bool, push *bool, pushTag *bool) error {
 	// Validate that git-flow is initialized
 	initialized, err := config.IsInitialized()
 	if err != nil {
@@ -297,7 +297,7 @@ func finishBranch(cfg *config.Config, branchType string, name string, branchConf
 	}
 
 	// Resolve all options once at the beginning
-	resolvedOptions := config.ResolveFinishOptions(cfg, branchType, shortName, tagOptions, retentionOptions, mergeOptions, fetch, noVerify)
+	resolvedOptions := config.ResolveFinishOptions(cfg, branchType, shortName, tagOptions, retentionOptions, mergeOptions, fetch, noVerify, push, pushTag)
 
 	// Run pre-hook before starting finish operation
 	gitDir, err := git.GetGitDir()
@@ -785,6 +785,13 @@ func handleDeleteBranchStep(cfg *config.Config, state *mergestate.MergeState, re
 		}
 	}
 
+	// Push stage: runs after all local work is complete and the merge state is
+	// cleared. A missing remote is a skip (exit 0); a rejected push is a real
+	// error, leaving the completed local finish as-is.
+	if err := pushFinishedBranches(cfg, state, resolvedOptions); err != nil {
+		return err
+	}
+
 	fmt.Printf("Successfully finished branch '%s' and updated %d child base branches\n", state.FullBranchName, len(state.UpdatedBranches))
 
 	// Run post-hook after successful completion
@@ -807,6 +814,64 @@ func handleDeleteBranchStep(cfg *config.Config, state *mergestate.MergeState, re
 		if result.Executed && result.Output != "" {
 			fmt.Print(result.Output)
 		}
+	}
+
+	return nil
+}
+
+// pushFinishedBranches pushes the branches modified by the finish (the target
+// branch plus each auto-updated child base branch) and the created tag to the
+// configured remote, according to the resolved push options. It runs as the final
+// stage of a completed finish.
+//
+// Behavior:
+//   - Nothing to push (neither branches nor tag enabled): no-op, no output.
+//   - Remote not configured: prints a skip note and returns nil (exit 0).
+//   - A push failure (e.g. non-fast-forward rejection): returns the error
+//     verbatim, which propagates to a non-zero exit. The completed local finish
+//     is left as-is (nothing is rolled back).
+func pushFinishedBranches(cfg *config.Config, state *mergestate.MergeState, resolvedOptions *config.ResolvedFinishOptions) error {
+	// Only push the tag if one was actually created.
+	tagToPush := resolvedOptions.PushTag && resolvedOptions.ShouldTag
+
+	// Nothing to do.
+	if !resolvedOptions.PushBranches && !tagToPush {
+		return nil
+	}
+
+	remote := cfg.Remote
+
+	// A missing remote is a skip-with-note, not an error.
+	if !git.RemoteExists(remote) {
+		fmt.Printf("Note: Remote '%s' not configured, skipping push\n", remote)
+		return nil
+	}
+
+	fmt.Printf("Pushing to remote '%s'...\n", remote)
+
+	if resolvedOptions.PushBranches {
+		// Ordered, de-duplicated branch list: parent first, then updated children,
+		// skipping any child equal to the parent.
+		branches := []string{state.ParentBranch}
+		for _, child := range state.UpdatedBranches {
+			if child != state.ParentBranch {
+				branches = append(branches, child)
+			}
+		}
+
+		for _, branch := range branches {
+			if err := git.PushRef(remote, branch); err != nil {
+				return &errors.GitError{Operation: fmt.Sprintf("push branch '%s'", branch), Err: err}
+			}
+			fmt.Printf("  %s -> %s/%s\n", branch, remote, branch)
+		}
+	}
+
+	if tagToPush {
+		if err := git.PushTag(remote, resolvedOptions.TagName); err != nil {
+			return &errors.GitError{Operation: fmt.Sprintf("push tag '%s'", resolvedOptions.TagName), Err: err}
+		}
+		fmt.Printf("  %s (tag) -> %s\n", resolvedOptions.TagName, remote)
 	}
 
 	return nil
@@ -918,7 +983,7 @@ func updateChildBranch(cfg *config.Config, branchName string, state *mergestate.
 			var resolvedOptions *config.ResolvedFinishOptions
 			if cfg != nil {
 				// Try to resolve options for better tag information in message
-				resolvedOptions = config.ResolveFinishOptions(cfg, state.BranchType, state.BranchName, nil, nil, nil, nil, nil)
+				resolvedOptions = config.ResolveFinishOptions(cfg, state.BranchType, state.BranchName, nil, nil, nil, nil, nil, nil, nil)
 			}
 
 			// Generate and print detailed conflict message

--- a/cmd/shorthand.go
+++ b/cmd/shorthand.go
@@ -161,7 +161,10 @@ func RegisterShorthandCommands() {
 			if noVerify {
 				noVerifyPtr = &noVerify
 			}
-			FinishCommand(branchType, name, continueOp, abortOp, force, tagOptions, retentionOptions, mergeOptions, nil, noVerifyPtr, nil, nil)
+			// Resolve push flags (unset stays nil so config can apply)
+			push := getBoolPtr(cmd, "push", "no-push")
+			pushTag := getBoolPtr(cmd, "pushtag", "no-pushtag")
+			FinishCommand(branchType, name, continueOp, abortOp, force, tagOptions, retentionOptions, mergeOptions, nil, noVerifyPtr, push, pushTag)
 		},
 	}
 

--- a/cmd/shorthand.go
+++ b/cmd/shorthand.go
@@ -161,7 +161,7 @@ func RegisterShorthandCommands() {
 			if noVerify {
 				noVerifyPtr = &noVerify
 			}
-			FinishCommand(branchType, name, continueOp, abortOp, force, tagOptions, retentionOptions, mergeOptions, nil, noVerifyPtr)
+			FinishCommand(branchType, name, continueOp, abortOp, force, tagOptions, retentionOptions, mergeOptions, nil, noVerifyPtr, nil, nil)
 		},
 	}
 

--- a/cmd/shorthand.go
+++ b/cmd/shorthand.go
@@ -161,10 +161,11 @@ func RegisterShorthandCommands() {
 			if noVerify {
 				noVerifyPtr = &noVerify
 			}
-			// Resolve push flags (unset stays nil so config can apply)
+			// Resolve fetch and push flags (unset stays nil so config can apply)
+			fetch := getBoolPtr(cmd, "fetch", "no-fetch")
 			push := getBoolPtr(cmd, "push", "no-push")
 			pushTag := getBoolPtr(cmd, "pushtag", "no-pushtag")
-			FinishCommand(branchType, name, continueOp, abortOp, force, tagOptions, retentionOptions, mergeOptions, nil, noVerifyPtr, push, pushTag)
+			FinishCommand(branchType, name, continueOp, abortOp, force, tagOptions, retentionOptions, mergeOptions, fetch, noVerifyPtr, push, pushTag)
 		},
 	}
 

--- a/cmd/topicbranch.go
+++ b/cmd/topicbranch.go
@@ -154,6 +154,12 @@ func registerBranchCommand(branchType string) {
 			fetch, _ := cmd.Flags().GetBool("fetch")
 			noFetch, _ := cmd.Flags().GetBool("no-fetch")
 
+			// Get push flags
+			push, _ := cmd.Flags().GetBool("push")
+			noPush, _ := cmd.Flags().GetBool("no-push")
+			pushtag, _ := cmd.Flags().GetBool("pushtag")
+			noPushtag, _ := cmd.Flags().GetBool("no-pushtag")
+
 			// Get hook bypass flag
 			noVerify, _ := cmd.Flags().GetBool("no-verify")
 
@@ -222,7 +228,7 @@ func registerBranchCommand(branchType string) {
 			}
 
 			// Call the generic finish command with the branch type and name
-			FinishCommand(branchType, name, continueOp, abortOp, force, tagOptions, retentionOptions, mergeOptions, getBoolFlag(fetch, noFetch), getSingleBoolPtr(noVerify))
+			FinishCommand(branchType, name, continueOp, abortOp, force, tagOptions, retentionOptions, mergeOptions, getBoolFlag(fetch, noFetch), getSingleBoolPtr(noVerify), getBoolFlag(push, noPush), getBoolFlag(pushtag, noPushtag))
 		},
 	}
 
@@ -448,6 +454,12 @@ func addFinishFlags(cmd *cobra.Command) {
 	// Fetch Flags
 	cmd.Flags().Bool("fetch", false, "Fetch from remote before finishing")
 	cmd.Flags().Bool("no-fetch", false, "Don't fetch from remote before finishing")
+
+	// Remote Push Options
+	cmd.Flags().Bool("push", false, "Push the target and updated child branches (and the created tag) after finishing")
+	cmd.Flags().Bool("no-push", false, "Don't push after finishing (overrides config)")
+	cmd.Flags().Bool("pushtag", false, "Push the created tag after finishing (defaults to the push setting)")
+	cmd.Flags().Bool("no-pushtag", false, "Don't push the created tag after finishing")
 
 	// Hook Control Flags
 	cmd.Flags().Bool("no-verify", false, "Bypass pre-commit and commit-msg hooks during merge and commit operations")

--- a/docs/avh-compatibility-analysis.md
+++ b/docs/avh-compatibility-analysis.md
@@ -89,11 +89,12 @@ These git-flow-avh options are **not currently supported** in git-flow-next:
 | Missing Option | Description | Impact |
 |----------------|-------------|--------|
 | `gitflow.allowdirty` | Allow operations with dirty working tree | 🔴 High |
-| `gitflow.*.finish.push` | Auto-push after finishing | 🔴 High |
-| `gitflow.*.finish.pushproduction` | Push to production branch after finish | 🟡 Medium |
-| `gitflow.*.finish.pushdevelop` | Push to develop branch after finish | 🟡 Medium |
+| `gitflow.*.finish.pushproduction` | Push to production branch after finish | 🟢 Covered by `gitflow.*.finish.push` |
+| `gitflow.*.finish.pushdevelop` | Push to develop branch after finish | 🟢 Covered by `gitflow.*.finish.push` |
 | `gitflow.*.finish.nobackmerge` | Skip back-merge to develop | 🟡 Medium |
 | `gitflow.*.finish.ff-master` | Fast-forward merge to master | 🟡 Medium |
+
+**Note on push-on-finish**: git-flow-next implements push-on-finish generically via `gitflow.*.finish.push` (and `gitflow.*.finish.pushtag`) plus the `--push`/`--no-push` and `--pushtag`/`--no-pushtag` flags. A single `--push` pushes the target branch **and** every auto-updated child base branch (plus the created tag), so avh's separate `--pushproduction`/`--pushdevelop` knobs are unnecessary — the child set is derived from the branch topology rather than hard-coded to production/develop.
 
 ### 🆕 git-flow-next Exclusive Features
 These features are **only available** in git-flow-next:
@@ -142,8 +143,9 @@ gitflow.allowdirty=true  # Add system-level support
 # AVH
 gitflow.release.finish.push=true
 
-# Needed in git-flow-next
-gitflow.release.finish.push=true  # Add to finish command options
+# git-flow-next (supported)
+gitflow.release.finish.push=true     # Push target + auto-updated children + tag
+gitflow.release.finish.pushtag=false # Optional: decouple the tag from the branch push
 ```
 
 ---
@@ -209,9 +211,10 @@ git-flow-next implements shorthand commands that work on the current branch:
 | `-m/--message` | ✅ | ✅ |
 | `--notag` | ✅ | ✅ |
 | `--continue/--abort` | ❌ | ✅ (git-flow-next exclusive) |
-| `-p/--push` | ✅ | ❌ |
-| `--pushproduction` | ✅ | ❌ |
-| `--pushdevelop` | ✅ | ❌ |
+| `--push` / `--no-push` | ✅ | ✅ (pushes target + auto-updated children + tag) |
+| `--pushtag` / `--no-pushtag` | ❌ | ✅ (git-flow-next exclusive) |
+| `--pushproduction` | ✅ | 🟢 Covered by `--push` |
+| `--pushdevelop` | ✅ | 🟢 Covered by `--push` |
 | `-b/--nobackmerge` | ✅ | ❌ |
 | `--ff-master` | ✅ | ❌ |
 | `--showcommands` | ✅ | ❌ |
@@ -232,7 +235,7 @@ git-flow-next implements shorthand commands that work on the current branch:
 
 - **Core Features**: 100% compatible (branch management, merge strategies)
 - **Configuration Translation**: 90% automatic (prefix mapping, branch names)
-- **Command Options**: 75% compatible (most finish flags supported, missing push)
+- **Command Options**: 75% compatible (most finish flags supported, including push-on-finish)
 - **Advanced Features**: 60% compatible (preserve-merges and no-ff now supported)
 
 ### Command Compatibility: 80%
@@ -245,7 +248,7 @@ git-flow-next implements shorthand commands that work on the current branch:
 ### Combined Compatibility Score: 82%
 
 - **Core Workflow**: 95% compatible (start → work → finish → delete)
-- **Team Collaboration**: 75% compatible (publish and track work; push-on-finish missing)
+- **Team Collaboration**: 75% compatible (publish, track, and push-on-finish work)
 - **Configuration**: 85% compatible
 - **Commands**: 80% compatible
 
@@ -256,7 +259,6 @@ git-flow-next implements shorthand commands that work on the current branch:
 ### Phase 1: Critical Gaps
 **Configuration:**
 1. **`gitflow.allowdirty`** — Allow dirty working tree operations
-2. **`gitflow.*.finish.push`** — Auto-push after finishing operations
 
 **Commands:**
 1. **`diff` command** — Show changes compared to parent branch
@@ -267,8 +269,7 @@ git-flow-next implements shorthand commands that work on the current branch:
 
 **Commands:**
 1. **`--verbose` on list** — Detailed branch listing
-2. **Missing finish push flags** — `--pushproduction/--pushdevelop`
-3. **Universal `--showcommands` flag** — Debug/learning aid across all commands
+2. **Universal `--showcommands` flag** — Debug/learning aid across all commands
 
 ### Phase 3: Advanced Features
 **Commands:**

--- a/docs/git-flow-finish.1.md
+++ b/docs/git-flow-finish.1.md
@@ -138,6 +138,28 @@ The operation maintains a persistent state file that allows it to resume after c
 **--no-fetch**
 : Don't fetch from remote before finishing. Disables the default fetch behavior. Overrides git config setting `gitflow.<type>.finish.fetch`.
 
+### Remote Push Options
+
+By default, finishing a branch performs only local work; nothing is pushed. These options opt in to pushing the results of a completed finish to the configured remote (`gitflow.remote`, default `origin`) as a final stage, after all merges, tags, child updates, and branch deletion are done. The finished topic branch itself is never pushed by these options.
+
+When pushing branches, finish pushes the target (parent) branch first, followed by each auto-updated child base branch (for example `main` then `develop` on a release or hotfix finish). Pushes use a plain `git push`, so the base branches must already track their remote.
+
+**--push**
+: Push the target branch and each auto-updated child base branch (and, by default, the created tag) after finishing. Overrides git config setting `gitflow.<type>.finish.push`.
+
+**--no-push**
+: Don't push branches after finishing. Because the tag-push default derives from the branch-push decision, `--no-push` also suppresses the inherited tag push unless `--pushtag` is given explicitly. Overrides git config setting `gitflow.<type>.finish.push`.
+
+**--pushtag**
+: Push the created tag after finishing. The default for pushing the tag follows the resolved branch-push setting, so a bare `--push` already pushes the tag; use `--pushtag` to push the tag without pushing branches, or to re-enable the tag push when branch pushing is disabled. Has no effect when no tag was created. Overrides git config setting `gitflow.<type>.finish.pushtag`.
+
+**--no-pushtag**
+: Don't push the created tag after finishing, even when branches are pushed. Overrides git config setting `gitflow.<type>.finish.pushtag`.
+
+If no remote is configured, the push stage is skipped with a note and finish still exits successfully. If a push is rejected (for example a non-fast-forward update because the remote has diverged), finish exits with an error; the local finish is already complete and nothing is rolled back — re-run the push manually after reconciling.
+
+CLI push flags are not persisted across `--continue`. Options are re-resolved on continue, so to enable a push that must survive a conflict-and-continue, set the `gitflow.<type>.finish.push` config key rather than relying on the flag.
+
 ### Hook Control
 
 **--no-verify**
@@ -376,6 +398,29 @@ git flow feature finish my-feature --no-verify
 Useful in CI/CD environments where hooks might interfere:
 ```bash
 git flow release finish 1.2.0 --no-verify --tag
+```
+
+### Pushing After Finish
+
+Push the target branch (and any auto-updated child branches) plus the created tag after finishing:
+```bash
+git flow release finish 1.2.0 --push
+```
+
+Push the updated branches but not the tag:
+```bash
+git flow release finish 1.2.0 --push --no-pushtag
+```
+
+Push only the created tag, leaving branches local:
+```bash
+git flow release finish 1.2.0 --pushtag
+```
+
+Always push a branch type on finish by enabling it in config:
+```bash
+git config gitflow.feature.finish.push true
+git flow feature finish my-feature
 ```
 
 ## WORKFLOW BEHAVIOR

--- a/docs/git-flow-finish.1.md
+++ b/docs/git-flow-finish.1.md
@@ -142,7 +142,7 @@ The operation maintains a persistent state file that allows it to resume after c
 
 By default, finishing a branch performs only local work; nothing is pushed. These options opt in to pushing the results of a completed finish to the configured remote (`gitflow.remote`, default `origin`) as a final stage, after all merges, tags, child updates, and branch deletion are done. The finished topic branch itself is never pushed by these options.
 
-When pushing branches, finish pushes the target (parent) branch first, followed by each auto-updated child base branch (for example `main` then `develop` on a release or hotfix finish). Pushes use a plain `git push`, so the base branches must already track their remote.
+When pushing branches, finish pushes the target (parent) branch first, followed by each auto-updated child base branch (for example `main` then `develop` on a release or hotfix finish). Each branch is pushed explicitly to the configured remote with a plain `git push <remote> <branch>`, so it does not depend on or alter the branch's upstream tracking configuration.
 
 **--push**
 : Push the target branch and each auto-updated child base branch (and, by default, the created tag) after finishing. Overrides git config setting `gitflow.<type>.finish.push`.

--- a/docs/gitflow-config.5.md
+++ b/docs/gitflow-config.5.md
@@ -478,6 +478,18 @@ The finish command supports extensive merge strategy configuration through comma
 : *Type*: boolean
 : *Default*: true
 
+### Remote Push Options
+
+**gitflow.*type*.finish.push**
+: Push the results of a completed finish to the configured remote (`gitflow.remote`, default `origin`) as a final stage. When enabled, the target (parent) branch and each auto-updated child base branch are pushed (parent first), and — unless overridden by the `pushtag` key — the created tag is pushed too. The finished topic branch itself is never pushed. If no remote is configured, the push stage is skipped with a note and finish still succeeds. A rejected (non-fast-forward) push causes finish to exit with an error, leaving the already-completed local finish untouched. Corresponds to `--push`/`--no-push`.
+: *Type*: boolean
+: *Default*: false
+
+**gitflow.*type*.finish.pushtag**
+: Push the created tag on finish. When this key is unset, tag pushing follows the resolved `push` decision, so enabling `push` also pushes the tag. Set this key explicitly to decouple the tag from the branch decision: `true` pushes the tag even when branches are not pushed, `false` suppresses the tag push even when branches are. Has no effect when no tag was created. Corresponds to `--pushtag`/`--no-pushtag`.
+: *Type*: boolean
+: *Default*: (follows `gitflow.*type*.finish.push`)
+
 ### Merge Message Options
 
 **gitflow.*type*.finish.mergemessage**

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -35,6 +35,10 @@ type ResolvedFinishOptions struct {
 
 	// Hook options
 	NoVerify bool // Whether to skip pre-commit and commit-msg hooks
+
+	// Push options
+	PushBranches bool // Whether to push the target and updated child branches after finishing
+	PushTag      bool // Whether to push the created tag after finishing
 }
 
 // TagOptions represents command-line tag options
@@ -74,7 +78,7 @@ type MergeStrategyOptions struct {
 // Layer 1: Branch configuration defaults
 // Layer 2: Command-specific git config (gitflow.<branchtype>.finish.*)
 // Layer 3: Command-line arguments (highest priority)
-func ResolveFinishOptions(cfg *Config, branchType string, branchName string, tagOpts *TagOptions, retentionOpts *BranchRetentionOptions, mergeOpts *MergeStrategyOptions, fetch *bool, noVerify *bool) *ResolvedFinishOptions {
+func ResolveFinishOptions(cfg *Config, branchType string, branchName string, tagOpts *TagOptions, retentionOpts *BranchRetentionOptions, mergeOpts *MergeStrategyOptions, fetch *bool, noVerify *bool, push *bool, pushTag *bool) *ResolvedFinishOptions {
 	branchConfig := cfg.Branches[branchType]
 
 	// Compute full branch name from prefix + branchName
@@ -82,6 +86,11 @@ func ResolveFinishOptions(cfg *Config, branchType string, branchName string, tag
 
 	// Resolve merge strategy components
 	strategy, useRebase, preserveMerges, noFastForward, useSquash := resolveMergeStrategy(cfg, branchConfig, branchType, mergeOpts)
+
+	// Resolve push options. Order matters: pushTag's default derives from the
+	// resolved pushBranches value, so resolve branches first.
+	pushBranches := resolveFinishPush(cfg, branchType, push)
+	pushTagResolved := resolveFinishPushTag(cfg, branchType, pushBranches, pushTag)
 
 	return &ResolvedFinishOptions{
 		// Tag resolution
@@ -115,6 +124,10 @@ func ResolveFinishOptions(cfg *Config, branchType string, branchName string, tag
 
 		// Hook resolution
 		NoVerify: resolveFinishNoVerify(cfg, branchType, noVerify),
+
+		// Push resolution
+		PushBranches: pushBranches,
+		PushTag:      pushTagResolved,
 	}
 }
 
@@ -474,6 +487,49 @@ func resolveFinishNoVerify(cfg *Config, branchType string, noVerify *bool) bool 
 	}
 
 	return skipVerify
+}
+
+// resolveFinishPush resolves whether to push the target and updated child branches
+// after finishing. There is no Layer 1 branch-type property for this operational
+// setting (mirrors resolveFinishNoVerify).
+func resolveFinishPush(cfg *Config, branchType string, push *bool) bool {
+	// Layer 1: Default is not to push
+	pushBranches := false
+
+	// Layer 2: Command-specific config
+	if getCommandConfigBool(cfg, fmt.Sprintf("gitflow.%s.finish.push", branchType)) {
+		pushBranches = true
+	}
+
+	// Layer 3: Command-line flags override config
+	if push != nil {
+		pushBranches = *push
+	}
+
+	return pushBranches
+}
+
+// resolveFinishPushTag resolves whether to push the created tag after finishing.
+// The default follows the resolved branch-push decision so a bare --push (or push
+// config) also pushes the tag. A gitflow.<type>.finish.pushtag key overrides that
+// default only when explicitly set (distinguishing "unset" from "false"), and the
+// CLI flag wins over both.
+func resolveFinishPushTag(cfg *Config, branchType string, resolvedPush bool, pushTag *bool) bool {
+	// Layer 1: Default derives from the resolved branch-push decision
+	pushTagVal := resolvedPush
+
+	// Layer 2: Command-specific config, honored only when the key exists so an
+	// unset key does not clobber the derived default.
+	if v, ok := cfg.CommandConfig[fmt.Sprintf("gitflow.%s.finish.pushtag", branchType)]; ok {
+		pushTagVal = v == "true"
+	}
+
+	// Layer 3: Command-line flags override config
+	if pushTag != nil {
+		pushTagVal = *pushTag
+	}
+
+	return pushTagVal
 }
 
 // resolveSquashMessage resolves the squash commit message.

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -637,7 +637,7 @@ func PushRef(remote, branch string) error {
 	cmd := exec.Command("git", "push", remote, branch)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to push branch '%s' to '%s': %s", branch, remote, strings.TrimSpace(string(output)))
+		return fmt.Errorf("failed to push branch '%s' to '%s': %w (output: %s)", branch, remote, err, strings.TrimSpace(string(output)))
 	}
 	return nil
 }
@@ -648,7 +648,7 @@ func PushTag(remote, tag string) error {
 	cmd := exec.Command("git", "push", remote, "tag", tag)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to push tag '%s' to '%s': %s", tag, remote, strings.TrimSpace(string(output)))
+		return fmt.Errorf("failed to push tag '%s' to '%s': %w (output: %s)", tag, remote, err, strings.TrimSpace(string(output)))
 	}
 	return nil
 }

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -631,8 +631,9 @@ func PushBranch(remote, branch string, pushOptions []string) error {
 
 // PushRef pushes a branch to a remote with a plain `git push <remote> <branch>`
 // (no -u). Finish pushes base branches that already track their remote, so this
-// avoids rewriting tracking config. The combined output is returned verbatim on
-// failure so a rejected (non-fast-forward) push surfaces to the caller.
+// avoids rewriting tracking config. On failure it returns a wrapped error that
+// embeds the underlying error and the trimmed combined output, so a rejected
+// (non-fast-forward) push surfaces to the caller.
 func PushRef(remote, branch string) error {
 	cmd := exec.Command("git", "push", remote, branch)
 	output, err := cmd.CombinedOutput()
@@ -643,7 +644,8 @@ func PushRef(remote, branch string) error {
 }
 
 // PushTag pushes a single tag to a remote with `git push <remote> tag <tag>`.
-// The combined output is returned verbatim on failure.
+// On failure it returns a wrapped error that embeds the underlying error and the
+// trimmed combined output.
 func PushTag(remote, tag string) error {
 	cmd := exec.Command("git", "push", remote, "tag", tag)
 	output, err := cmd.CombinedOutput()

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -629,6 +629,30 @@ func PushBranch(remote, branch string, pushOptions []string) error {
 	return nil
 }
 
+// PushRef pushes a branch to a remote with a plain `git push <remote> <branch>`
+// (no -u). Finish pushes base branches that already track their remote, so this
+// avoids rewriting tracking config. The combined output is returned verbatim on
+// failure so a rejected (non-fast-forward) push surfaces to the caller.
+func PushRef(remote, branch string) error {
+	cmd := exec.Command("git", "push", remote, branch)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to push branch '%s' to '%s': %s", branch, remote, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// PushTag pushes a single tag to a remote with `git push <remote> tag <tag>`.
+// The combined output is returned verbatim on failure.
+func PushTag(remote, tag string) error {
+	cmd := exec.Command("git", "push", remote, "tag", tag)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to push tag '%s' to '%s': %s", tag, remote, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
 // CreateTrackingBranch creates a local branch that tracks a remote branch
 func CreateTrackingBranch(localBranch, remote, remoteBranch string) error {
 	// git checkout -b <local> --track <remote>/<branch>

--- a/test/cmd/finish_push_test.go
+++ b/test/cmd/finish_push_test.go
@@ -889,3 +889,38 @@ func TestFinishPushShorthandForwardsFlag(t *testing.T) {
 		t.Errorf("Expected push header and main push line via shorthand. Output: %s", output)
 	}
 }
+
+// TestFinishFetchShorthandForwardsFlag tests that the shorthand `git flow finish`
+// (operating on the current topic branch) honors the --fetch flag. Regression
+// guard: the shorthand registered the fetch flags but dropped them when calling
+// FinishCommand (passing nil), so `git flow finish --fetch` silently fell back to
+// config/defaults instead of honoring the flag.
+// Steps:
+//  1. Sets up a single-track repo with origin tracking main
+//  2. Disables fetch via config so the default alone would not fetch
+//  3. Creates feature branch 'login' with one commit (leaves it checked out)
+//  4. Runs the shorthand 'git flow finish --fetch' (no type/name)
+//  5. Verifies the fetch message appears, proving the flag was forwarded and
+//     overrode the config
+func TestFinishFetchShorthandForwardsFlag(t *testing.T) {
+	dir, remoteDir := setupSingleTrackWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	// Disable fetch via config so a dropped --fetch flag would result in no fetch.
+	// The flag must override this config to prove it is forwarded.
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.feature.finish.fetch", "false"); err != nil {
+		t.Fatalf("Failed to configure fetch option: %v", err)
+	}
+
+	createTopicCommit(t, dir, "feature", "login", "login.txt", "login content")
+
+	output, err := testutil.RunGitFlow(t, dir, "finish", "--fetch")
+	if err != nil {
+		t.Fatalf("Failed to finish via shorthand with --fetch: %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(output, "Fetching from remote") {
+		t.Errorf("Expected fetch to occur via shorthand --fetch (flag forwarded, overriding config). Output: %s", output)
+	}
+}

--- a/test/cmd/finish_push_test.go
+++ b/test/cmd/finish_push_test.go
@@ -652,7 +652,9 @@ func TestFinishPushRunsAfterContinue(t *testing.T) {
 	if _, err := testutil.RunGitFlow(t, dir, "release", "start", "1.0.0"); err != nil {
 		t.Fatalf("Failed to start release: %v", err)
 	}
-	testutil.WriteFile(t, dir, "conflict.txt", "release version")
+	if err := testutil.WriteFile(t, dir, "conflict.txt", "release version"); err != nil {
+		t.Fatalf("Failed to write conflict.txt: %v", err)
+	}
 	if _, err := testutil.RunGit(t, dir, "add", "conflict.txt"); err != nil {
 		t.Fatalf("Failed to add conflict.txt: %v", err)
 	}
@@ -663,7 +665,9 @@ func TestFinishPushRunsAfterContinue(t *testing.T) {
 	if _, err := testutil.RunGit(t, dir, "checkout", "main"); err != nil {
 		t.Fatalf("Failed to checkout main: %v", err)
 	}
-	testutil.WriteFile(t, dir, "conflict.txt", "main version")
+	if err := testutil.WriteFile(t, dir, "conflict.txt", "main version"); err != nil {
+		t.Fatalf("Failed to write conflict.txt on main: %v", err)
+	}
 	if _, err := testutil.RunGit(t, dir, "add", "conflict.txt"); err != nil {
 		t.Fatalf("Failed to add conflict.txt on main: %v", err)
 	}
@@ -698,7 +702,9 @@ func TestFinishPushRunsAfterContinue(t *testing.T) {
 	}
 
 	// Resolve and continue.
-	testutil.WriteFile(t, dir, "conflict.txt", "resolved")
+	if err := testutil.WriteFile(t, dir, "conflict.txt", "resolved"); err != nil {
+		t.Fatalf("Failed to write conflict resolution: %v", err)
+	}
 	if _, err := testutil.RunGit(t, dir, "add", "conflict.txt"); err != nil {
 		t.Fatalf("Failed to stage resolution: %v", err)
 	}
@@ -738,7 +744,9 @@ func TestFinishPushRejectedNonFastForward(t *testing.T) {
 		t.Fatalf("Failed to clone remote: %v", err)
 	}
 	testutil.ConfigureGitIdentity(t, secondDir)
-	testutil.WriteFile(t, secondDir, "remote.txt", "remote change")
+	if err := testutil.WriteFile(t, secondDir, "remote.txt", "remote change"); err != nil {
+		t.Fatalf("Failed to write remote.txt: %v", err)
+	}
 	if _, err := testutil.RunGit(t, secondDir, "add", "remote.txt"); err != nil {
 		t.Fatalf("Failed to add remote.txt: %v", err)
 	}

--- a/test/cmd/finish_push_test.go
+++ b/test/cmd/finish_push_test.go
@@ -1,0 +1,852 @@
+package cmd_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// Push output format asserted throughout these tests (from the spec examples):
+//   Header line: "Pushing to remote 'origin'..."
+//   Per branch:  "  <branch> -> origin/<branch>"
+//   Tag:         "  <tag> (tag) -> origin"
+const (
+	pushHeader     = "Pushing to remote 'origin'..."
+	pushMainLine   = "  main -> origin/main"
+	pushDevelLine  = "  develop -> origin/develop"
+	pushTag100Line = "  1.0.0 (tag) -> origin"
+)
+
+// setupSingleTrackWithRemote creates a GitHub-flow (single-track) repository with
+// an origin remote whose main branch is tracked. This maps to the spec's
+// "single-track" layout: main only, feature -> main, no develop, no tag.
+// Returns the local repo dir and the bare remote dir.
+func setupSingleTrackWithRemote(t *testing.T) (string, string) {
+	t.Helper()
+	dir := testutil.SetupTestRepo(t)
+
+	if _, err := testutil.RunGitFlow(t, dir, "init", "--preset=github"); err != nil {
+		testutil.CleanupTestRepo(t, dir)
+		t.Fatalf("Failed to initialize git-flow github preset: %v", err)
+	}
+
+	remoteDir, err := testutil.AddRemote(t, dir, "origin", false)
+	if err != nil {
+		testutil.CleanupTestRepo(t, dir)
+		t.Fatalf("Failed to add remote: %v", err)
+	}
+
+	if _, err := testutil.RunGit(t, dir, "push", "-u", "origin", "main"); err != nil {
+		testutil.CleanupTestRepo(t, dir)
+		testutil.CleanupTestRepo(t, remoteDir)
+		t.Fatalf("Failed to push main: %v", err)
+	}
+
+	return dir, remoteDir
+}
+
+// setupSingleTrackNoRemote creates a GitHub-flow (single-track) repository with
+// no remote configured.
+func setupSingleTrackNoRemote(t *testing.T) string {
+	t.Helper()
+	dir := testutil.SetupTestRepo(t)
+
+	if _, err := testutil.RunGitFlow(t, dir, "init", "--preset=github"); err != nil {
+		testutil.CleanupTestRepo(t, dir)
+		t.Fatalf("Failed to initialize git-flow github preset: %v", err)
+	}
+
+	return dir
+}
+
+// createTopicCommit starts a topic branch of the given type and commits one file
+// to it, leaving that branch checked out.
+func createTopicCommit(t *testing.T, dir, branchType, name, file, content string) {
+	t.Helper()
+	if _, err := testutil.RunGitFlow(t, dir, branchType, "start", name); err != nil {
+		t.Fatalf("Failed to start %s branch %s: %v", branchType, name, err)
+	}
+	if err := testutil.WriteFile(t, dir, file, content); err != nil {
+		t.Fatalf("Failed to write %s: %v", file, err)
+	}
+	if _, err := testutil.RunGit(t, dir, "add", file); err != nil {
+		t.Fatalf("Failed to add %s: %v", file, err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Add "+file); err != nil {
+		t.Fatalf("Failed to commit %s: %v", file, err)
+	}
+}
+
+// TestFinishPushDefaultDoesNotPush tests that finishing without any push flag or
+// config does not push to the remote.
+// Steps:
+// 1. Sets up a single-track (github preset) repo with origin tracking main
+// 2. Creates feature branch 'login' with one commit
+// 3. Runs 'git flow feature finish login --no-fetch' (no push flag, no config)
+// 4. Verifies exit 0 and that main is ahead of origin (not pushed)
+// 5. Verifies output contains no "Pushing to remote" header
+func TestFinishPushDefaultDoesNotPush(t *testing.T) {
+	dir, remoteDir := setupSingleTrackWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	createTopicCommit(t, dir, "feature", "login", "login.txt", "login content")
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "login", "--no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to finish feature branch: %v\nOutput: %s", err, output)
+	}
+
+	if got := testutil.CommitsAhead(t, dir, "origin/main", "main"); got == 0 {
+		t.Errorf("Expected main to be ahead of origin (not pushed), got %d commits ahead", got)
+	}
+	if strings.Contains(output, pushHeader) {
+		t.Errorf("Expected no push to occur by default. Output: %s", output)
+	}
+}
+
+// TestFinishPushSingleTrackFeature tests that --push pushes the target branch on a
+// single-track feature finish (no children, no tag).
+// Steps:
+// 1. Sets up a single-track repo with origin tracking main
+// 2. Creates feature branch 'login' with one commit
+// 3. Runs 'git flow feature finish login --push --no-fetch'
+// 4. Verifies exit 0 and main up to date with origin (pushed)
+// 5. Verifies output shows the push header and the main push line
+// 6. Verifies the finished topic branch is NOT pushed to origin
+func TestFinishPushSingleTrackFeature(t *testing.T) {
+	dir, remoteDir := setupSingleTrackWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	createTopicCommit(t, dir, "feature", "login", "login.txt", "login content")
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "login", "--push", "--no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to finish feature branch with --push: %v\nOutput: %s", err, output)
+	}
+
+	if got := testutil.CommitsAhead(t, dir, "origin/main", "main"); got != 0 {
+		t.Errorf("Expected main up to date with origin (pushed), got %d commits ahead", got)
+	}
+	if !strings.Contains(output, pushHeader) {
+		t.Errorf("Expected push header in output. Output: %s", output)
+	}
+	if !strings.Contains(output, pushMainLine) {
+		t.Errorf("Expected main push line in output. Output: %s", output)
+	}
+
+	// The topic branch itself is never pushed by these flags.
+	heads, err := testutil.RunGit(t, dir, "ls-remote", "--heads", "origin")
+	if err != nil {
+		t.Fatalf("Failed to list remote heads: %v", err)
+	}
+	if strings.Contains(heads, "refs/heads/feature/login") {
+		t.Errorf("Expected feature/login NOT to be pushed to origin. Heads: %s", heads)
+	}
+}
+
+// TestFinishPushClassicReleaseBranchesAndTag tests that --push on a classic release
+// pushes the target branch, the auto-updated child branch, and the created tag.
+// Steps:
+// 1. Sets up a classic repo (main + develop tracked) with origin
+// 2. Creates release branch '1.0.0' with one commit
+// 3. Runs 'git flow release finish 1.0.0 --push --no-fetch'
+// 4. Verifies exit 0 and that main and develop are up to date with origin
+// 5. Verifies the release tag 1.0.0 exists on origin
+// 6. Verifies output shows main, develop, and tag push lines
+func TestFinishPushClassicReleaseBranchesAndTag(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	createTopicCommit(t, dir, "release", "1.0.0", "release.txt", "release content")
+
+	output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0", "--push", "--no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to finish release with --push: %v\nOutput: %s", err, output)
+	}
+
+	if got := testutil.CommitsAhead(t, dir, "origin/main", "main"); got != 0 {
+		t.Errorf("Expected main up to date with origin, got %d ahead", got)
+	}
+	if got := testutil.CommitsAhead(t, dir, "origin/develop", "develop"); got != 0 {
+		t.Errorf("Expected develop up to date with origin, got %d ahead", got)
+	}
+	if !testutil.RemoteTagExists(t, dir, "origin", "1.0.0") {
+		t.Error("Expected tag 1.0.0 to exist on origin")
+	}
+	if !strings.Contains(output, pushMainLine) {
+		t.Errorf("Expected main push line. Output: %s", output)
+	}
+	if !strings.Contains(output, pushDevelLine) {
+		t.Errorf("Expected develop push line. Output: %s", output)
+	}
+	if !strings.Contains(output, pushTag100Line) {
+		t.Errorf("Expected tag push line. Output: %s", output)
+	}
+}
+
+// TestFinishPushConfigEnablesPush tests that gitflow.feature.finish.push=true
+// triggers a push without any CLI flag.
+// Steps:
+// 1. Sets up a single-track repo with origin tracking main
+// 2. Sets gitflow.feature.finish.push=true
+// 3. Creates feature branch 'login' with one commit
+// 4. Runs 'git flow feature finish login --no-fetch' (no push flag)
+// 5. Verifies exit 0 and main up to date with origin (config alone triggers push)
+// 6. Verifies output contains the main push line
+func TestFinishPushConfigEnablesPush(t *testing.T) {
+	dir, remoteDir := setupSingleTrackWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.feature.finish.push", "true"); err != nil {
+		t.Fatalf("Failed to configure push: %v", err)
+	}
+
+	createTopicCommit(t, dir, "feature", "login", "login.txt", "login content")
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "login", "--no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to finish feature branch: %v\nOutput: %s", err, output)
+	}
+
+	if got := testutil.CommitsAhead(t, dir, "origin/main", "main"); got != 0 {
+		t.Errorf("Expected main up to date with origin (config push), got %d ahead", got)
+	}
+	if !strings.Contains(output, pushMainLine) {
+		t.Errorf("Expected main push line. Output: %s", output)
+	}
+}
+
+// TestFinishPushNoPushFlagOverridesConfig tests that --no-push overrides
+// gitflow.feature.finish.push=true.
+// Steps:
+// 1. Sets up a single-track repo with origin tracking main
+// 2. Sets gitflow.feature.finish.push=true
+// 3. Creates feature branch 'login' with one commit
+// 4. Runs 'git flow feature finish login --no-push --no-fetch'
+// 5. Verifies exit 0 and main ahead of origin (nothing pushed)
+// 6. Verifies output contains no "Pushing to remote" header
+func TestFinishPushNoPushFlagOverridesConfig(t *testing.T) {
+	dir, remoteDir := setupSingleTrackWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.feature.finish.push", "true"); err != nil {
+		t.Fatalf("Failed to configure push: %v", err)
+	}
+
+	createTopicCommit(t, dir, "feature", "login", "login.txt", "login content")
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "login", "--no-push", "--no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to finish feature branch: %v\nOutput: %s", err, output)
+	}
+
+	if got := testutil.CommitsAhead(t, dir, "origin/main", "main"); got == 0 {
+		t.Errorf("Expected main ahead of origin (--no-push overrides config), got %d ahead", got)
+	}
+	if strings.Contains(output, pushHeader) {
+		t.Errorf("Expected no push with --no-push. Output: %s", output)
+	}
+}
+
+// TestFinishPushBranchesNotTag tests that --push --no-pushtag pushes branches but
+// not the tag on a classic release.
+// Steps:
+// 1. Sets up a classic repo with origin
+// 2. Creates release branch '1.0.0' with one commit
+// 3. Runs 'git flow release finish 1.0.0 --push --no-pushtag --no-fetch'
+// 4. Verifies exit 0 and main and develop up to date with origin
+// 5. Verifies tag 1.0.0 is NOT on origin
+// 6. Verifies output shows branch lines but no (tag) line
+func TestFinishPushBranchesNotTag(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	createTopicCommit(t, dir, "release", "1.0.0", "release.txt", "release content")
+
+	output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0", "--push", "--no-pushtag", "--no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to finish release: %v\nOutput: %s", err, output)
+	}
+
+	if got := testutil.CommitsAhead(t, dir, "origin/main", "main"); got != 0 {
+		t.Errorf("Expected main up to date with origin, got %d ahead", got)
+	}
+	if got := testutil.CommitsAhead(t, dir, "origin/develop", "develop"); got != 0 {
+		t.Errorf("Expected develop up to date with origin, got %d ahead", got)
+	}
+	if testutil.RemoteTagExists(t, dir, "origin", "1.0.0") {
+		t.Error("Expected tag 1.0.0 NOT to be on origin with --no-pushtag")
+	}
+	if !strings.Contains(output, pushMainLine) {
+		t.Errorf("Expected main push line. Output: %s", output)
+	}
+	if strings.Contains(output, "(tag)") {
+		t.Errorf("Expected no tag push line. Output: %s", output)
+	}
+}
+
+// TestFinishPushTagOnlyViaFlag tests that --pushtag alone pushes only the tag, not
+// branches, on a classic release.
+// Steps:
+// 1. Sets up a classic repo with origin
+// 2. Creates release branch '1.0.0' with one commit
+// 3. Runs 'git flow release finish 1.0.0 --pushtag --no-fetch' (no --push)
+// 4. Verifies exit 0 and tag 1.0.0 exists on origin
+// 5. Verifies main and develop are ahead of origin (branches not pushed)
+// 6. Verifies output shows the tag line but no branch push lines
+func TestFinishPushTagOnlyViaFlag(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	createTopicCommit(t, dir, "release", "1.0.0", "release.txt", "release content")
+
+	output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0", "--pushtag", "--no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to finish release: %v\nOutput: %s", err, output)
+	}
+
+	if !testutil.RemoteTagExists(t, dir, "origin", "1.0.0") {
+		t.Error("Expected tag 1.0.0 to exist on origin")
+	}
+	if got := testutil.CommitsAhead(t, dir, "origin/main", "main"); got == 0 {
+		t.Errorf("Expected main ahead of origin (branches not pushed), got %d ahead", got)
+	}
+	if got := testutil.CommitsAhead(t, dir, "origin/develop", "develop"); got == 0 {
+		t.Errorf("Expected develop ahead of origin (branches not pushed), got %d ahead", got)
+	}
+	if !strings.Contains(output, pushTag100Line) {
+		t.Errorf("Expected tag push line. Output: %s", output)
+	}
+	if strings.Contains(output, pushMainLine) || strings.Contains(output, pushDevelLine) {
+		t.Errorf("Expected no branch push lines. Output: %s", output)
+	}
+}
+
+// TestFinishPushConfigBranchesTagSuppressed tests per-key config where push=true
+// but pushtag=false on a classic release.
+// Steps:
+// 1. Sets up a classic repo with origin
+// 2. Sets gitflow.release.finish.push=true and gitflow.release.finish.pushtag=false
+// 3. Creates release branch '1.0.0' with one commit
+// 4. Runs 'git flow release finish 1.0.0 --no-fetch' (no flags)
+// 5. Verifies exit 0 and main and develop up to date with origin
+// 6. Verifies tag 1.0.0 is NOT on origin (tag suppressed)
+func TestFinishPushConfigBranchesTagSuppressed(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.release.finish.push", "true"); err != nil {
+		t.Fatalf("Failed to configure push: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.release.finish.pushtag", "false"); err != nil {
+		t.Fatalf("Failed to configure pushtag: %v", err)
+	}
+
+	createTopicCommit(t, dir, "release", "1.0.0", "release.txt", "release content")
+
+	output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0", "--no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to finish release: %v\nOutput: %s", err, output)
+	}
+
+	if got := testutil.CommitsAhead(t, dir, "origin/main", "main"); got != 0 {
+		t.Errorf("Expected main up to date with origin, got %d ahead", got)
+	}
+	if got := testutil.CommitsAhead(t, dir, "origin/develop", "develop"); got != 0 {
+		t.Errorf("Expected develop up to date with origin, got %d ahead", got)
+	}
+	if testutil.RemoteTagExists(t, dir, "origin", "1.0.0") {
+		t.Error("Expected tag 1.0.0 NOT to be on origin (pushtag=false)")
+	}
+}
+
+// TestFinishPushConfigTagOnly tests that gitflow.release.finish.pushtag=true alone
+// pushes the tag but not branches.
+// Steps:
+// 1. Sets up a classic repo with origin
+// 2. Sets gitflow.release.finish.pushtag=true (no push config, no flags)
+// 3. Creates release branch '1.0.0' with one commit
+// 4. Runs 'git flow release finish 1.0.0 --no-fetch'
+// 5. Verifies exit 0 and tag 1.0.0 exists on origin
+// 6. Verifies main and develop are ahead of origin (branches not pushed)
+func TestFinishPushConfigTagOnly(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.release.finish.pushtag", "true"); err != nil {
+		t.Fatalf("Failed to configure pushtag: %v", err)
+	}
+
+	createTopicCommit(t, dir, "release", "1.0.0", "release.txt", "release content")
+
+	output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0", "--no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to finish release: %v\nOutput: %s", err, output)
+	}
+
+	if !testutil.RemoteTagExists(t, dir, "origin", "1.0.0") {
+		t.Error("Expected tag 1.0.0 to exist on origin (pushtag config)")
+	}
+	if got := testutil.CommitsAhead(t, dir, "origin/main", "main"); got == 0 {
+		t.Errorf("Expected main ahead of origin (branches not pushed), got %d ahead", got)
+	}
+	if got := testutil.CommitsAhead(t, dir, "origin/develop", "develop"); got == 0 {
+		t.Errorf("Expected develop ahead of origin (branches not pushed), got %d ahead", got)
+	}
+}
+
+// TestFinishPushTagFlagOverridesConfigFalse tests that --pushtag overrides
+// gitflow.release.finish.pushtag=false without implying --push.
+// Steps:
+// 1. Sets up a classic repo with origin
+// 2. Sets gitflow.release.finish.pushtag=false
+// 3. Creates release branch '1.0.0' with one commit
+// 4. Runs 'git flow release finish 1.0.0 --pushtag --no-fetch'
+// 5. Verifies exit 0 and tag 1.0.0 exists on origin (flag overrides config)
+// 6. Verifies main and develop are ahead of origin (--pushtag alone does not imply --push)
+func TestFinishPushTagFlagOverridesConfigFalse(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.release.finish.pushtag", "false"); err != nil {
+		t.Fatalf("Failed to configure pushtag: %v", err)
+	}
+
+	createTopicCommit(t, dir, "release", "1.0.0", "release.txt", "release content")
+
+	output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0", "--pushtag", "--no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to finish release: %v\nOutput: %s", err, output)
+	}
+
+	if !testutil.RemoteTagExists(t, dir, "origin", "1.0.0") {
+		t.Error("Expected tag 1.0.0 to exist on origin (--pushtag overrides config)")
+	}
+	if got := testutil.CommitsAhead(t, dir, "origin/main", "main"); got == 0 {
+		t.Errorf("Expected main ahead of origin (--pushtag must not imply --push), got %d ahead", got)
+	}
+	if got := testutil.CommitsAhead(t, dir, "origin/develop", "develop"); got == 0 {
+		t.Errorf("Expected develop ahead of origin (--pushtag must not imply --push), got %d ahead", got)
+	}
+}
+
+// TestFinishPushNoPushSuppressesInheritedTag tests that --no-push suppresses the
+// inherited tag push even when gitflow.release.finish.push=true.
+// Steps:
+// 1. Sets up a classic repo with origin
+// 2. Sets gitflow.release.finish.push=true
+// 3. Creates release branch '1.0.0' with one commit
+// 4. Runs 'git flow release finish 1.0.0 --no-push --no-fetch'
+// 5. Verifies exit 0, main and develop ahead of origin, and tag 1.0.0 NOT on origin
+func TestFinishPushNoPushSuppressesInheritedTag(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.release.finish.push", "true"); err != nil {
+		t.Fatalf("Failed to configure push: %v", err)
+	}
+
+	createTopicCommit(t, dir, "release", "1.0.0", "release.txt", "release content")
+
+	output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0", "--no-push", "--no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to finish release: %v\nOutput: %s", err, output)
+	}
+
+	if got := testutil.CommitsAhead(t, dir, "origin/main", "main"); got == 0 {
+		t.Errorf("Expected main ahead of origin (--no-push), got %d ahead", got)
+	}
+	if got := testutil.CommitsAhead(t, dir, "origin/develop", "develop"); got == 0 {
+		t.Errorf("Expected develop ahead of origin (--no-push), got %d ahead", got)
+	}
+	if testutil.RemoteTagExists(t, dir, "origin", "1.0.0") {
+		t.Error("Expected tag 1.0.0 NOT to be on origin (--no-push suppresses inherited tag)")
+	}
+}
+
+// TestFinishPushTagNoopWhenNoTag tests that --push --pushtag on a single-track
+// feature (no tag created) pushes the branch and no-ops the tag.
+// Steps:
+// 1. Sets up a single-track repo with origin tracking main
+// 2. Creates feature branch 'login' with one commit
+// 3. Runs 'git flow feature finish login --push --pushtag --no-fetch'
+// 4. Verifies exit 0 (no error over absent tag) and main up to date with origin
+// 5. Verifies output shows the main push line and no (tag) line
+func TestFinishPushTagNoopWhenNoTag(t *testing.T) {
+	dir, remoteDir := setupSingleTrackWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	createTopicCommit(t, dir, "feature", "login", "login.txt", "login content")
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "login", "--push", "--pushtag", "--no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to finish feature branch: %v\nOutput: %s", err, output)
+	}
+
+	if got := testutil.CommitsAhead(t, dir, "origin/main", "main"); got != 0 {
+		t.Errorf("Expected main up to date with origin, got %d ahead", got)
+	}
+	if !strings.Contains(output, pushMainLine) {
+		t.Errorf("Expected main push line. Output: %s", output)
+	}
+	if strings.Contains(output, "(tag)") {
+		t.Errorf("Expected no tag push line when no tag created. Output: %s", output)
+	}
+}
+
+// TestFinishPushClassicHotfix tests that --push works on a classic hotfix, pushing
+// the target branch, the auto-updated develop, and the hotfix tag.
+// Steps:
+// 1. Sets up a classic repo with origin
+// 2. Creates hotfix branch '1.0.1' with one commit
+// 3. Runs 'git flow hotfix finish 1.0.1 --push --no-fetch'
+// 4. Verifies exit 0 and main and develop up to date with origin
+// 5. Verifies hotfix tag 1.0.1 exists on origin
+func TestFinishPushClassicHotfix(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	createTopicCommit(t, dir, "hotfix", "1.0.1", "hotfix.txt", "hotfix content")
+
+	output, err := testutil.RunGitFlow(t, dir, "hotfix", "finish", "1.0.1", "--push", "--no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to finish hotfix with --push: %v\nOutput: %s", err, output)
+	}
+
+	if got := testutil.CommitsAhead(t, dir, "origin/main", "main"); got != 0 {
+		t.Errorf("Expected main up to date with origin, got %d ahead", got)
+	}
+	if got := testutil.CommitsAhead(t, dir, "origin/develop", "develop"); got != 0 {
+		t.Errorf("Expected develop up to date with origin, got %d ahead", got)
+	}
+	if !testutil.RemoteTagExists(t, dir, "origin", "1.0.1") {
+		t.Error("Expected hotfix tag 1.0.1 to exist on origin")
+	}
+}
+
+// TestFinishPushPerBranchTypeIndependence tests that push resolution keys off the
+// branch type: a feature configured to push does, while a hotfix configured not to
+// does not.
+// Steps:
+// 1. Sets up a classic repo with origin
+// 2. Sets gitflow.feature.finish.push=true and gitflow.hotfix.finish.push=false
+// 3. Creates feature branch 'x' (-> develop) with one commit and finishes it
+// 4. Verifies develop up to date with origin (feature target pushed)
+// 5. Creates hotfix branch '1.0.1' (-> main) with one commit and finishes it
+// 6. Verifies main and develop are ahead of origin (hotfix pushes nothing)
+// 7. Verifies hotfix tag 1.0.1 is NOT on origin and no push header in hotfix output
+func TestFinishPushPerBranchTypeIndependence(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.feature.finish.push", "true"); err != nil {
+		t.Fatalf("Failed to configure feature push: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.hotfix.finish.push", "false"); err != nil {
+		t.Fatalf("Failed to configure hotfix push: %v", err)
+	}
+
+	// Finish the feature (target develop should be pushed).
+	createTopicCommit(t, dir, "feature", "x", "feature-x.txt", "feature x content")
+	featureOutput, err := testutil.RunGitFlow(t, dir, "feature", "finish", "x", "--no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to finish feature: %v\nOutput: %s", err, featureOutput)
+	}
+	if got := testutil.CommitsAhead(t, dir, "origin/develop", "develop"); got != 0 {
+		t.Errorf("Expected develop up to date with origin after feature finish, got %d ahead", got)
+	}
+
+	// Finish the hotfix (nothing should be pushed).
+	createTopicCommit(t, dir, "hotfix", "1.0.1", "hotfix.txt", "hotfix content")
+	hotfixOutput, err := testutil.RunGitFlow(t, dir, "hotfix", "finish", "1.0.1", "--no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to finish hotfix: %v\nOutput: %s", err, hotfixOutput)
+	}
+	if got := testutil.CommitsAhead(t, dir, "origin/main", "main"); got == 0 {
+		t.Errorf("Expected main ahead of origin after hotfix finish (no push), got %d ahead", got)
+	}
+	if got := testutil.CommitsAhead(t, dir, "origin/develop", "develop"); got == 0 {
+		t.Errorf("Expected develop ahead of origin after hotfix finish (no push), got %d ahead", got)
+	}
+	if testutil.RemoteTagExists(t, dir, "origin", "1.0.1") {
+		t.Error("Expected hotfix tag 1.0.1 NOT to be on origin (hotfix push disabled)")
+	}
+	if strings.Contains(hotfixOutput, pushHeader) {
+		t.Errorf("Expected no push header in hotfix output. Output: %s", hotfixOutput)
+	}
+}
+
+// TestFinishPushNoRemoteSkips tests that --push with no remote configured skips the
+// push with a note rather than erroring.
+// Steps:
+// 1. Sets up a single-track repo with NO remote
+// 2. Creates feature branch 'login' with one commit
+// 3. Runs 'git flow feature finish login --push'
+// 4. Verifies exit 0 and the finish completes (feature branch deleted, main has merge)
+// 5. Verifies output notes the push was skipped and contains no hard error
+func TestFinishPushNoRemoteSkips(t *testing.T) {
+	dir := setupSingleTrackNoRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	createTopicCommit(t, dir, "feature", "login", "login.txt", "login content")
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "login", "--push")
+	if err != nil {
+		t.Fatalf("Expected finish to succeed with no remote, got error: %v\nOutput: %s", err, output)
+	}
+
+	if testutil.BranchExists(t, dir, "feature/login") {
+		t.Error("Expected feature/login to be deleted")
+	}
+	if _, err := testutil.RunGit(t, dir, "checkout", "main"); err != nil {
+		t.Fatalf("Failed to checkout main: %v", err)
+	}
+	if !testutil.FileExists(t, dir, "login.txt") {
+		t.Error("Expected login.txt to exist in main")
+	}
+
+	lower := strings.ToLower(output)
+	if !strings.Contains(lower, "push") || !strings.Contains(lower, "skip") {
+		t.Errorf("Expected a skip note mentioning push. Output: %s", output)
+	}
+}
+
+// TestFinishPushRunsAfterContinue tests that push (enabled via config) runs at the
+// end of a resumed finish and does not run during the conflicted initial stage.
+// Steps:
+// 1. Sets up a classic repo with origin and gitflow.release.finish.push=true
+// 2. Creates release branch '1.0.0' with conflicting content against main
+// 3. Runs 'git flow release finish 1.0.0 --no-fetch' which conflicts
+// 4. Verifies conflict state, that nothing was pushed, and no push header
+// 5. Resolves the conflict and runs 'git flow release finish --continue 1.0.0'
+// 6. Verifies exit 0, main and develop up to date with origin, and tag 1.0.0 on origin
+func TestFinishPushRunsAfterContinue(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.release.finish.push", "true"); err != nil {
+		t.Fatalf("Failed to configure push: %v", err)
+	}
+
+	// Create release branch with conflicting content, then add conflicting
+	// content to main so the merge into main conflicts.
+	if _, err := testutil.RunGitFlow(t, dir, "release", "start", "1.0.0"); err != nil {
+		t.Fatalf("Failed to start release: %v", err)
+	}
+	testutil.WriteFile(t, dir, "conflict.txt", "release version")
+	if _, err := testutil.RunGit(t, dir, "add", "conflict.txt"); err != nil {
+		t.Fatalf("Failed to add conflict.txt: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Release conflict"); err != nil {
+		t.Fatalf("Failed to commit release conflict: %v", err)
+	}
+
+	if _, err := testutil.RunGit(t, dir, "checkout", "main"); err != nil {
+		t.Fatalf("Failed to checkout main: %v", err)
+	}
+	testutil.WriteFile(t, dir, "conflict.txt", "main version")
+	if _, err := testutil.RunGit(t, dir, "add", "conflict.txt"); err != nil {
+		t.Fatalf("Failed to add conflict.txt on main: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Main conflict"); err != nil {
+		t.Fatalf("Failed to commit main conflict: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "checkout", "release/1.0.0"); err != nil {
+		t.Fatalf("Failed to checkout release branch: %v", err)
+	}
+
+	// Initial finish conflicts.
+	conflictOutput, _ := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0", "--no-fetch")
+	if !strings.Contains(conflictOutput, "conflict") && !strings.Contains(conflictOutput, "CONFLICT") {
+		t.Errorf("Expected merge conflict. Output: %s", conflictOutput)
+	}
+	// Conflict stage must not have pushed anything.
+	if _, err := os.Stat(filepath.Join(dir, ".git", "MERGE_HEAD")); os.IsNotExist(err) {
+		t.Error("Expected .git/MERGE_HEAD to exist during conflict")
+	}
+	state, err := testutil.LoadMergeState(t, dir)
+	if err != nil {
+		t.Fatalf("Expected in-progress merge state: %v", err)
+	}
+	if state.Action != "finish" {
+		t.Errorf("Expected in-progress finish, got action %q", state.Action)
+	}
+	if testutil.RemoteTagExists(t, dir, "origin", "1.0.0") {
+		t.Error("Expected tag 1.0.0 absent from origin during conflict")
+	}
+	if strings.Contains(conflictOutput, pushHeader) {
+		t.Errorf("Expected no push header during conflict. Output: %s", conflictOutput)
+	}
+
+	// Resolve and continue.
+	testutil.WriteFile(t, dir, "conflict.txt", "resolved")
+	if _, err := testutil.RunGit(t, dir, "add", "conflict.txt"); err != nil {
+		t.Fatalf("Failed to stage resolution: %v", err)
+	}
+	continueOutput, err := testutil.RunGitFlow(t, dir, "release", "finish", "--continue", "1.0.0")
+	if err != nil {
+		t.Fatalf("Failed to continue finish: %v\nOutput: %s", err, continueOutput)
+	}
+
+	if got := testutil.CommitsAhead(t, dir, "origin/main", "main"); got != 0 {
+		t.Errorf("Expected main up to date with origin after continue, got %d ahead", got)
+	}
+	if got := testutil.CommitsAhead(t, dir, "origin/develop", "develop"); got != 0 {
+		t.Errorf("Expected develop up to date with origin after continue, got %d ahead", got)
+	}
+	if !testutil.RemoteTagExists(t, dir, "origin", "1.0.0") {
+		t.Error("Expected tag 1.0.0 on origin after continue")
+	}
+}
+
+// TestFinishPushRejectedNonFastForward tests that a rejected (non-ff) push surfaces
+// as an error while leaving the completed local finish intact.
+// Steps:
+// 1. Sets up a single-track repo with origin tracking main
+// 2. Diverges origin/main by pushing a commit from a second clone
+// 3. Creates feature branch 'login' with one commit locally (main stays behind)
+// 4. Runs 'git flow feature finish login --push --no-fetch'
+// 5. Verifies non-zero exit and the error reports the rejected push
+// 6. Verifies the local finish is complete (feature deleted, main has merge, no merge state)
+func TestFinishPushRejectedNonFastForward(t *testing.T) {
+	dir, remoteDir := setupSingleTrackWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	// Diverge origin/main via a second clone.
+	secondDir := t.TempDir()
+	if _, err := testutil.RunGit(t, secondDir, "clone", remoteDir, "."); err != nil {
+		t.Fatalf("Failed to clone remote: %v", err)
+	}
+	testutil.ConfigureGitIdentity(t, secondDir)
+	testutil.WriteFile(t, secondDir, "remote.txt", "remote change")
+	if _, err := testutil.RunGit(t, secondDir, "add", "remote.txt"); err != nil {
+		t.Fatalf("Failed to add remote.txt: %v", err)
+	}
+	if _, err := testutil.RunGit(t, secondDir, "commit", "-m", "Remote change"); err != nil {
+		t.Fatalf("Failed to commit remote change: %v", err)
+	}
+	if _, err := testutil.RunGit(t, secondDir, "push", "origin", "main"); err != nil {
+		t.Fatalf("Failed to push remote change: %v", err)
+	}
+
+	// Create the feature locally; local main stays behind origin/main.
+	createTopicCommit(t, dir, "feature", "login", "login.txt", "login content")
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "login", "--push", "--no-fetch")
+	if err == nil {
+		t.Fatalf("Expected finish to fail on non-ff push. Output: %s", output)
+	}
+
+	lower := strings.ToLower(output)
+	if !strings.Contains(lower, "reject") && !strings.Contains(lower, "non-fast-forward") && !strings.Contains(lower, "fast-forward") {
+		t.Errorf("Expected error to report rejected/non-fast-forward push. Output: %s", output)
+	}
+
+	// Local finish is already complete; nothing rolled back.
+	if testutil.BranchExists(t, dir, "feature/login") {
+		t.Error("Expected feature/login to be deleted (local finish complete)")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, ".git", "MERGE_HEAD")); !os.IsNotExist(statErr) {
+		t.Error("Expected no .git/MERGE_HEAD (finish complete)")
+	}
+	if _, loadErr := testutil.LoadMergeState(t, dir); loadErr == nil {
+		t.Error("Expected no in-progress merge state (finish complete)")
+	}
+	if _, err := testutil.RunGit(t, dir, "checkout", "main"); err != nil {
+		t.Fatalf("Failed to checkout main: %v", err)
+	}
+	if !testutil.FileExists(t, dir, "login.txt") {
+		t.Error("Expected login.txt in main (merge completed locally)")
+	}
+}
+
+// TestFinishPushConfigPushInheritsTag tests that a bare gitflow.release.finish.push=true
+// (no pushtag key, no flags) pushes the created tag via the default-derivation path.
+// Steps:
+// 1. Sets up a classic repo with origin
+// 2. Sets gitflow.release.finish.push=true (no pushtag key)
+// 3. Creates release branch '1.0.0' with one commit
+// 4. Runs 'git flow release finish 1.0.0 --no-fetch'
+// 5. Verifies exit 0, main and develop up to date with origin, and tag 1.0.0 on origin
+func TestFinishPushConfigPushInheritsTag(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.release.finish.push", "true"); err != nil {
+		t.Fatalf("Failed to configure push: %v", err)
+	}
+
+	createTopicCommit(t, dir, "release", "1.0.0", "release.txt", "release content")
+
+	output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0", "--no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to finish release: %v\nOutput: %s", err, output)
+	}
+
+	if got := testutil.CommitsAhead(t, dir, "origin/main", "main"); got != 0 {
+		t.Errorf("Expected main up to date with origin, got %d ahead", got)
+	}
+	if got := testutil.CommitsAhead(t, dir, "origin/develop", "develop"); got != 0 {
+		t.Errorf("Expected develop up to date with origin, got %d ahead", got)
+	}
+	if !testutil.RemoteTagExists(t, dir, "origin", "1.0.0") {
+		t.Error("Expected tag 1.0.0 on origin (pushTag inherits config push value)")
+	}
+}
+
+// TestFinishPushOrderingParentThenChildren tests that --push output lists the parent
+// branch before child branches, the tag after both, and dedupes the parent push line.
+// Steps:
+// 1. Sets up a classic repo with origin
+// 2. Creates release branch '1.0.0' with one commit
+// 3. Runs 'git flow release finish 1.0.0 --push --no-fetch' and captures output
+// 4. Verifies main push line precedes develop push line, which precedes the tag line
+// 5. Verifies the exact main push line appears exactly once (dedupe)
+func TestFinishPushOrderingParentThenChildren(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	createTopicCommit(t, dir, "release", "1.0.0", "release.txt", "release content")
+
+	output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0", "--push", "--no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to finish release: %v\nOutput: %s", err, output)
+	}
+
+	mainIdx := strings.Index(output, pushMainLine)
+	develIdx := strings.Index(output, pushDevelLine)
+	tagIdx := strings.Index(output, pushTag100Line)
+	if mainIdx < 0 || develIdx < 0 || tagIdx < 0 {
+		t.Fatalf("Expected all three push lines present. Output: %s", output)
+	}
+	if !(mainIdx < develIdx) {
+		t.Errorf("Expected main push line before develop push line. Output: %s", output)
+	}
+	if !(develIdx < tagIdx) {
+		t.Errorf("Expected develop push line before tag line. Output: %s", output)
+	}
+	if count := strings.Count(output, pushMainLine); count != 1 {
+		t.Errorf("Expected exact main push line exactly once (dedupe), got %d. Output: %s", count, output)
+	}
+}

--- a/test/cmd/finish_push_test.go
+++ b/test/cmd/finish_push_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 // Push output format asserted throughout these tests (from the spec examples):
-//   Header line: "Pushing to remote 'origin'..."
-//   Per branch:  "  <branch> -> origin/<branch>"
-//   Tag:         "  <tag> (tag) -> origin"
+//
+//	Header line: "Pushing to remote 'origin'..."
+//	Per branch:  "  <branch> -> origin/<branch>"
+//	Tag:         "  <tag> (tag) -> origin"
 const (
 	pushHeader     = "Pushing to remote 'origin'..."
 	pushMainLine   = "  main -> origin/main"
@@ -848,5 +849,35 @@ func TestFinishPushOrderingParentThenChildren(t *testing.T) {
 	}
 	if count := strings.Count(output, pushMainLine); count != 1 {
 		t.Errorf("Expected exact main push line exactly once (dedupe), got %d. Output: %s", count, output)
+	}
+}
+
+// TestFinishPushShorthandForwardsFlag tests that the shorthand `git flow finish`
+// (operating on the current topic branch) honors the --push flag. Regression
+// guard: the shorthand originally registered the push flags but dropped them
+// when calling FinishCommand, so `git flow finish --push` silently did nothing.
+// Steps:
+// 1. Sets up a single-track repo with origin tracking main
+// 2. Creates feature branch 'login' with one commit (leaves it checked out)
+// 3. Runs the shorthand 'git flow finish --push --no-fetch' (no type/name)
+// 4. Verifies main is up to date with origin (the flag was forwarded)
+// 5. Verifies output shows the push header and the main push line
+func TestFinishPushShorthandForwardsFlag(t *testing.T) {
+	dir, remoteDir := setupSingleTrackWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	createTopicCommit(t, dir, "feature", "login", "login.txt", "login content")
+
+	output, err := testutil.RunGitFlow(t, dir, "finish", "--push", "--no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to finish via shorthand with --push: %v\nOutput: %s", err, output)
+	}
+
+	if got := testutil.CommitsAhead(t, dir, "origin/main", "main"); got != 0 {
+		t.Errorf("Expected main up to date with origin (shorthand --push forwarded), got %d commits ahead. Output: %s", got, output)
+	}
+	if !strings.Contains(output, pushHeader) || !strings.Contains(output, pushMainLine) {
+		t.Errorf("Expected push header and main push line via shorthand. Output: %s", output)
 	}
 }

--- a/test/testutil/git.go
+++ b/test/testutil/git.go
@@ -295,7 +295,22 @@ func RemoteTagExists(t *testing.T, dir, remote, tag string) bool {
 	if err != nil {
 		t.Fatalf("Failed to list remote tags: %v\nOutput: %s", err, output)
 	}
-	return strings.Contains(output, fmt.Sprintf("refs/tags/%s", tag))
+	// ls-remote lines are "<sha>\t<ref>"; annotated tags add a peeled
+	// "<sha>\trefs/tags/<tag>^{}" line. Compare the ref field exactly so a
+	// searched tag is not matched as a prefix of a longer tag (e.g. "1.0"
+	// must not match "refs/tags/1.0.0").
+	wantRef := fmt.Sprintf("refs/tags/%s", tag)
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		ref := strings.TrimSuffix(fields[1], "^{}")
+		if ref == wantRef {
+			return true
+		}
+	}
+	return false
 }
 
 // CommitsAhead returns the number of commits that branch has that base does not,

--- a/test/testutil/git.go
+++ b/test/testutil/git.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -283,6 +284,36 @@ func RemoteBranchExists(t *testing.T, dir string, remote string, branch string) 
 	ref := fmt.Sprintf("refs/remotes/%s/%s", remote, branch)
 	_, err := RunGit(t, dir, "rev-parse", "--verify", "--quiet", ref)
 	return err == nil
+}
+
+// RemoteTagExists checks whether a tag exists on the given remote by querying
+// the remote directly with `git ls-remote --tags`. This reflects what was
+// actually pushed to the remote, not the local tag database.
+func RemoteTagExists(t *testing.T, dir, remote, tag string) bool {
+	t.Helper()
+	output, err := RunGit(t, dir, "ls-remote", "--tags", remote)
+	if err != nil {
+		t.Fatalf("Failed to list remote tags: %v\nOutput: %s", err, output)
+	}
+	return strings.Contains(output, fmt.Sprintf("refs/tags/%s", tag))
+}
+
+// CommitsAhead returns the number of commits that branch has that base does not,
+// computed via `git rev-list --count <base>..<branch>`. Use it with a remote
+// tracking ref as base (e.g. CommitsAhead(t, dir, "origin/main", "main")) to
+// determine whether a local branch has been pushed: a result of 0 means the
+// branch is up to date with the remote, > 0 means it is ahead (not pushed).
+func CommitsAhead(t *testing.T, dir, base, branch string) int {
+	t.Helper()
+	output, err := RunGit(t, dir, "rev-list", "--count", fmt.Sprintf("%s..%s", base, branch))
+	if err != nil {
+		t.Fatalf("Failed to count commits ahead (%s..%s): %v\nOutput: %s", base, branch, err, output)
+	}
+	count, err := strconv.Atoi(strings.TrimSpace(output))
+	if err != nil {
+		t.Fatalf("Failed to parse commit count %q: %v", output, err)
+	}
+	return count
 }
 
 // SetupTestRepoWithRemote creates a test repository with git-flow initialized and a local remote.


### PR DESCRIPTION
Adds opt-in `--push`/`--no-push` and `--pushtag`/`--no-pushtag` flags plus `gitflow.<type>.finish.push` / `.pushtag` config keys so a completed finish can push the branches it modified and the tag it created to the remote in one step, instead of requiring a manual `git push` afterward.

When enabled, finish runs a push stage as its final step — after all merges, the tag, child updates, and topic-branch cleanup succeed and the merge state is cleared. It pushes the target/parent branch plus each auto-updated child base branch (`state.ParentBranch` + `state.UpdatedBranches`), then the created tag if `pushTag` resolves true. Everything is off by default. Resolution uses the existing two-active-layer precedence (Layer 2 config, then Layer 3 CLI); `pushTag` derives its default from the resolved `push` value before its own config key and flag apply. A missing remote is a skip-with-note (exit 0), consistent with the fetch path; a rejected non-fast-forward push is a real error with no rollback, since the local finish is already complete. Options are re-resolved on `--continue`, so a push enabled via config survives a conflict resume. Changes touch `internal/config/resolver.go` (two fields, two resolvers), `cmd/finish.go` (the push stage and threaded options), `cmd/topicbranch.go` and `cmd/shorthand.go` (flag wiring), and `internal/git/repo.go` (new `PushRef` and `PushTag` helpers). A commit in this branch also fixes the shorthand `git flow finish` path, which registered the push flags but dropped them by passing nil pointers to `FinishCommand`.

Resolves #20

## Remarks

- avh's `--pushproduction`/`--pushdevelop` are intentionally out of scope; `--push` covers the target and children generically, matching the single-track-main default that has no fixed develop branch.
- A CLI-only `--push` on the initial run does not persist across `--continue` (flags are not stored in merge state); enabling push that must survive a conflict is done via config, which is documented.

**Review focus:**
- `internal/config/resolver.go` — `pushTag` default deriving from resolved `push` before its own config/flag apply
- `cmd/finish.go` — push stage placement (after merge-state clear, before success summary) and the missing-remote skip vs non-ff error distinction
- `cmd/shorthand.go` — the dropped-flag fix and its regression test