### PR TITLE
feat(finish): harden fetch and remote sync preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `finish` now treats a fetch failure against a reachable-but-failing remote as fatal (was a silent note); the error names the cause and suggests `--no-fetch` / `--force`
+- `finish` now aborts when the topic branch is ahead of its remote (was a silent note that proceeded and merged)
+- `finish` renders a diverged-specific message when the topic branch has diverged (previously reused the "behind" wording)
+- `start` now skips the fetch silently when no remote is configured, and shares the unified fetch resolution (default → config → flag) with `finish`
+
 ## [1.1.0] - 2026-04-06
 
 ### Added

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -159,7 +159,7 @@ The finish command supports per-branch-type configuration:
 | `keepremote` | Keep remote branch | `true`, `false` | `false` |
 | `keeplocal` | Keep local branch | `true`, `false` | `false` |
 | `force-delete` | Force delete branch | `true`, `false` | `false` |
-| `fetch` | Fetch before operation | `true`, `false` | `false` |
+| `fetch` | Fetch before operation (`gitflow.<type>.<cmd>.fetch`; default → config → `--fetch`/`--no-fetch`) | `true`, `false` | `true` for `finish`, `false` for `start` |
 
 #### Examples
 

--- a/cmd/finish.go
+++ b/cmd/finish.go
@@ -204,7 +204,7 @@ func executeFinish(branchType string, name string, continueOp bool, abortOp bool
 	// Fetch the topic (and parent, best-effort) and verify the topic is in sync with its remote.
 	// This runs only on the initial finish, never on --continue/--abort (handled above). A fatal
 	// fetch failure or an out-of-sync topic aborts here, before any merge.
-	if err := runFetchSyncPreflight(cfg, branchType, cfg.Remote, name, branchConfig.Parent, resolvedOptions.ShouldFetch, force); err != nil {
+	if err := runFetchSyncPreflight(cfg, branchType, cfg.Remote, name, shortName, branchConfig.Parent, resolvedOptions.ShouldFetch, force); err != nil {
 		return err
 	}
 

--- a/cmd/finish.go
+++ b/cmd/finish.go
@@ -201,45 +201,11 @@ func executeFinish(branchType string, name string, continueOp bool, abortOp bool
 	// Resolve all options once before starting operations
 	resolvedOptions := config.ResolveFinishOptions(cfg, branchType, shortName, tagOptions, retentionOptions, mergeOptions, fetch, noVerify)
 
-	// Perform fetch if enabled (only on initial finish, not continue)
-	if resolvedOptions.ShouldFetch && git.RemoteExists(cfg.Remote) {
-		fmt.Printf("Fetching from remote '%s'...\n", cfg.Remote)
-		// Fetch base branch
-		if err := git.FetchBranch(cfg.Remote, branchConfig.Parent); err != nil {
-			// Non-fatal: remote branch might not exist
-			fmt.Printf("Note: Could not fetch base branch '%s': %v\n", branchConfig.Parent, err)
-		}
-		// Fetch topic branch
-		if err := git.FetchBranch(cfg.Remote, name); err != nil {
-			// Non-fatal: remote branch might not exist
-			fmt.Printf("Note: Could not fetch topic branch '%s': %v\n", name, err)
-		}
-		fmt.Printf("Fetch completed\n")
-	}
-
-	// Check if local branch is in sync with remote (unless --force)
-	if !force {
-		status, commitCount, err := git.CompareBranchWithRemote(name)
-		if err == nil { // Only check if we can get tracking info
-			switch status {
-			case git.SyncStatusBehind, git.SyncStatusDiverged:
-				trackingBranch, err := git.GetTrackingBranch(name)
-				if err != nil {
-					trackingBranch = "remote tracking branch"
-				}
-				return &errors.BranchBehindRemoteError{
-					BranchName:   name,
-					RemoteBranch: trackingBranch,
-					CommitCount:  commitCount,
-					BranchType:   branchType,
-				}
-			case git.SyncStatusAhead:
-				// Local is ahead - proceed (optionally warn)
-				fmt.Printf("Note: Local branch is %d commit(s) ahead of remote\n", commitCount)
-			}
-			// SyncStatusEqual or SyncStatusNoTracking - proceed normally
-		}
-		// If err != nil (no tracking branch), proceed normally - no remote to compare against
+	// Fetch the topic (and parent, best-effort) and verify the topic is in sync with its remote.
+	// This runs only on the initial finish, never on --continue/--abort (handled above). A fatal
+	// fetch failure or an out-of-sync topic aborts here, before any merge.
+	if err := runFetchSyncPreflight(cfg, branchType, cfg.Remote, name, branchConfig.Parent, resolvedOptions.ShouldFetch, force); err != nil {
+		return err
 	}
 
 	// Regular finish command flow

--- a/cmd/preflight.go
+++ b/cmd/preflight.go
@@ -64,25 +64,33 @@ func runFetchSyncPreflight(cfg *config.Config, branchType, remote, topicBranch, 
 	// Sync-check the topic only when it still has a remote ref and a tracking branch.
 	if !force && topicRefFound && git.HasTrackingBranch(topicBranch) {
 		status, commitCount, err := git.CompareBranchWithRemote(topicBranch)
-		if err == nil {
-			switch status {
-			case git.SyncStatusAhead, git.SyncStatusBehind, git.SyncStatusDiverged:
-				trackingBranch, terr := git.GetTrackingBranch(topicBranch)
-				if terr != nil {
-					trackingBranch = "remote tracking branch"
-				}
-				return &errors.BranchNotInSyncError{
-					BranchName:   topicBranch,
-					ShortName:    shortName,
-					RemoteBranch: trackingBranch,
-					Status:       string(status),
-					CommitCount:  commitCount,
-					BranchType:   branchType,
-				}
+		if err != nil {
+			// HasTrackingBranch already confirmed a tracking branch, and when fetching, the topic
+			// fetch succeeded — so a compare failure here is unexpected (e.g. a corrupt/dangling
+			// tracking ref or a rev-list failure). Fail closed rather than merging against an
+			// undetermined sync status; --force skips this whole block.
+			return &errors.GitError{
+				Operation: fmt.Sprintf("determine sync status for branch '%s'", topicBranch),
+				Err:       err,
 			}
-			// SyncStatusEqual or SyncStatusNoTracking: proceed normally.
 		}
-		// err != nil: unable to compare (no tracking data) — proceed normally.
+		switch status {
+		case git.SyncStatusAhead, git.SyncStatusBehind, git.SyncStatusDiverged:
+			trackingBranch, terr := git.GetTrackingBranch(topicBranch)
+			if terr != nil {
+				trackingBranch = "remote tracking branch"
+			}
+			return &errors.BranchNotInSyncError{
+				BranchName:   topicBranch,
+				ShortName:    shortName,
+				RemoteBranch: trackingBranch,
+				Status:       string(status),
+				CommitCount:  commitCount,
+				BranchType:   branchType,
+			}
+		}
+		// SyncStatusEqual: the topic is in sync, proceed normally. (SyncStatusNoTracking always
+		// arrives with a non-nil error, handled fatally above.)
 	}
 
 	return nil

--- a/cmd/preflight.go
+++ b/cmd/preflight.go
@@ -24,7 +24,7 @@ import (
 // extension points (kept out of this signature to avoid unused hooks):
 //   - #99: parent sync-check before merge.
 //   - #88: fast-forward the parent from its remote before merge.
-func runFetchSyncPreflight(cfg *config.Config, branchType, remote, topicBranch, parentBranch string, shouldFetch, force bool) error {
+func runFetchSyncPreflight(cfg *config.Config, branchType, remote, topicBranch, shortName, parentBranch string, shouldFetch, force bool) error {
 	// topicRefFound tracks whether the topic still has a remote ref to compare against. It stays
 	// true when the fetch is skipped (we then rely on existing tracking data).
 	topicRefFound := true
@@ -46,7 +46,11 @@ func runFetchSyncPreflight(cfg *config.Config, branchType, remote, topicBranch, 
 				// sync check for this topic.
 				fmt.Printf("Note: Remote branch for '%s' not found; skipping sync check\n", topicBranch)
 				topicRefFound = false
-				_ = git.DeleteRemoteTrackingRef(remote, topicBranch)
+				// Best-effort cleanup: the ref may already be absent, so a failure here is a
+				// note, not a reason to abort the finish.
+				if derr := git.DeleteRemoteTrackingRef(remote, topicBranch); derr != nil {
+					fmt.Printf("Note: Could not prune stale tracking ref for '%s': %v\n", topicBranch, derr)
+				}
 			} else if !force {
 				return &errors.FetchFailedError{
 					Remote: remote,
@@ -69,6 +73,7 @@ func runFetchSyncPreflight(cfg *config.Config, branchType, remote, topicBranch, 
 				}
 				return &errors.BranchNotInSyncError{
 					BranchName:   topicBranch,
+					ShortName:    shortName,
 					RemoteBranch: trackingBranch,
 					Status:       string(status),
 					CommitCount:  commitCount,

--- a/cmd/preflight.go
+++ b/cmd/preflight.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	goerrors "errors"
+	"fmt"
+
+	"github.com/gittower/git-flow-next/internal/config"
+	"github.com/gittower/git-flow-next/internal/errors"
+	"github.com/gittower/git-flow-next/internal/git"
+)
+
+// runFetchSyncPreflight guards the initial finish against an out-of-date topic branch. It fetches
+// the topic (and, best-effort, the parent) and then verifies the topic is in sync with its remote.
+//
+// Behavior:
+//   - shouldFetch=false or no remote configured: fetch is skipped (no "Fetching" line). The topic
+//     sync check still runs against existing tracking data (so --no-fetch does not skip it).
+//   - Topic fetch reports a missing remote ref (never pushed / deleted after a remote merge): the
+//     missing ref is benign — the stale tracking ref is pruned and the sync check is skipped.
+//   - Topic fetch fails with a transport/auth error: fatal (FetchFailedError) unless force.
+//   - Topic ahead/behind/diverged from its remote: fatal (BranchNotInSyncError) unless force.
+//
+// The parent is fetched only best-effort here; it is intentionally NOT sync-checked. Future
+// extension points (kept out of this signature to avoid unused hooks):
+//   - #99: parent sync-check before merge.
+//   - #88: fast-forward the parent from its remote before merge.
+func runFetchSyncPreflight(cfg *config.Config, branchType, remote, topicBranch, parentBranch string, shouldFetch, force bool) error {
+	// topicRefFound tracks whether the topic still has a remote ref to compare against. It stays
+	// true when the fetch is skipped (we then rely on existing tracking data).
+	topicRefFound := true
+
+	if shouldFetch && git.RemoteExists(remote) {
+		fmt.Printf("Fetching from remote '%s'...\n", remote)
+
+		// Fetch the parent best-effort. Any failure (including a missing ref) is a non-fatal
+		// note; the parent is not sync-checked here (see #99).
+		if err := git.FetchBranch(remote, parentBranch); err != nil {
+			fmt.Printf("Note: Could not fetch base branch '%s': %v\n", parentBranch, err)
+		}
+
+		// Fetch the topic, distinguishing a benign missing ref from a fatal transport failure.
+		if err := git.FetchBranch(remote, topicBranch); err != nil {
+			if goerrors.Is(err, git.ErrRemoteRefNotFound) {
+				// The remote branch is gone (or was never pushed). Prune the stale tracking ref
+				// so later steps do not treat it as an existing remote branch, and skip the
+				// sync check for this topic.
+				fmt.Printf("Note: Remote branch for '%s' not found; skipping sync check\n", topicBranch)
+				topicRefFound = false
+				_ = git.DeleteRemoteTrackingRef(remote, topicBranch)
+			} else if !force {
+				return &errors.FetchFailedError{
+					Remote: remote,
+					Branch: topicBranch,
+					Detail: err.Error(),
+				}
+			}
+		}
+	}
+
+	// Sync-check the topic only when it still has a remote ref and a tracking branch.
+	if !force && topicRefFound && git.HasTrackingBranch(topicBranch) {
+		status, commitCount, err := git.CompareBranchWithRemote(topicBranch)
+		if err == nil {
+			switch status {
+			case git.SyncStatusAhead, git.SyncStatusBehind, git.SyncStatusDiverged:
+				trackingBranch, terr := git.GetTrackingBranch(topicBranch)
+				if terr != nil {
+					trackingBranch = "remote tracking branch"
+				}
+				return &errors.BranchNotInSyncError{
+					BranchName:   topicBranch,
+					RemoteBranch: trackingBranch,
+					Status:       string(status),
+					CommitCount:  commitCount,
+					BranchType:   branchType,
+				}
+			}
+			// SyncStatusEqual or SyncStatusNoTracking: proceed normally.
+		}
+		// err != nil: unable to compare (no tracking data) — proceed normally.
+	}
+
+	return nil
+}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -106,22 +106,14 @@ func start(branchType string, name string, base string, shouldFetch *bool) error
 
 // executeStart performs the actual start operation (called within hooks wrapper)
 func executeStart(branchType string, name string, base string, shouldFetch *bool, cfg *config.Config, branchConfig config.BranchConfig, fullBranchName string, startPoint string) error {
-	// Determine if we should fetch
-	fetchFromConfig := false
-	if shouldFetch == nil {
-		// If not explicitly specified, check config
-		configKey := fmt.Sprintf("gitflow.%s.start.fetch", branchType)
-		fetchConfig, err := git.GetConfig(configKey)
-		if err == nil && fetchConfig == "true" {
-			fetchFromConfig = true
-		}
-	}
-
-	// Perform fetch if requested
+	// Determine if we should fetch using the shared resolver (default false for start):
+	// Layer 1 default -> gitflow.<type>.start.fetch config -> CLI flag.
 	remoteName := cfg.Remote
-	if shouldFetch != nil && *shouldFetch || shouldFetch == nil && fetchFromConfig {
+	if config.ResolveStartShouldFetch(cfg, branchType, shouldFetch) {
+		// Skip silently when no remote is configured (no "Fetching" line, no error).
 		if git.RemoteExists(remoteName) {
 			fmt.Printf("Fetching from %s...\n", remoteName)
+			// Non-fatal: a failed fetch is a warning; start has no sync gate.
 			if err := git.Fetch(remoteName); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
 			}

--- a/docs/git-flow-finish.1.md
+++ b/docs/git-flow-finish.1.md
@@ -41,7 +41,7 @@ The operation maintains a persistent state file that allows it to resume after c
 : Abort the finish operation and return to the original state. When no finish operation is in progress, **--abort** is a no-op and exits successfully.
 
 **--force**, **-f**
-: Force finish: skip the remote fetch/sync check and allow finishing non-standard branches. When used, bypasses the safety check that prevents finishing when the local branch is ahead of, behind, or diverged from its remote tracking branch, and ignores any fetch failure.
+: Force finish: ignore fetch failures, skip the remote sync check, and allow finishing non-standard branches. The fetch is still attempted, but any failure is ignored rather than fatal, and the safety check that prevents finishing when the local branch is ahead of, behind, or diverged from its remote tracking branch is bypassed.
 
 ### Tag Creation
 

--- a/docs/git-flow-finish.1.md
+++ b/docs/git-flow-finish.1.md
@@ -41,7 +41,7 @@ The operation maintains a persistent state file that allows it to resume after c
 : Abort the finish operation and return to the original state. When no finish operation is in progress, **--abort** is a no-op and exits successfully.
 
 **--force**, **-f**
-: Force finish: skip remote branch sync check and allow finishing non-standard branches. When used, bypasses the safety check that prevents finishing when the local branch is behind its remote tracking branch.
+: Force finish: skip the remote fetch/sync check and allow finishing non-standard branches. When used, bypasses the safety check that prevents finishing when the local branch is ahead of, behind, or diverged from its remote tracking branch, and ignores any fetch failure.
 
 ### Tag Creation
 
@@ -133,10 +133,10 @@ The operation maintains a persistent state file that allows it to resume after c
 ### Remote Fetch Options
 
 **--fetch**
-: Fetch from remote before finishing the branch (default). This fetches both the base branch and the topic branch to ensure the latest remote changes are known before merging. Overrides git config setting `gitflow.<type>.finish.fetch`. If no remote is configured, the fetch is automatically skipped.
+: Fetch from remote before finishing the branch (default). This fetches both the base branch and the topic branch to ensure the latest remote changes are known before merging. Overrides git config setting `gitflow.<type>.finish.fetch`. If no remote is configured, the fetch is automatically skipped. The base (parent) branch is fetched best-effort — a failure there is a non-fatal note. A failure fetching the **topic** branch against a reachable-but-failing remote is **fatal**: finish aborts and names the cause, suggesting `--no-fetch` or `--force`. A remote that simply has no ref for the topic (never pushed, or deleted after a remote merge) is treated as benign and the topic's sync check is skipped.
 
 **--no-fetch**
-: Don't fetch from remote before finishing. Disables the default fetch behavior. Overrides git config setting `gitflow.<type>.finish.fetch`.
+: Don't fetch from remote before finishing. Disables the default fetch behavior. Overrides git config setting `gitflow.<type>.finish.fetch`. The fetch is skipped, but the remote sync check still runs against existing (local) tracking data.
 
 ### Hook Control
 
@@ -145,17 +145,17 @@ The operation maintains a persistent state file that allows it to resume after c
 
 ## REMOTE SYNC CHECK
 
-Before performing the merge operation, the finish command checks if the local topic branch is in sync with its remote tracking branch. This safety check prevents accidental data loss when the remote has commits that are not present locally.
+Before performing the merge operation, the finish command checks if the local topic branch is in sync with its remote tracking branch. This safety check prevents accidental data loss when the remote has commits that are not present locally, and prevents merging work that has not been published. Only the topic branch is sync-checked; the parent branch is fetched best-effort but not compared.
 
 ### Sync Status Behavior
 
 **Equal**: Local and remote are at the same commit. Finish proceeds normally.
 
-**Ahead**: Local has commits not pushed to remote. Finish proceeds with an informational note about unpushed commits.
+**Ahead**: Local has commits not pushed to remote. Finish **aborts with an error** so the unpublished commits are not merged without being pushed first.
 
 **Behind**: Remote has commits not present locally. Finish **aborts with an error** to prevent discarding those changes.
 
-**Diverged**: Both local and remote have unique commits. Finish **aborts with an error** since the branches have diverged.
+**Diverged**: Both local and remote have unique commits. Finish **aborts with an error** with a diverged-specific message, since finishing would discard the remote-only commits.
 
 **No Tracking**: Branch has no remote tracking branch configured. Finish proceeds normally (no remote to compare against).
 

--- a/docs/git-flow-start.1.md
+++ b/docs/git-flow-start.1.md
@@ -28,10 +28,10 @@ The new branch is created from the configured starting point for the topic branc
 ## OPTIONS
 
 **--fetch**
-: Fetch from remote before creating branch to ensure latest state. If no remote is configured, the fetch is automatically skipped.
+: Fetch from remote before creating branch to ensure latest state. If no remote is configured, the fetch is skipped silently. A fetch failure is a non-fatal warning — the branch is still created (start has no sync gate). Overrides git config setting `gitflow.<type>.start.fetch`.
 
 **--no-fetch**
-: Don't fetch from remote before creating branch (default behavior)
+: Don't fetch from remote before creating branch (default behavior). Overrides git config setting `gitflow.<type>.start.fetch`.
 
 ## BRANCH NAMING
 

--- a/docs/gitflow-config.5.md
+++ b/docs/gitflow-config.5.md
@@ -206,8 +206,8 @@ These are operational settings that adjust command behavior. Some can override L
 : *Values*: **merge**, **rebase**, **squash**
 
 **fetch**
-: Fetch from remote before operation.
-: *Default*: false
+: Fetch from remote before the operation. This is a Layer 2 operational setting only (there is no Layer 1 branch-type knob). Resolution is uniform across commands: per-command default, then `gitflow.<type>.<cmd>.fetch`, then the `--fetch`/`--no-fetch` CLI flag (which always wins).
+: *Default*: **true** for `finish` (so the sync check runs against fresh data), **false** for `start`.
 
 **keep**
 : Keep branch after finishing (finish command only).
@@ -473,10 +473,15 @@ The finish command supports extensive merge strategy configuration through comma
 ### Remote Fetch Options
 
 **gitflow.*type*.finish.fetch**
-: Fetch from remote before finishing a topic branch. When enabled, fetches both the base branch and the topic branch from the remote to ensure the latest remote state is known before merging.
-: After fetching, if the local topic branch is behind or diverged from its remote tracking branch, the finish operation will abort with an error to prevent accidental data loss. Use `--force` to bypass this safety check.
+: Fetch from remote before finishing a topic branch. When enabled, fetches the base branch (best-effort) and the topic branch from the remote to ensure the latest remote state is known before merging. A failure fetching the topic branch against a reachable-but-failing remote is fatal; a remote with no ref for the topic (never pushed, or deleted after a remote merge) is benign and its sync check is skipped.
+: After fetching, if the local topic branch is ahead of, behind, or diverged from its remote tracking branch, the finish operation aborts with an error to prevent accidental data loss or merging unpublished work. Use `--force` to bypass this safety check. `--no-fetch` skips only the fetch; the sync check still runs against existing tracking data.
 : *Type*: boolean
 : *Default*: true
+
+**gitflow.*type*.start.fetch**
+: Fetch from remote before starting a topic branch. When no remote is configured, the fetch is skipped silently. A fetch failure is a non-fatal warning — the branch is still created (start has no sync gate).
+: *Type*: boolean
+: *Default*: false
 
 ### Merge Message Options
 

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -437,13 +437,15 @@ func resolveFinishNoFF(cfg *Config, branchType string, mergeOpts *MergeStrategyO
 	return noFF
 }
 
-// resolveFinishShouldFetch resolves whether to fetch from remote before finishing
-func resolveFinishShouldFetch(cfg *Config, branchType string, fetch *bool) bool {
-	// Layer 1: Default is to fetch (ensures sync check has accurate data)
-	shouldFetch := true
+// resolveShouldFetch resolves whether to fetch from the remote before a command runs, using the
+// standard precedence: Layer-1 default (per command) -> gitflow.<type>.<cmd>.fetch config ->
+// CLI flag. Shared by finish (default true) and start (default false).
+func resolveShouldFetch(cfg *Config, branchType, cmd string, defaultFetch bool, fetch *bool) bool {
+	// Layer 1: Command default
+	shouldFetch := defaultFetch
 
-	// Layer 2: Check command-specific config (can set true OR false)
-	configKey := fmt.Sprintf("gitflow.%s.finish.fetch", branchType)
+	// Layer 2: Command-specific config (can set true OR false)
+	configKey := fmt.Sprintf("gitflow.%s.%s.fetch", branchType, cmd)
 	if value, exists := cfg.CommandConfig[configKey]; exists {
 		shouldFetch = value == "true"
 	}
@@ -454,6 +456,18 @@ func resolveFinishShouldFetch(cfg *Config, branchType string, fetch *bool) bool 
 	}
 
 	return shouldFetch
+}
+
+// resolveFinishShouldFetch resolves whether to fetch from remote before finishing.
+// The default is true (ensures the sync check runs against accurate data).
+func resolveFinishShouldFetch(cfg *Config, branchType string, fetch *bool) bool {
+	return resolveShouldFetch(cfg, branchType, "finish", true, fetch)
+}
+
+// ResolveStartShouldFetch resolves whether to fetch from remote before starting a branch.
+// The default is false (start does not fetch unless explicitly enabled).
+func ResolveStartShouldFetch(cfg *Config, branchType string, fetch *bool) bool {
+	return resolveShouldFetch(cfg, branchType, "start", false, fetch)
 }
 
 // resolveFinishNoVerify resolves whether to skip pre-commit and commit-msg hooks

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -254,6 +254,7 @@ const (
 // --force is given. The message is tailored to the specific Status.
 type BranchNotInSyncError struct {
 	BranchName   string
+	ShortName    string // topic name without the branch-type prefix, used to build the suggested command
 	RemoteBranch string
 	Status       string // "ahead", "behind", or "diverged"
 	CommitCount  int
@@ -261,10 +262,12 @@ type BranchNotInSyncError struct {
 }
 
 func (e *BranchNotInSyncError) Error() string {
-	// Get the short name by extracting the part after the last slash if it exists
-	shortName := e.BranchName
-	if idx := lastSlashIndex(e.BranchName); idx != -1 {
-		shortName = e.BranchName[idx+1:]
+	// Use the caller-supplied short name for the suggested command. Deriving it here from the
+	// full branch name would mishandle nested topic names (e.g. feature/ui/login). Fall back to
+	// the full name only if the caller left it unset.
+	shortName := e.ShortName
+	if shortName == "" {
+		shortName = e.BranchName
 	}
 
 	switch e.Status {
@@ -288,13 +291,11 @@ The local and remote branches each have commits the other does not.
 Finishing now would discard the remote-only commits.
 
 To resolve:
-  git flow %s update %s    # merge/rebase remote changes
-  git pull                       # or pull directly
+  git pull                       # merge/rebase the remote changes first
 
 To finish anyway (discarding remote changes):
   git flow %s finish --force %s`,
 			e.BranchName, e.RemoteBranch, e.CommitCount,
-			e.BranchType, shortName,
 			e.BranchType, shortName)
 	default: // SyncStatusBehind
 		return fmt.Sprintf(`local branch '%s' is behind '%s' by %d commit(s).
@@ -303,13 +304,11 @@ The remote branch has commits not present locally. Finishing now
 would discard those changes.
 
 To resolve:
-  git flow %s update %s    # merge/rebase remote changes
-  git pull                       # or pull directly
+  git pull                       # merge/rebase the remote changes first
 
 To finish anyway (discarding remote changes):
   git flow %s finish --force %s`,
 			e.BranchName, e.RemoteBranch, e.CommitCount,
-			e.BranchType, shortName,
 			e.BranchType, shortName)
 	}
 }
@@ -333,22 +332,12 @@ func (e *FetchFailedError) Error() string {
 The remote could not be reached, so the sync check cannot run against
 fresh data. To proceed anyway:
   --no-fetch    skip the fetch and use local tracking data
-  --force       skip the fetch and the sync check entirely`,
+  --force       ignore fetch failures and skip the sync check`,
 		e.Branch, e.Remote, e.Detail)
 }
 
 func (e *FetchFailedError) ExitCode() ExitCode {
 	return ExitCodeGitError
-}
-
-// lastSlashIndex returns the index of the last slash in a string, or -1 if not found
-func lastSlashIndex(s string) int {
-	for i := len(s) - 1; i >= 0; i-- {
-		if s[i] == '/' {
-			return i
-		}
-	}
-	return -1
 }
 
 // RemoteNotConfiguredError indicates a required remote is not configured

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -241,23 +241,63 @@ func (e *RemoteBranchNotFoundError) ExitCode() ExitCode {
 	return ExitCodeBranchNotFound
 }
 
-// BranchBehindRemoteError indicates the local branch is behind its remote tracking branch.
-// Finishing would discard the remote commits, which is likely unintended.
-type BranchBehindRemoteError struct {
+// Sync status values for BranchNotInSyncError. These mirror the git.BranchSyncStatus string
+// values but are duplicated here to avoid an import cycle (internal/git imports would be circular).
+const (
+	SyncStatusAhead    = "ahead"
+	SyncStatusBehind   = "behind"
+	SyncStatusDiverged = "diverged"
+)
+
+// BranchNotInSyncError indicates the local topic branch is not in sync with its remote tracking
+// branch. Finishing while ahead, behind, or diverged risks losing work, so it aborts unless
+// --force is given. The message is tailored to the specific Status.
+type BranchNotInSyncError struct {
 	BranchName   string
 	RemoteBranch string
+	Status       string // "ahead", "behind", or "diverged"
 	CommitCount  int
 	BranchType   string
 }
 
-func (e *BranchBehindRemoteError) Error() string {
+func (e *BranchNotInSyncError) Error() string {
 	// Get the short name by extracting the part after the last slash if it exists
 	shortName := e.BranchName
 	if idx := lastSlashIndex(e.BranchName); idx != -1 {
 		shortName = e.BranchName[idx+1:]
 	}
 
-	return fmt.Sprintf(`local branch '%s' is behind '%s' by %d commit(s).
+	switch e.Status {
+	case SyncStatusAhead:
+		return fmt.Sprintf(`local branch '%s' is ahead of '%s' by %d commit(s).
+
+The local branch has commits that have not been published to the remote.
+Finishing now would complete the merge without pushing those commits.
+
+To resolve:
+  git push                       # publish your local commits first
+
+To finish anyway (without pushing):
+  git flow %s finish --force %s`,
+			e.BranchName, e.RemoteBranch, e.CommitCount,
+			e.BranchType, shortName)
+	case SyncStatusDiverged:
+		return fmt.Sprintf(`local branch '%s' has diverged from '%s' by %d commit(s).
+
+The local and remote branches each have commits the other does not.
+Finishing now would discard the remote-only commits.
+
+To resolve:
+  git flow %s update %s    # merge/rebase remote changes
+  git pull                       # or pull directly
+
+To finish anyway (discarding remote changes):
+  git flow %s finish --force %s`,
+			e.BranchName, e.RemoteBranch, e.CommitCount,
+			e.BranchType, shortName,
+			e.BranchType, shortName)
+	default: // SyncStatusBehind
+		return fmt.Sprintf(`local branch '%s' is behind '%s' by %d commit(s).
 
 The remote branch has commits not present locally. Finishing now
 would discard those changes.
@@ -268,13 +308,37 @@ To resolve:
 
 To finish anyway (discarding remote changes):
   git flow %s finish --force %s`,
-		e.BranchName, e.RemoteBranch, e.CommitCount,
-		e.BranchType, shortName,
-		e.BranchType, shortName)
+			e.BranchName, e.RemoteBranch, e.CommitCount,
+			e.BranchType, shortName,
+			e.BranchType, shortName)
+	}
 }
 
-func (e *BranchBehindRemoteError) ExitCode() ExitCode {
+func (e *BranchNotInSyncError) ExitCode() ExitCode {
 	return ExitCodeValidationError
+}
+
+// FetchFailedError indicates a targeted fetch of a branch failed with a transport/auth error
+// (as opposed to a benign missing remote ref). It is fatal so the user does not unknowingly
+// finish against stale data; the message names the cause and offers escape hatches.
+type FetchFailedError struct {
+	Remote string
+	Branch string
+	Detail string
+}
+
+func (e *FetchFailedError) Error() string {
+	return fmt.Sprintf(`failed to fetch '%s' from remote '%s': %s
+
+The remote could not be reached, so the sync check cannot run against
+fresh data. To proceed anyway:
+  --no-fetch    skip the fetch and use local tracking data
+  --force       skip the fetch and the sync check entirely`,
+		e.Branch, e.Remote, e.Detail)
+}
+
+func (e *FetchFailedError) ExitCode() ExitCode {
+	return ExitCodeGitError
 }
 
 // lastSlashIndex returns the index of the last slash in a string, or -1 if not found

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -732,9 +732,11 @@ func FetchBranch(remote, branch string) error {
 	if err != nil {
 		stderr := strings.TrimSpace(string(output))
 		if isRemoteRefNotFound(stderr) {
-			return fmt.Errorf("fetch branch '%s' from '%s': %s: %w", branch, remote, stderr, ErrRemoteRefNotFound)
+			// Join the benign sentinel with the underlying exec error so callers can classify via
+			// errors.Is(ErrRemoteRefNotFound) while the original error stays available for diagnostics.
+			return fmt.Errorf("fetch branch '%s' from '%s': %s: %w", branch, remote, stderr, errors.Join(ErrRemoteRefNotFound, err))
 		}
-		return fmt.Errorf("failed to fetch branch '%s' from '%s': %s", branch, remote, stderr)
+		return fmt.Errorf("failed to fetch branch '%s' from '%s': %s: %w", branch, remote, stderr, err)
 	}
 	return nil
 }

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -724,6 +724,10 @@ func CompareBranchWithRemote(branch string) (BranchSyncStatus, int, error) {
 //     trimmed stderr.
 func FetchBranch(remote, branch string) error {
 	cmd := exec.Command("git", "fetch", remote, branch)
+	// Pin the locale so isRemoteRefNotFound classifies stderr against git's English phrasing,
+	// regardless of the user's LANG/LC_* settings. A localized "missing ref" message would
+	// otherwise be misclassified as a fatal transport failure.
+	cmd.Env = append(os.Environ(), "LC_ALL=C")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		stderr := strings.TrimSpace(string(output))

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -766,7 +766,9 @@ func DeleteRemoteTrackingRef(remote, branch string) error {
 	ref := fmt.Sprintf("refs/remotes/%s/%s", remote, branch)
 	cmd := exec.Command("git", "update-ref", "-d", ref)
 	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to delete remote tracking ref '%s': %s", ref, strings.TrimSpace(string(output)))
+		// Wrap the underlying exec error with %w so the exit status stays available for diagnostics,
+		// mirroring FetchBranch's error wrapping, while still surfacing the trimmed git output.
+		return fmt.Errorf("failed to delete remote tracking ref '%s': %s: %w", ref, strings.TrimSpace(string(output)), err)
 	}
 	return nil
 }

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -8,6 +9,12 @@ import (
 	"strconv"
 	"strings"
 )
+
+// ErrRemoteRefNotFound is a sentinel error returned by FetchBranch when git reports that the
+// requested branch does not exist on the remote (e.g. never pushed, or deleted after a remote
+// merge). This is benign: callers treat it as "no remote ref to compare against" rather than a
+// transport failure.
+var ErrRemoteRefNotFound = errors.New("remote ref not found")
 
 // BranchSyncStatus represents the sync status between a local branch and its remote tracking branch
 type BranchSyncStatus string
@@ -709,11 +716,51 @@ func CompareBranchWithRemote(branch string) (BranchSyncStatus, int, error) {
 
 // FetchBranch fetches a specific branch from a remote.
 // This is a targeted fetch that only updates the specified branch reference.
+//
+// On failure it classifies the git error:
+//   - If stderr indicates the branch does not exist on the remote, it wraps the benign
+//     sentinel ErrRemoteRefNotFound (check with errors.Is).
+//   - Any other non-zero exit (transport/auth failure) returns a fatal error carrying the
+//     trimmed stderr.
 func FetchBranch(remote, branch string) error {
 	cmd := exec.Command("git", "fetch", remote, branch)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to fetch branch '%s' from '%s': %s", branch, remote, strings.TrimSpace(string(output)))
+		stderr := strings.TrimSpace(string(output))
+		if isRemoteRefNotFound(stderr) {
+			return fmt.Errorf("fetch branch '%s' from '%s': %s: %w", branch, remote, stderr, ErrRemoteRefNotFound)
+		}
+		return fmt.Errorf("failed to fetch branch '%s' from '%s': %s", branch, remote, stderr)
+	}
+	return nil
+}
+
+// isRemoteRefNotFound reports whether git stderr indicates the requested ref does not exist on
+// the remote (as opposed to a transport/auth failure). Matching is case-insensitive.
+func isRemoteRefNotFound(stderr string) bool {
+	lowered := strings.ToLower(stderr)
+	return strings.Contains(lowered, "couldn't find remote ref") ||
+		strings.Contains(lowered, "could not find remote ref") ||
+		strings.Contains(lowered, "no such ref") ||
+		strings.Contains(lowered, "not our ref")
+}
+
+// HasTrackingBranch reports whether the given local branch has a remote tracking branch
+// configured. It is a thin wrapper over GetTrackingBranch that returns false on any error.
+func HasTrackingBranch(branch string) bool {
+	_, err := GetTrackingBranch(branch)
+	return err == nil
+}
+
+// DeleteRemoteTrackingRef removes a stale remote-tracking ref (refs/remotes/<remote>/<branch>)
+// from the local repository. It is used to prune a tracking ref once the corresponding remote
+// branch is found to be gone. Errors are returned so callers may log them, but they are safe to
+// ignore (the ref may already be absent).
+func DeleteRemoteTrackingRef(remote, branch string) error {
+	ref := fmt.Sprintf("refs/remotes/%s/%s", remote, branch)
+	cmd := exec.Command("git", "update-ref", "-d", ref)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to delete remote tracking ref '%s': %s", ref, strings.TrimSpace(string(output)))
 	}
 	return nil
 }

--- a/test/cmd/finish_fetch_test.go
+++ b/test/cmd/finish_fetch_test.go
@@ -786,7 +786,7 @@ func TestFinishUnreachableRemoteAborts(t *testing.T) {
 	commitFeatureAndPush(t, dir, "feature.txt", "feature content", "Add feature file", "feature/test-unreachable")
 
 	// Break the remote so any fetch fails with a transport error
-	if _, err := testutil.RunGit(t, dir, "remote", "set-url", "origin", "/nonexistent/repo.git"); err != nil {
+	if _, err := testutil.RunGit(t, dir, "remote", "set-url", "origin", "./nonexistent-remote-repo.git"); err != nil {
 		t.Fatalf("Failed to break remote: %v", err)
 	}
 
@@ -845,7 +845,7 @@ func TestFinishUnreachableRemoteNoFetchCompletes(t *testing.T) {
 	}
 	commitFeatureAndPush(t, dir, "feature.txt", "feature content", "Add feature file", "feature/test-unreachable-nofetch")
 
-	if _, err := testutil.RunGit(t, dir, "remote", "set-url", "origin", "/nonexistent/repo.git"); err != nil {
+	if _, err := testutil.RunGit(t, dir, "remote", "set-url", "origin", "./nonexistent-remote-repo.git"); err != nil {
 		t.Fatalf("Failed to break remote: %v", err)
 	}
 
@@ -889,7 +889,7 @@ func TestFinishUnreachableRemoteForceCompletes(t *testing.T) {
 	}
 	commitFeatureAndPush(t, dir, "feature.txt", "feature content", "Add feature file", "feature/test-unreachable-force")
 
-	if _, err := testutil.RunGit(t, dir, "remote", "set-url", "origin", "/nonexistent/repo.git"); err != nil {
+	if _, err := testutil.RunGit(t, dir, "remote", "set-url", "origin", "./nonexistent-remote-repo.git"); err != nil {
 		t.Fatalf("Failed to break remote: %v", err)
 	}
 

--- a/test/cmd/finish_fetch_test.go
+++ b/test/cmd/finish_fetch_test.go
@@ -201,8 +201,10 @@ func TestFinishFeatureBranchDefaultFetch(t *testing.T) {
 }
 
 // TestFinishFeatureBranchNoFetchFromConfig tests finishing with fetch disabled via git config.
+// Uses a remote-backed fixture so the absence of "Fetching" genuinely reflects the config
+// (fetch=false), not the no-remote guard.
 // Steps:
-// 1. Sets up a test repository and initializes git-flow
+// 1. Sets up a test repository with a remote and initializes git-flow
 // 2. Configures gitflow.feature.finish.fetch = false in git config
 // 3. Creates a feature branch
 // 4. Adds a test file to the feature branch
@@ -212,18 +214,13 @@ func TestFinishFeatureBranchDefaultFetch(t *testing.T) {
 // 8. Verifies the branch is merged into develop
 // 9. Verifies the feature branch is deleted
 func TestFinishFeatureBranchNoFetchFromConfig(t *testing.T) {
-	// Setup test repository (no remote needed since we're testing no-fetch)
-	dir := testutil.SetupTestRepo(t)
+	// Setup test repository with remote so the absence of fetch reflects the config
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
 	defer testutil.CleanupTestRepo(t, dir)
-
-	// Initialize git-flow with defaults
-	_, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
-	if err != nil {
-		t.Fatalf("Failed to initialize git-flow: %v", err)
-	}
+	defer testutil.CleanupTestRepo(t, remoteDir)
 
 	// Configure fetch to be disabled for feature finish
-	_, err = testutil.RunGit(t, dir, "config", "gitflow.feature.finish.fetch", "false")
+	_, err := testutil.RunGit(t, dir, "config", "gitflow.feature.finish.fetch", "false")
 	if err != nil {
 		t.Fatalf("Failed to configure fetch option: %v", err)
 	}
@@ -617,5 +614,442 @@ func TestFinishFeatureBranchNoRemote(t *testing.T) {
 	}
 	if !testutil.FileExists(t, dir, "no-remote-test.txt") {
 		t.Error("Expected no-remote-test.txt to exist in develop branch")
+	}
+}
+
+// commitFeatureAndPush is a small helper: writes and commits a file on the current branch,
+// then pushes the given branch with upstream tracking. Returns the branch's SHA after the commit.
+func commitFeatureAndPush(t *testing.T, dir, file, content, commitMsg, branch string) string {
+	t.Helper()
+	testutil.WriteFile(t, dir, file, content)
+	if _, err := testutil.RunGit(t, dir, "add", file); err != nil {
+		t.Fatalf("Failed to add %s: %v", file, err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", commitMsg); err != nil {
+		t.Fatalf("Failed to commit %s: %v", file, err)
+	}
+	if _, err := testutil.RunGit(t, dir, "push", "--set-upstream", "origin", branch); err != nil {
+		t.Fatalf("Failed to push %s: %v", branch, err)
+	}
+	sha, err := testutil.RunGit(t, dir, "rev-parse", branch)
+	if err != nil {
+		t.Fatalf("Failed to get SHA of %s: %v", branch, err)
+	}
+	return strings.TrimSpace(sha)
+}
+
+// TestFinishNoUpstreamSkipsFetch tests Scenario 2: a remote is configured but the topic branch has
+// no upstream. The topic fetch/sync is skipped (the missing remote ref is benign); the parent may
+// still be fetched best-effort. Finish completes and merges the topic.
+// Steps:
+// 1. Sets up a test repository with remote and initializes git-flow
+// 2. Creates a feature branch and commits (does NOT push — no tracking branch)
+// 3. Finishes the feature branch
+// 4. Verifies no sync abort and that the branch is merged into develop
+func TestFinishNoUpstreamSkipsFetch(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "test-no-upstream"); err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+	testutil.WriteFile(t, dir, "feature.txt", "feature content")
+	if _, err := testutil.RunGit(t, dir, "add", "feature.txt"); err != nil {
+		t.Fatalf("Failed to add file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Add feature file"); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// Finish without pushing (topic has no upstream)
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "test-no-upstream")
+	if err != nil {
+		t.Fatalf("Expected finish to complete with no upstream topic. Error: %v\nOutput: %s", err, output)
+	}
+
+	// Load-bearing: no sync abort
+	if strings.Contains(output, "is behind") || strings.Contains(output, "is ahead") || strings.Contains(output, "has diverged") {
+		t.Errorf("Expected no sync abort for a topic with no upstream. Output: %s", output)
+	}
+
+	// Load-bearing: topic merged into develop
+	if testutil.BranchExists(t, dir, "feature/test-no-upstream") {
+		t.Error("Expected feature branch to be deleted")
+	}
+	if _, err := testutil.RunGit(t, dir, "checkout", "develop"); err != nil {
+		t.Fatalf("Failed to checkout develop: %v", err)
+	}
+	if !testutil.FileExists(t, dir, "feature.txt") {
+		t.Error("Expected feature.txt to exist in develop branch")
+	}
+}
+
+// TestFinishStaleRemoteRefIsBenign tests Scenario 4 (the linchpin): a stale remote-tracking ref
+// remains after the remote branch was deleted remotely. The topic fetch reports ref-not-found,
+// which is benign — the sync check against the stale ref is skipped, and finish completes.
+// Steps:
+// 1. Sets up a test repository with remote and initializes git-flow
+// 2. Creates a feature branch, commits B, and pushes it (tracking ref origin/... = B)
+// 3. Adds a local commit C (so local = C, stale tracking ref = B, B != C)
+// 4. Deletes the branch directly in the bare remote (tracking ref not pruned)
+// 5. Asserts the preconditions (remote ref absent, origin ref = B, local = C, B != C)
+// 6. Finishes the feature branch WITHOUT --force
+// 7. Verifies no ahead/diverged abort and that commit C is merged into develop
+func TestFinishStaleRemoteRefIsBenign(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "test-stale"); err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+
+	// Commit B and push (tracking ref origin/feature/test-stale = B)
+	shaB := commitFeatureAndPush(t, dir, "stale-b.txt", "b", "Commit B", "feature/test-stale")
+
+	// Add local commit C (not pushed)
+	testutil.WriteFile(t, dir, "stale-c.txt", "c")
+	if _, err := testutil.RunGit(t, dir, "add", "stale-c.txt"); err != nil {
+		t.Fatalf("Failed to add stale-c.txt: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Commit C"); err != nil {
+		t.Fatalf("Failed to commit C: %v", err)
+	}
+	shaCraw, err := testutil.RunGit(t, dir, "rev-parse", "feature/test-stale")
+	if err != nil {
+		t.Fatalf("Failed to get local SHA: %v", err)
+	}
+	shaC := strings.TrimSpace(shaCraw)
+
+	// Delete the branch directly in the bare remote (local tracking ref NOT pruned)
+	if _, err := testutil.RunGit(t, remoteDir, "update-ref", "-d", "refs/heads/feature/test-stale"); err != nil {
+		t.Fatalf("Failed to delete branch in bare remote: %v", err)
+	}
+
+	// Preconditions (guard against a vacuous test)
+	if _, err := testutil.RunGit(t, remoteDir, "rev-parse", "--verify", "refs/heads/feature/test-stale"); err == nil {
+		t.Fatalf("Precondition failed: expected the bare remote ref to be absent")
+	}
+	originRefRaw, err := testutil.RunGit(t, dir, "rev-parse", "origin/feature/test-stale")
+	if err != nil {
+		t.Fatalf("Precondition failed: stale tracking ref should resolve: %v", err)
+	}
+	if strings.TrimSpace(originRefRaw) != shaB {
+		t.Fatalf("Precondition failed: expected origin/feature/test-stale = B (%s), got %s", shaB, strings.TrimSpace(originRefRaw))
+	}
+	if shaB == shaC {
+		t.Fatalf("Precondition failed: expected B (%s) != C (%s)", shaB, shaC)
+	}
+
+	// Finish WITHOUT --force
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "test-stale")
+	if err != nil {
+		t.Fatalf("Expected finish to complete with a stale remote ref. Error: %v\nOutput: %s", err, output)
+	}
+
+	// No ahead/diverged abort against the stale ref
+	if strings.Contains(output, "is ahead") || strings.Contains(output, "has diverged") {
+		t.Errorf("Expected no ahead/diverged abort against the stale ref. Output: %s", output)
+	}
+
+	// Commit C merged into develop
+	if testutil.BranchExists(t, dir, "feature/test-stale") {
+		t.Error("Expected feature branch to be deleted")
+	}
+	if _, err := testutil.RunGit(t, dir, "checkout", "develop"); err != nil {
+		t.Fatalf("Failed to checkout develop: %v", err)
+	}
+	if !testutil.FileExists(t, dir, "stale-c.txt") {
+		t.Error("Expected stale-c.txt (commit C) to be merged into develop")
+	}
+}
+
+// TestFinishUnreachableRemoteAborts tests Scenario 5: a reachable-but-failing remote makes the
+// topic fetch fail with a transport error, which is now fatal. Finish aborts and does not merge.
+// Steps:
+// 1. Sets up a test repository with remote and initializes git-flow
+// 2. Creates a feature branch, commits, and pushes it (in sync)
+// 3. Points origin at a nonexistent path so fetch fails with a transport error
+// 4. Records develop's SHA before finishing
+// 5. Finishes the feature branch
+// 6. Verifies a fatal error naming the topic branch and suggesting --no-fetch / --force
+// 7. Verifies the merge did not happen (develop unchanged, branch still exists)
+func TestFinishUnreachableRemoteAborts(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "test-unreachable"); err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+	commitFeatureAndPush(t, dir, "feature.txt", "feature content", "Add feature file", "feature/test-unreachable")
+
+	// Break the remote so any fetch fails with a transport error
+	if _, err := testutil.RunGit(t, dir, "remote", "set-url", "origin", "/nonexistent/repo.git"); err != nil {
+		t.Fatalf("Failed to break remote: %v", err)
+	}
+
+	developBefore, err := testutil.RunGit(t, dir, "rev-parse", "develop")
+	if err != nil {
+		t.Fatalf("Failed to get develop SHA: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "test-unreachable")
+	if err == nil {
+		t.Errorf("Expected finish to fail on an unreachable remote. Output: %s", output)
+	}
+
+	// Verify the fatal error is the topic fetch and offers the escape hatches
+	if !strings.Contains(output, "feature/test-unreachable") {
+		t.Errorf("Expected the fatal error to name the topic branch. Output: %s", output)
+	}
+	if !strings.Contains(output, "--no-fetch") || !strings.Contains(output, "--force") {
+		t.Errorf("Expected the fatal error to suggest --no-fetch and --force. Output: %s", output)
+	}
+
+	// Verify no merge happened
+	developAfter, err := testutil.RunGit(t, dir, "rev-parse", "develop")
+	if err != nil {
+		t.Fatalf("Failed to get develop SHA after: %v", err)
+	}
+	if developBefore != developAfter {
+		t.Errorf("Expected develop unchanged after aborted finish. Before: %s After: %s", developBefore, developAfter)
+	}
+	if !testutil.BranchExists(t, dir, "feature/test-unreachable") {
+		t.Error("Expected feature branch to still exist after aborted finish")
+	}
+}
+
+// TestFinishUnreachableRemoteNoFetchCompletes tests Scenario 6: --no-fetch skips the fetch entirely,
+// so an unreachable remote does not block finishing. keepremote avoids the unrelated remote-delete
+// failure on the broken URL (delete behavior is out of scope for this change).
+// Steps:
+// 1. Sets up a test repository with remote and initializes git-flow; enables keepremote
+// 2. Creates a feature branch, commits, and pushes it (in sync tracking data)
+// 3. Points origin at a nonexistent path
+// 4. Finishes with --no-fetch
+// 5. Verifies no fetch occurred and the branch merged into develop
+func TestFinishUnreachableRemoteNoFetchCompletes(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	// keepremote isolates the test to the fetch behavior (delete is out of scope)
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.feature.finish.keepremote", "true"); err != nil {
+		t.Fatalf("Failed to set keepremote config: %v", err)
+	}
+
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "test-unreachable-nofetch"); err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+	commitFeatureAndPush(t, dir, "feature.txt", "feature content", "Add feature file", "feature/test-unreachable-nofetch")
+
+	if _, err := testutil.RunGit(t, dir, "remote", "set-url", "origin", "/nonexistent/repo.git"); err != nil {
+		t.Fatalf("Failed to break remote: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "--no-fetch", "test-unreachable-nofetch")
+	if err != nil {
+		t.Fatalf("Expected finish to complete with --no-fetch. Error: %v\nOutput: %s", err, output)
+	}
+	if strings.Contains(output, "Fetching from remote") {
+		t.Errorf("Expected no fetch with --no-fetch. Output: %s", output)
+	}
+	if testutil.BranchExists(t, dir, "feature/test-unreachable-nofetch") {
+		t.Error("Expected feature branch to be deleted")
+	}
+	if _, err := testutil.RunGit(t, dir, "checkout", "develop"); err != nil {
+		t.Fatalf("Failed to checkout develop: %v", err)
+	}
+	if !testutil.FileExists(t, dir, "feature.txt") {
+		t.Error("Expected feature.txt to exist in develop branch")
+	}
+}
+
+// TestFinishUnreachableRemoteForceCompletes tests Scenario 7: --force ignores the fetch failure.
+// keepremote avoids the unrelated remote-delete failure on the broken URL.
+// Steps:
+// 1. Sets up a test repository with remote and initializes git-flow; enables keepremote
+// 2. Creates a feature branch, commits, and pushes it
+// 3. Points origin at a nonexistent path
+// 4. Finishes with --force
+// 5. Verifies the branch merged into develop
+func TestFinishUnreachableRemoteForceCompletes(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.feature.finish.keepremote", "true"); err != nil {
+		t.Fatalf("Failed to set keepremote config: %v", err)
+	}
+
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "test-unreachable-force"); err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+	commitFeatureAndPush(t, dir, "feature.txt", "feature content", "Add feature file", "feature/test-unreachable-force")
+
+	if _, err := testutil.RunGit(t, dir, "remote", "set-url", "origin", "/nonexistent/repo.git"); err != nil {
+		t.Fatalf("Failed to break remote: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "--force", "test-unreachable-force")
+	if err != nil {
+		t.Fatalf("Expected finish to complete with --force. Error: %v\nOutput: %s", err, output)
+	}
+	if testutil.BranchExists(t, dir, "feature/test-unreachable-force") {
+		t.Error("Expected feature branch to be deleted")
+	}
+	if _, err := testutil.RunGit(t, dir, "checkout", "develop"); err != nil {
+		t.Fatalf("Failed to checkout develop: %v", err)
+	}
+	if !testutil.FileExists(t, dir, "feature.txt") {
+		t.Error("Expected feature.txt to exist in develop branch")
+	}
+}
+
+// TestFinishAheadRemoteForceCompletes tests Scenario 11b: --force bypasses the sync check when the
+// topic is ahead of the remote, so finish completes.
+// Steps:
+// 1. Sets up a test repository with remote and initializes git-flow
+// 2. Creates a feature branch, commits, and pushes it
+// 3. Adds a local commit without pushing (ahead by 1)
+// 4. Finishes with --force
+// 5. Verifies the branch merged into develop
+func TestFinishAheadRemoteForceCompletes(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "test-ahead-force"); err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+	commitFeatureAndPush(t, dir, "feature.txt", "feature content", "Add feature file", "feature/test-ahead-force")
+
+	// Ahead by 1 (local-only commit)
+	testutil.WriteFile(t, dir, "local.txt", "local content")
+	if _, err := testutil.RunGit(t, dir, "add", "local.txt"); err != nil {
+		t.Fatalf("Failed to add local.txt: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Local commit"); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "--force", "test-ahead-force")
+	if err != nil {
+		t.Fatalf("Expected finish with --force to succeed when ahead. Error: %v\nOutput: %s", err, output)
+	}
+	if testutil.BranchExists(t, dir, "feature/test-ahead-force") {
+		t.Error("Expected feature branch to be deleted")
+	}
+	if _, err := testutil.RunGit(t, dir, "checkout", "develop"); err != nil {
+		t.Fatalf("Failed to checkout develop: %v", err)
+	}
+	if !testutil.FileExists(t, dir, "local.txt") {
+		t.Error("Expected local.txt to exist in develop branch")
+	}
+}
+
+// TestFinishDivergedRemoteForceCompletes tests Scenario 11c: --force bypasses the sync check when
+// the topic has diverged from the remote, so finish completes.
+// Steps:
+// 1. Sets up a test repository with remote and initializes git-flow
+// 2. Creates a feature branch, commits, and pushes it
+// 3. Creates divergence (remote-only commit via a second clone; local-only commit) and fetches
+// 4. Finishes with --force
+// 5. Verifies the branch merged into develop
+func TestFinishDivergedRemoteForceCompletes(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "test-diverged-force"); err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+	commitFeatureAndPush(t, dir, "feature.txt", "feature content", "Add feature file", "feature/test-diverged-force")
+
+	// Remote-only commit via a second clone
+	secondDir := t.TempDir()
+	if _, err := testutil.RunGit(t, secondDir, "clone", remoteDir, "."); err != nil {
+		t.Fatalf("Failed to clone: %v", err)
+	}
+	testutil.ConfigureGitIdentity(t, secondDir)
+	if _, err := testutil.RunGit(t, secondDir, "checkout", "feature/test-diverged-force"); err != nil {
+		t.Fatalf("Failed to checkout feature in second repo: %v", err)
+	}
+	testutil.WriteFile(t, secondDir, "remote-change.txt", "remote content")
+	if _, err := testutil.RunGit(t, secondDir, "add", "remote-change.txt"); err != nil {
+		t.Fatalf("Failed to add file in second repo: %v", err)
+	}
+	if _, err := testutil.RunGit(t, secondDir, "commit", "-m", "Remote commit"); err != nil {
+		t.Fatalf("Failed to commit in second repo: %v", err)
+	}
+	if _, err := testutil.RunGit(t, secondDir, "push", "origin", "feature/test-diverged-force"); err != nil {
+		t.Fatalf("Failed to push from second repo: %v", err)
+	}
+
+	// Local-only commit (creates divergence), then fetch to update the tracking ref
+	testutil.WriteFile(t, dir, "local-change.txt", "local content")
+	if _, err := testutil.RunGit(t, dir, "add", "local-change.txt"); err != nil {
+		t.Fatalf("Failed to add local-change.txt: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Local commit"); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "fetch", "origin"); err != nil {
+		t.Fatalf("Failed to fetch: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "--force", "test-diverged-force")
+	if err != nil {
+		t.Fatalf("Expected finish with --force to succeed when diverged. Error: %v\nOutput: %s", err, output)
+	}
+	if testutil.BranchExists(t, dir, "feature/test-diverged-force") {
+		t.Error("Expected feature branch to be deleted")
+	}
+	if _, err := testutil.RunGit(t, dir, "checkout", "develop"); err != nil {
+		t.Fatalf("Failed to checkout develop: %v", err)
+	}
+	if !testutil.FileExists(t, dir, "local-change.txt") {
+		t.Error("Expected local-change.txt to exist in develop branch")
+	}
+}
+
+// TestFinishParentAbsentOnRemoteIsBenign tests Scenario 12: the parent branch is absent on the
+// remote (deleted there) while the topic is in sync. The parent fetch fails with ref-not-found,
+// which is a non-fatal note; the topic fetch+sync pass and finish completes.
+// Steps:
+// 1. Sets up a test repository with remote and initializes git-flow
+// 2. Creates a feature branch, commits, and pushes it (in sync)
+// 3. Deletes develop directly in the bare remote
+// 4. Finishes the feature branch
+// 5. Verifies finish completes and the topic merged into local develop
+func TestFinishParentAbsentOnRemoteIsBenign(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "test-parent-absent"); err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+	commitFeatureAndPush(t, dir, "feature.txt", "feature content", "Add feature file", "feature/test-parent-absent")
+
+	// Delete the parent (develop) directly in the bare remote; topic stays in sync
+	if _, err := testutil.RunGit(t, remoteDir, "update-ref", "-d", "refs/heads/develop"); err != nil {
+		t.Fatalf("Failed to delete develop in bare remote: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "test-parent-absent")
+	if err != nil {
+		t.Fatalf("Expected finish to complete when the parent is absent on the remote. Error: %v\nOutput: %s", err, output)
+	}
+	if testutil.BranchExists(t, dir, "feature/test-parent-absent") {
+		t.Error("Expected feature branch to be deleted")
+	}
+	if _, err := testutil.RunGit(t, dir, "checkout", "develop"); err != nil {
+		t.Fatalf("Failed to checkout develop: %v", err)
+	}
+	if !testutil.FileExists(t, dir, "feature.txt") {
+		t.Error("Expected feature.txt to be merged into local develop")
 	}
 }

--- a/test/cmd/finish_sync_test.go
+++ b/test/cmd/finish_sync_test.go
@@ -574,7 +574,7 @@ func TestFinishContinueSkipsRemoteCheck(t *testing.T) {
 	}
 
 	// Break the remote so any fetch during continue would fatally fail
-	_, err = testutil.RunGit(t, dir, "remote", "set-url", "origin", "/nonexistent/repo.git")
+	_, err = testutil.RunGit(t, dir, "remote", "set-url", "origin", "./nonexistent-remote-repo.git")
 	if err != nil {
 		t.Fatalf("Failed to break remote: %v", err)
 	}

--- a/test/cmd/finish_sync_test.go
+++ b/test/cmd/finish_sync_test.go
@@ -77,6 +77,12 @@ func TestFinishFeatureBranchBehindRemote(t *testing.T) {
 		t.Fatalf("Failed to fetch: %v", err)
 	}
 
+	// Record develop's SHA before finishing
+	developBefore, err := testutil.RunGit(t, dir, "rev-parse", "develop")
+	if err != nil {
+		t.Fatalf("Failed to get develop SHA: %v", err)
+	}
+
 	// Attempt to finish the feature branch
 	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "test-behind")
 
@@ -90,14 +96,23 @@ func TestFinishFeatureBranchBehindRemote(t *testing.T) {
 		t.Errorf("Expected error message to mention 'behind'. Output: %s", output)
 	}
 
-	// Verify error message suggests update command
-	if !strings.Contains(output, "git flow feature update") {
-		t.Errorf("Expected error message to suggest update command. Output: %s", output)
+	// Verify error message suggests pulling the remote changes
+	if !strings.Contains(output, "git pull") {
+		t.Errorf("Expected error message to suggest 'git pull'. Output: %s", output)
 	}
 
 	// Verify error message suggests --force option
 	if !strings.Contains(output, "--force") {
 		t.Errorf("Expected error message to suggest --force option. Output: %s", output)
+	}
+
+	// Verify the merge did not happen: develop is unchanged
+	developAfter, err := testutil.RunGit(t, dir, "rev-parse", "develop")
+	if err != nil {
+		t.Fatalf("Failed to get develop SHA after: %v", err)
+	}
+	if developBefore != developAfter {
+		t.Errorf("Expected develop to be unchanged after aborted finish. Before: %s After: %s", developBefore, developAfter)
 	}
 
 	// Verify branch still exists (finish was aborted)

--- a/test/cmd/finish_sync_test.go
+++ b/test/cmd/finish_sync_test.go
@@ -759,3 +759,64 @@ func TestFinishNoFetchStillRunsSyncCheck(t *testing.T) {
 		t.Error("Expected feature branch to still exist after aborted finish")
 	}
 }
+
+// TestFinishCompareErrorAborts verifies that when a tracking branch exists but the sync comparison
+// itself fails (e.g. a corrupt/dangling tracking ref), finish fails closed rather than merging
+// against an undetermined sync status. This exercises the compare-error branch of the preflight,
+// which HasTrackingBranch gates entry into, so reaching a compare error is unexpected and fatal.
+// Steps:
+//  1. Sets up a test repository with remote and initializes git-flow
+//  2. Creates a feature branch, commits, and pushes it (establishes a tracking ref)
+//  3. Corrupts the loose remote-tracking ref to point at a nonexistent object, so @{upstream} still
+//     resolves by name (HasTrackingBranch stays true) but rev-list can no longer compare
+//  4. Finishes with --no-fetch (so the corrupt ref is not repaired by a fetch)
+//  5. Verifies finish fails, names the sync-status determination, and does not merge
+func TestFinishCompareErrorAborts(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "test-compare-error"); err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+	commitFeatureAndPush(t, dir, "feature.txt", "feature content", "Add feature file", "feature/test-compare-error")
+
+	// Corrupt the loose remote-tracking ref: point it at a nonexistent object. @{upstream} still
+	// resolves the tracking name (so HasTrackingBranch stays true), but rev-list can no longer walk
+	// the ref, forcing CompareBranchWithRemote to fail.
+	trackingRef := ".git/refs/remotes/origin/feature/test-compare-error"
+	if _, err := testutil.RunGit(t, dir, "rev-parse", "--verify", "origin/feature/test-compare-error"); err != nil {
+		t.Fatalf("Precondition failed: expected a loose tracking ref to exist: %v", err)
+	}
+	if err := testutil.WriteFile(t, dir, trackingRef, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n"); err != nil {
+		t.Fatalf("Failed to corrupt tracking ref: %v", err)
+	}
+
+	developBefore, err := testutil.RunGit(t, dir, "rev-parse", "develop")
+	if err != nil {
+		t.Fatalf("Failed to get develop SHA: %v", err)
+	}
+
+	// --no-fetch so the corrupt ref is not repaired by a fetch before the sync check
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "--no-fetch", "test-compare-error")
+	if err == nil {
+		t.Errorf("Expected finish to fail when the sync status cannot be determined. Output: %s", output)
+	}
+
+	// Verify the failure is the sync-status determination (not a merge or unrelated error)
+	if !strings.Contains(output, "determine sync status") {
+		t.Errorf("Expected the error to name the sync-status determination. Output: %s", output)
+	}
+
+	// Verify no merge happened: develop unchanged and the branch still exists
+	developAfter, err := testutil.RunGit(t, dir, "rev-parse", "develop")
+	if err != nil {
+		t.Fatalf("Failed to get develop SHA after: %v", err)
+	}
+	if developBefore != developAfter {
+		t.Errorf("Expected develop unchanged after aborted finish. Before: %s After: %s", developBefore, developAfter)
+	}
+	if !testutil.BranchExists(t, dir, "feature/test-compare-error") {
+		t.Error("Expected feature branch to still exist after aborted finish")
+	}
+}

--- a/test/cmd/finish_sync_test.go
+++ b/test/cmd/finish_sync_test.go
@@ -106,14 +106,16 @@ func TestFinishFeatureBranchBehindRemote(t *testing.T) {
 	}
 }
 
-// TestFinishFeatureBranchAheadOfRemote tests that finish succeeds when local is ahead of remote.
+// TestFinishFeatureBranchAheadOfRemote tests that finish aborts when local is ahead of remote.
+// This is Scenario 9: being ahead now aborts (previously a silent note that proceeded and merged).
 // Steps:
 // 1. Sets up a test repository with remote and initializes git-flow
 // 2. Creates a feature branch and pushes it with tracking
-// 3. Adds a local commit without pushing
-// 4. Finishes the feature branch
-// 5. Verifies the operation succeeds
-// 6. Verifies the note about being ahead is shown
+// 3. Adds a local commit without pushing (ahead by 1)
+// 4. Records develop's SHA before finishing
+// 5. Attempts to finish the feature branch
+// 6. Verifies the operation fails with an "ahead" message including the commit count
+// 7. Verifies the merge did not happen (develop unchanged, branch still exists)
 func TestFinishFeatureBranchAheadOfRemote(t *testing.T) {
 	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
 	defer testutil.CleanupTestRepo(t, dir)
@@ -142,7 +144,7 @@ func TestFinishFeatureBranchAheadOfRemote(t *testing.T) {
 		t.Fatalf("Failed to push branch: %v", err)
 	}
 
-	// Add another local commit without pushing
+	// Add another local commit without pushing (ahead by 1)
 	testutil.WriteFile(t, dir, "local.txt", "local content")
 	_, err = testutil.RunGit(t, dir, "add", "local.txt")
 	if err != nil {
@@ -153,41 +155,55 @@ func TestFinishFeatureBranchAheadOfRemote(t *testing.T) {
 		t.Fatalf("Failed to commit: %v", err)
 	}
 
-	// Finish the feature branch
+	// Record develop's SHA before finishing
+	developBefore, err := testutil.RunGit(t, dir, "rev-parse", "develop")
+	if err != nil {
+		t.Fatalf("Failed to get develop SHA: %v", err)
+	}
+
+	// Attempt to finish the feature branch
 	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "test-ahead")
-	if err != nil {
-		t.Fatalf("Expected finish to succeed when ahead of remote. Error: %v\nOutput: %s", err, output)
+
+	// Verify failure
+	if err == nil {
+		t.Errorf("Expected finish to fail when ahead of remote. Output: %s", output)
 	}
 
-	// Verify note about being ahead is shown
+	// Verify error message mentions being ahead with the commit count
 	if !strings.Contains(output, "ahead") {
-		t.Errorf("Expected note about being ahead of remote. Output: %s", output)
+		t.Errorf("Expected error message to mention 'ahead'. Output: %s", output)
+	}
+	if !strings.Contains(output, "1 commit") {
+		t.Errorf("Expected error message to include the commit count. Output: %s", output)
 	}
 
-	// Verify branch is deleted
-	if testutil.BranchExists(t, dir, "feature/test-ahead") {
-		t.Error("Expected feature branch to be deleted")
-	}
-
-	// Verify changes are merged into develop
-	_, err = testutil.RunGit(t, dir, "checkout", "develop")
+	// Verify the merge did not happen: develop is unchanged
+	developAfter, err := testutil.RunGit(t, dir, "rev-parse", "develop")
 	if err != nil {
-		t.Fatalf("Failed to checkout develop: %v", err)
+		t.Fatalf("Failed to get develop SHA after: %v", err)
+	}
+	if developBefore != developAfter {
+		t.Errorf("Expected develop to be unchanged after aborted finish. Before: %s After: %s", developBefore, developAfter)
 	}
 
-	if !testutil.FileExists(t, dir, "local.txt") {
-		t.Error("Expected local.txt to exist in develop branch")
+	// Verify branch still exists (finish was aborted)
+	if !testutil.BranchExists(t, dir, "feature/test-ahead") {
+		t.Error("Expected feature branch to still exist after aborted finish")
 	}
 }
 
-// TestFinishFeatureBranchDivergedFromRemote tests that finish fails when branches have diverged.
+// TestFinishFeatureBranchDivergedFromRemote tests that finish aborts with a diverged-specific
+// message when branches have diverged. This is Scenario 10: diverged now renders its own message
+// rather than reusing the plain "behind" wording.
 // Steps:
 // 1. Sets up a test repository with remote and initializes git-flow
 // 2. Creates a feature branch and pushes it with tracking
 // 3. Simulates divergence: remote gets commit, local gets different commit
 // 4. Fetches to update remote refs
-// 5. Attempts to finish the feature branch
-// 6. Verifies the operation fails with appropriate error
+// 5. Records develop's SHA before finishing
+// 6. Attempts to finish the feature branch
+// 7. Verifies the operation fails with a diverged-specific message (not "behind")
+// 8. Verifies the merge did not happen (develop unchanged, branch still exists)
 func TestFinishFeatureBranchDivergedFromRemote(t *testing.T) {
 	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
 	defer testutil.CleanupTestRepo(t, dir)
@@ -260,6 +276,12 @@ func TestFinishFeatureBranchDivergedFromRemote(t *testing.T) {
 		t.Fatalf("Failed to fetch: %v", err)
 	}
 
+	// Record develop's SHA before finishing
+	developBefore, err := testutil.RunGit(t, dir, "rev-parse", "develop")
+	if err != nil {
+		t.Fatalf("Failed to get develop SHA: %v", err)
+	}
+
 	// Attempt to finish the feature branch
 	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "test-diverged")
 
@@ -268,9 +290,21 @@ func TestFinishFeatureBranchDivergedFromRemote(t *testing.T) {
 		t.Error("Expected finish to fail when diverged from remote")
 	}
 
-	// Verify error message mentions being behind (diverged branches are also behind)
-	if !strings.Contains(output, "behind") {
-		t.Errorf("Expected error message to mention 'behind'. Output: %s", output)
+	// Verify error message describes divergence and is NOT the plain "behind" wording
+	if !strings.Contains(output, "diverged") {
+		t.Errorf("Expected error message to mention 'diverged'. Output: %s", output)
+	}
+	if strings.Contains(output, "behind") {
+		t.Errorf("Expected a diverged-specific message, not the 'behind' wording. Output: %s", output)
+	}
+
+	// Verify the merge did not happen: develop is unchanged
+	developAfter, err := testutil.RunGit(t, dir, "rev-parse", "develop")
+	if err != nil {
+		t.Fatalf("Failed to get develop SHA after: %v", err)
+	}
+	if developBefore != developAfter {
+		t.Errorf("Expected develop to be unchanged after aborted finish. Before: %s After: %s", developBefore, developAfter)
 	}
 
 	// Verify branch still exists (finish was aborted)
@@ -427,21 +461,34 @@ func TestFinishFeatureBranchForceBypassesRemoteCheck(t *testing.T) {
 	}
 }
 
-// TestFinishContinueSkipsRemoteCheck tests that --continue doesn't re-check remote status.
+// TestFinishContinueSkipsRemoteCheck tests that --continue does not re-run the fetch/sync preflight.
+// This is Scenario 23: the preflight is gated to the initial finish only. The topic is pushed in
+// sync so the initial finish passes the preflight and can then reach a merge conflict. The remote is
+// then broken; if --continue re-ran the preflight it would fatally abort on the unreachable remote.
+// keepremote is enabled so the unrelated remote-branch deletion (which would also fail on the broken
+// remote) does not mask the behavior under test.
 // Steps:
-// 1. Sets up a test repository with remote and initializes git-flow
-// 2. Creates merge conflict scenario
-// 3. Attempts finish (will conflict)
-// 4. Simulates remote getting ahead while conflict is being resolved
-// 5. Resolves conflict and continues with --continue
-// 6. Verifies continue succeeds (no remote re-check)
+// 1. Sets up a test repository with remote and initializes git-flow; enables keepremote
+// 2. Creates conflicting develop + feature changes; pushes the feature in sync
+// 3. Runs the initial finish, which passes the preflight then hits a merge conflict
+// 4. Verifies the conflict via .git/MERGE_HEAD
+// 5. Breaks the remote so any fetch would fatally fail
+// 6. Resolves the conflict and runs --continue
+// 7. Verifies continue completes without fetching or a transport abort, and clears the merge state
 func TestFinishContinueSkipsRemoteCheck(t *testing.T) {
 	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
 	defer testutil.CleanupTestRepo(t, dir)
 	defer testutil.CleanupTestRepo(t, remoteDir)
 
+	// Keep the remote branch so the delete step does not touch the (soon-broken) remote —
+	// this isolates the test to the preflight-skip behavior.
+	_, err := testutil.RunGit(t, dir, "config", "gitflow.feature.finish.keepremote", "true")
+	if err != nil {
+		t.Fatalf("Failed to set keepremote config: %v", err)
+	}
+
 	// Create conflicting content in develop
-	_, err := testutil.RunGit(t, dir, "checkout", "develop")
+	_, err = testutil.RunGit(t, dir, "checkout", "develop")
 	if err != nil {
 		t.Fatalf("Failed to checkout develop: %v", err)
 	}
@@ -471,13 +518,13 @@ func TestFinishContinueSkipsRemoteCheck(t *testing.T) {
 		t.Fatalf("Failed to commit feature changes: %v", err)
 	}
 
-	// Push the feature branch with tracking
+	// Push the feature branch with tracking (in sync — the preflight will pass)
 	_, err = testutil.RunGit(t, dir, "push", "--set-upstream", "origin", "feature/test-continue-remote")
 	if err != nil {
 		t.Fatalf("Failed to push branch: %v", err)
 	}
 
-	// Add more conflicting changes to develop
+	// Add more conflicting changes to develop so the merge will conflict
 	_, err = testutil.RunGit(t, dir, "checkout", "develop")
 	if err != nil {
 		t.Fatalf("Failed to checkout develop: %v", err)
@@ -498,7 +545,7 @@ func TestFinishContinueSkipsRemoteCheck(t *testing.T) {
 		t.Fatalf("Failed to checkout feature branch: %v", err)
 	}
 
-	// Try to finish (will conflict)
+	// Try to finish (default fetch=true) — passes the preflight, then hits the conflict
 	output, _ := testutil.RunGitFlow(t, dir, "feature", "finish", "test-continue-remote")
 
 	// Verify conflict was detected
@@ -506,37 +553,15 @@ func TestFinishContinueSkipsRemoteCheck(t *testing.T) {
 		t.Fatalf("Expected merge conflict to be detected. Output: %s", output)
 	}
 
-	// Simulate remote getting ahead while conflict is being resolved
-	secondDir := t.TempDir()
-	_, err = testutil.RunGit(t, secondDir, "clone", remoteDir, ".")
-	if err != nil {
-		t.Fatalf("Failed to clone: %v", err)
-	}
-	testutil.ConfigureGitIdentity(t, secondDir)
-
-	_, err = testutil.RunGit(t, secondDir, "checkout", "feature/test-continue-remote")
-	if err != nil {
-		t.Fatalf("Failed to checkout feature branch in second repo: %v", err)
+	// Verify the conflict via .git/MERGE_HEAD (not just output text)
+	if !testutil.FileExists(t, dir, ".git/MERGE_HEAD") {
+		t.Fatalf("Expected .git/MERGE_HEAD to exist during the merge conflict")
 	}
 
-	testutil.WriteFile(t, secondDir, "remote-while-resolving.txt", "remote content")
-	_, err = testutil.RunGit(t, secondDir, "add", "remote-while-resolving.txt")
+	// Break the remote so any fetch during continue would fatally fail
+	_, err = testutil.RunGit(t, dir, "remote", "set-url", "origin", "/nonexistent/repo.git")
 	if err != nil {
-		t.Fatalf("Failed to add file in second repo: %v", err)
-	}
-	_, err = testutil.RunGit(t, secondDir, "commit", "-m", "Remote commit while resolving")
-	if err != nil {
-		t.Fatalf("Failed to commit in second repo: %v", err)
-	}
-	_, err = testutil.RunGit(t, secondDir, "push", "origin", "feature/test-continue-remote")
-	if err != nil {
-		t.Fatalf("Failed to push from second repo: %v", err)
-	}
-
-	// Fetch in original repo to update remote refs (now local is behind)
-	_, err = testutil.RunGit(t, dir, "fetch", "origin")
-	if err != nil {
-		t.Fatalf("Failed to fetch: %v", err)
+		t.Fatalf("Failed to break remote: %v", err)
 	}
 
 	// Resolve conflict
@@ -546,15 +571,25 @@ func TestFinishContinueSkipsRemoteCheck(t *testing.T) {
 		t.Fatalf("Failed to resolve conflict: %v", err)
 	}
 
-	// Continue finish operation (should succeed despite being behind remote now)
+	// Continue finish operation (must not fetch or abort on the broken remote)
 	continueOutput, err := testutil.RunGitFlow(t, dir, "feature", "finish", "--continue", "test-continue-remote")
 	if err != nil {
-		t.Fatalf("Expected continue to succeed without re-checking remote. Error: %v\nOutput: %s", err, continueOutput)
+		t.Fatalf("Expected continue to succeed without re-running the preflight. Error: %v\nOutput: %s", err, continueOutput)
+	}
+
+	// Verify no fetch occurred during continue
+	if strings.Contains(continueOutput, "Fetching from remote") {
+		t.Errorf("Expected no fetch during --continue. Output: %s", continueOutput)
 	}
 
 	// Verify successful completion
 	if !strings.Contains(continueOutput, "Successfully finished") {
 		t.Errorf("Expected successful finish message after continue. Output: %s", continueOutput)
+	}
+
+	// Verify the merge state is cleared
+	if testutil.FileExists(t, dir, ".git/MERGE_HEAD") {
+		t.Errorf("Expected .git/MERGE_HEAD to be cleared after continue")
 	}
 
 	// Verify branch deleted
@@ -604,6 +639,11 @@ func TestFinishFeatureBranchEqualToRemote(t *testing.T) {
 		t.Fatalf("Expected finish to succeed when equal to remote. Error: %v\nOutput: %s", err, output)
 	}
 
+	// Verify fetch ran (default fetch=true with a reachable remote) — Scenario 3
+	if !strings.Contains(output, "Fetching from remote") {
+		t.Errorf("Expected fetch to occur before the in-sync finish. Output: %s", output)
+	}
+
 	// Verify no warning about being ahead or behind
 	if strings.Contains(output, "ahead") || strings.Contains(output, "behind") {
 		t.Errorf("Expected no warning about ahead/behind when equal to remote. Output: %s", output)
@@ -625,104 +665,82 @@ func TestFinishFeatureBranchEqualToRemote(t *testing.T) {
 	}
 }
 
-// TestFinishFetchFailsButSyncCheckStillRuns tests that when fetch fails, the sync check still runs.
+// TestFinishNoFetchStillRunsSyncCheck tests that --no-fetch skips the fetch but still runs
+// the sync check (Scenario 22). This replaces the old TestFinishFetchFailsButSyncCheckStillRuns,
+// which asserted a broken-URL fetch failure was non-fatal — a transport fetch failure is now
+// fatal (see TestFinishUnreachableRemoteAborts, Scenario 5). Here --no-fetch skips the fetch, so
+// the sync check runs against existing (stale) tracking data and still aborts on "behind".
 // Steps:
 // 1. Sets up a test repository with remote and initializes git-flow
-// 2. Creates a feature branch and pushes it with tracking
-// 3. Simulates remote changes by cloning, committing, and pushing
-// 4. Fetches in original repo to update remote refs (so sync check has data)
-// 5. Breaks the remote URL so subsequent fetch fails
-// 6. Attempts to finish with --fetch flag (fetch is disabled by default)
-// 7. Verifies fetch failure is non-fatal (note is printed)
-// 8. Verifies sync check still runs and catches "behind" state
-func TestFinishFetchFailsButSyncCheckStillRuns(t *testing.T) {
+// 2. Creates a feature branch, commits, and pushes it with tracking
+// 3. Resets the local branch back one commit so it is behind the remote by 1
+// 4. Records develop's SHA before finishing
+// 5. Runs finish with --no-fetch
+// 6. Verifies no fetch occurred but the sync check still aborts with "behind"
+// 7. Verifies the merge did not happen (develop unchanged, branch still exists)
+func TestFinishNoFetchStillRunsSyncCheck(t *testing.T) {
 	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
 	defer testutil.CleanupTestRepo(t, dir)
 	defer testutil.CleanupTestRepo(t, remoteDir)
 
 	// Create feature branch
-	_, err := testutil.RunGitFlow(t, dir, "feature", "start", "test-fetch-fail")
+	_, err := testutil.RunGitFlow(t, dir, "feature", "start", "test-no-fetch-sync")
 	if err != nil {
 		t.Fatalf("Failed to create feature branch: %v", err)
 	}
 
-	// Add a commit to the feature branch
+	// Add a commit and push with tracking
 	testutil.WriteFile(t, dir, "feature.txt", "feature content")
-	_, err = testutil.RunGit(t, dir, "add", "feature.txt")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "add", "feature.txt"); err != nil {
 		t.Fatalf("Failed to add file: %v", err)
 	}
-	_, err = testutil.RunGit(t, dir, "commit", "-m", "Add feature file")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "commit", "-m", "Add feature file"); err != nil {
 		t.Fatalf("Failed to commit: %v", err)
 	}
-
-	// Push with tracking
-	_, err = testutil.RunGit(t, dir, "push", "--set-upstream", "origin", "feature/test-fetch-fail")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "push", "--set-upstream", "origin", "feature/test-no-fetch-sync"); err != nil {
 		t.Fatalf("Failed to push branch: %v", err)
 	}
 
-	// Clone to a second working copy and make changes
-	secondDir := t.TempDir()
-	_, err = testutil.RunGit(t, secondDir, "clone", remoteDir, ".")
-	if err != nil {
-		t.Fatalf("Failed to clone: %v", err)
-	}
-	testutil.ConfigureGitIdentity(t, secondDir)
-
-	_, err = testutil.RunGit(t, secondDir, "checkout", "feature/test-fetch-fail")
-	if err != nil {
-		t.Fatalf("Failed to checkout feature branch in second repo: %v", err)
+	// Reset local branch back one commit so it is behind the remote by 1
+	if _, err = testutil.RunGit(t, dir, "reset", "--hard", "HEAD~1"); err != nil {
+		t.Fatalf("Failed to reset branch: %v", err)
 	}
 
-	testutil.WriteFile(t, secondDir, "remote-change.txt", "remote content")
-	_, err = testutil.RunGit(t, secondDir, "add", "remote-change.txt")
+	// Record develop's SHA before finishing
+	developBefore, err := testutil.RunGit(t, dir, "rev-parse", "develop")
 	if err != nil {
-		t.Fatalf("Failed to add file in second repo: %v", err)
-	}
-	_, err = testutil.RunGit(t, secondDir, "commit", "-m", "Remote commit")
-	if err != nil {
-		t.Fatalf("Failed to commit in second repo: %v", err)
-	}
-	_, err = testutil.RunGit(t, secondDir, "push", "origin", "feature/test-fetch-fail")
-	if err != nil {
-		t.Fatalf("Failed to push from second repo: %v", err)
+		t.Fatalf("Failed to get develop SHA: %v", err)
 	}
 
-	// Fetch in original repo to update remote refs (so sync check has data to work with)
-	_, err = testutil.RunGit(t, dir, "fetch", "origin")
-	if err != nil {
-		t.Fatalf("Failed to fetch: %v", err)
-	}
+	// Finish with --no-fetch: the fetch is skipped but the sync check still runs
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "--no-fetch", "test-no-fetch-sync")
 
-	// Break the remote URL so fetch will fail
-	_, err = testutil.RunGit(t, dir, "remote", "set-url", "origin", "/nonexistent/path/that/does/not/exist")
-	if err != nil {
-		t.Fatalf("Failed to change remote URL: %v", err)
-	}
-
-	// Attempt to finish with fetch explicitly enabled
-	// Fetch should fail but sync check should still run with previously fetched refs
-	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "--fetch", "test-fetch-fail")
-
-	// Verify failure due to being behind (not due to fetch failure)
+	// Verify failure due to being behind
 	if err == nil {
-		t.Error("Expected finish to fail when behind remote")
+		t.Errorf("Expected finish to fail when behind remote. Output: %s", output)
 	}
 
-	// Verify fetch failure note is printed (non-fatal)
-	if !strings.Contains(output, "Could not fetch") {
-		t.Errorf("Expected output to mention fetch failure. Output: %s", output)
+	// Verify no fetch occurred
+	if strings.Contains(output, "Fetching from remote") {
+		t.Errorf("Expected no fetch with --no-fetch. Output: %s", output)
 	}
 
-	// Verify sync check still ran and caught the "behind" state
+	// Verify the sync check still ran and caught the "behind" state
 	if !strings.Contains(output, "behind") {
 		t.Errorf("Expected error message to mention 'behind' (sync check should still run). Output: %s", output)
 	}
 
+	// Verify the merge did not happen: develop is unchanged
+	developAfter, err := testutil.RunGit(t, dir, "rev-parse", "develop")
+	if err != nil {
+		t.Fatalf("Failed to get develop SHA after: %v", err)
+	}
+	if developBefore != developAfter {
+		t.Errorf("Expected develop to be unchanged after aborted finish. Before: %s After: %s", developBefore, developAfter)
+	}
+
 	// Verify branch still exists (finish was aborted)
-	if !testutil.BranchExists(t, dir, "feature/test-fetch-fail") {
+	if !testutil.BranchExists(t, dir, "feature/test-no-fetch-sync") {
 		t.Error("Expected feature branch to still exist after aborted finish")
 	}
 }

--- a/test/cmd/start_test.go
+++ b/test/cmd/start_test.go
@@ -397,20 +397,21 @@ func TestStartWithoutInitialization(t *testing.T) {
 	}
 }
 
-// TestStartWithoutFetch tests the default behavior (no fetch)
+// TestStartWithoutFetch tests Scenario 19: the default start behavior does not fetch (default false).
+// Uses a remote-backed fixture so the absence of "Fetching" reflects the default, not a missing remote.
+// Steps:
+// 1. Sets up a test repository with a remote and initializes git-flow
+// 2. Runs 'git flow feature start' with no fetch flag and no fetch config
+// 3. Verifies no "Fetching" line appears
+// 4. Verifies the feature branch is created
 func TestStartWithoutFetch(t *testing.T) {
-	// Setup test repo
-	dir := testutil.SetupTestRepo(t)
+	// Setup test repo with remote so absence of fetch reflects the default (not a missing remote)
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
 	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
 
-	// Initialize git-flow with defaults
-	output, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
-	if err != nil {
-		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
-	}
-
-	// Run git-flow feature start without the fetch flag
-	output, err = testutil.RunGitFlow(t, dir, "feature", "start", "no-fetch-test")
+	// Run git-flow feature start without the fetch flag (default is no fetch)
+	output, err := testutil.RunGitFlow(t, dir, "feature", "start", "no-fetch-test")
 	if err != nil {
 		t.Fatalf("Failed to run git-flow feature start: %v\nOutput: %s", err, output)
 	}
@@ -418,6 +419,11 @@ func TestStartWithoutFetch(t *testing.T) {
 	// Verify that output does not contain fetching info
 	if strings.Contains(output, "Fetching from") {
 		t.Errorf("Expected no fetch operation, but output indicates fetching: %s", output)
+	}
+
+	// Verify the branch was created
+	if !testutil.BranchExists(t, dir, "feature/no-fetch-test") {
+		t.Error("Expected feature/no-fetch-test branch to exist")
 	}
 }
 
@@ -440,7 +446,13 @@ func TestStartWithFetchFlag(t *testing.T) {
 	}
 }
 
-// TestStartWithFetchConfig tests that the gitflow.<topic>.start.fetch config works
+// TestStartWithFetchConfig tests Scenario 20: gitflow.<topic>.start.fetch=true drives a fetch.
+// Steps:
+// 1. Sets up a test repository with a remote and initializes git-flow
+// 2. Sets gitflow.feature.start.fetch=true
+// 3. Runs 'git flow feature start' with no explicit fetch flag
+// 4. Verifies a "Fetching" line appears
+// 5. Verifies the feature branch is created
 func TestStartWithFetchConfig(t *testing.T) {
 	// Setup test repo with remote (includes git-flow init)
 	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
@@ -463,28 +475,36 @@ func TestStartWithFetchConfig(t *testing.T) {
 	if !strings.Contains(output, "Fetching from") {
 		t.Errorf("Expected fetch operation due to config, but output doesn't indicate fetching: %s", output)
 	}
+
+	// Verify the branch was created
+	if !testutil.BranchExists(t, dir, "feature/config-fetch-test") {
+		t.Error("Expected feature/config-fetch-test branch to exist")
+	}
 }
 
-// TestStartWithNoFetchOverridesConfig tests that --no-fetch overrides the config
+// TestStartWithNoFetchOverridesConfig tests Scenario 21: --no-fetch overrides start.fetch=true.
+// Uses a remote-backed fixture so the absence of "Fetching" reflects the flag overriding the config,
+// not a missing remote.
+// Steps:
+// 1. Sets up a test repository with a remote and initializes git-flow
+// 2. Sets gitflow.feature.start.fetch=true
+// 3. Runs 'git flow feature start' with --no-fetch
+// 4. Verifies no "Fetching" line appears (flag overrides config)
+// 5. Verifies the feature branch is created
 func TestStartWithNoFetchOverridesConfig(t *testing.T) {
-	// Setup test repo
-	dir := testutil.SetupTestRepo(t)
+	// Setup test repo with remote so absence of fetch reflects the flag, not a missing remote
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
 	defer testutil.CleanupTestRepo(t, dir)
-
-	// Initialize git-flow with defaults
-	output, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
-	if err != nil {
-		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
-	}
+	defer testutil.CleanupTestRepo(t, remoteDir)
 
 	// Set the config to enable fetch
-	_, err = testutil.RunGit(t, dir, "config", "gitflow.feature.start.fetch", "true")
+	_, err := testutil.RunGit(t, dir, "config", "gitflow.feature.start.fetch", "true")
 	if err != nil {
 		t.Fatalf("Failed to set config: %v", err)
 	}
 
 	// Run git-flow feature start with --no-fetch to override config
-	output, err = testutil.RunGitFlow(t, dir, "feature", "start", "no-fetch-override-test", "--no-fetch")
+	output, err := testutil.RunGitFlow(t, dir, "feature", "start", "no-fetch-override-test", "--no-fetch")
 	if err != nil {
 		t.Fatalf("Failed to run git-flow feature start: %v\nOutput: %s", err, output)
 	}
@@ -492,6 +512,11 @@ func TestStartWithNoFetchOverridesConfig(t *testing.T) {
 	// Verify that output does not contain fetching info
 	if strings.Contains(output, "Fetching from") {
 		t.Errorf("Expected no fetch operation due to --no-fetch flag, but output indicates fetching: %s", output)
+	}
+
+	// Verify the branch was created
+	if !testutil.BranchExists(t, dir, "feature/no-fetch-override-test") {
+		t.Error("Expected feature/no-fetch-override-test branch to exist")
 	}
 }
 
@@ -627,5 +652,134 @@ func TestStartFeatureBranchNoRemoteFetchSkipped(t *testing.T) {
 	// Verify branch was created
 	if !testutil.BranchExists(t, dir, "feature/no-remote-test") {
 		t.Error("Expected feature/no-remote-test branch to exist")
+	}
+}
+
+// TestStartFetchesAdvancedStartPoint tests Scenario 14: with start.fetch=true and a reachable
+// remote whose start point has advanced, start fetches and the advance becomes visible locally.
+// The advance is made from a second clone so the primary's origin/develop is not updated before
+// start runs — otherwise the test would pass without ever fetching.
+// Steps:
+// 1. Sets up a test repository with a remote and initializes git-flow; enables start.fetch
+// 2. Records OLD = the primary's origin/develop
+// 3. Advances develop from a second clone (commit + push); records NEW = the bare remote develop
+// 4. Asserts the primary's origin/develop is still OLD and the bare develop is NEW (out of sync)
+// 5. Runs 'git flow feature start'
+// 6. Verifies a "Fetching" line, the branch is created, and origin/develop now resolves to NEW
+func TestStartFetchesAdvancedStartPoint(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	// Enable fetch for start
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.feature.start.fetch", "true"); err != nil {
+		t.Fatalf("Failed to set fetch config: %v", err)
+	}
+
+	// Record OLD = the primary's origin/develop before advancing
+	oldRaw, err := testutil.RunGit(t, dir, "rev-parse", "origin/develop")
+	if err != nil {
+		t.Fatalf("Failed to get origin/develop: %v", err)
+	}
+	old := strings.TrimSpace(oldRaw)
+
+	// Advance develop from a second clone
+	secondDir := t.TempDir()
+	if _, err := testutil.RunGit(t, secondDir, "clone", remoteDir, "."); err != nil {
+		t.Fatalf("Failed to clone: %v", err)
+	}
+	testutil.ConfigureGitIdentity(t, secondDir)
+	if _, err := testutil.RunGit(t, secondDir, "checkout", "develop"); err != nil {
+		t.Fatalf("Failed to checkout develop in second repo: %v", err)
+	}
+	testutil.WriteFile(t, secondDir, "advance.txt", "advanced content")
+	if _, err := testutil.RunGit(t, secondDir, "add", "advance.txt"); err != nil {
+		t.Fatalf("Failed to add file in second repo: %v", err)
+	}
+	if _, err := testutil.RunGit(t, secondDir, "commit", "-m", "Advance develop"); err != nil {
+		t.Fatalf("Failed to commit in second repo: %v", err)
+	}
+	if _, err := testutil.RunGit(t, secondDir, "push", "origin", "develop"); err != nil {
+		t.Fatalf("Failed to push from second repo: %v", err)
+	}
+
+	// Record NEW = the bare remote develop
+	newRaw, err := testutil.RunGit(t, remoteDir, "rev-parse", "refs/heads/develop")
+	if err != nil {
+		t.Fatalf("Failed to get bare develop: %v", err)
+	}
+	newSHA := strings.TrimSpace(newRaw)
+
+	// Precondition: primary origin/develop still OLD, bare develop is NEW, and they differ
+	primaryBeforeRaw, err := testutil.RunGit(t, dir, "rev-parse", "origin/develop")
+	if err != nil {
+		t.Fatalf("Failed to get primary origin/develop: %v", err)
+	}
+	if strings.TrimSpace(primaryBeforeRaw) != old {
+		t.Fatalf("Precondition failed: expected primary origin/develop to still be OLD (%s), got %s", old, strings.TrimSpace(primaryBeforeRaw))
+	}
+	if old == newSHA {
+		t.Fatalf("Precondition failed: expected OLD (%s) != NEW (%s)", old, newSHA)
+	}
+
+	// Run start
+	output, err := testutil.RunGitFlow(t, dir, "feature", "start", "advanced-test")
+	if err != nil {
+		t.Fatalf("Failed to run git-flow feature start: %v\nOutput: %s", err, output)
+	}
+
+	// Verify fetch ran
+	if !strings.Contains(output, "Fetching from") {
+		t.Errorf("Expected a fetch to run. Output: %s", output)
+	}
+
+	// Verify branch created
+	if !testutil.BranchExists(t, dir, "feature/advanced-test") {
+		t.Error("Expected feature/advanced-test branch to exist")
+	}
+
+	// Verify the advance is now visible: primary origin/develop == NEW
+	afterRaw, err := testutil.RunGit(t, dir, "rev-parse", "origin/develop")
+	if err != nil {
+		t.Fatalf("Failed to get origin/develop after start: %v", err)
+	}
+	if strings.TrimSpace(afterRaw) != newSHA {
+		t.Errorf("Expected origin/develop to advance to NEW (%s) after start, got %s", newSHA, strings.TrimSpace(afterRaw))
+	}
+}
+
+// TestStartUnreachableRemoteWarnsAndCreates tests Scenario 15: with start.fetch=true and an
+// unreachable remote, the fetch failure is a non-fatal warning and the branch is still created.
+// RunGitFlow uses CombinedOutput, so the warning is asserted on the combined output.
+// Steps:
+// 1. Sets up a test repository with a remote and initializes git-flow; enables start.fetch
+// 2. Points origin at a nonexistent path
+// 3. Runs 'git flow feature start'
+// 4. Verifies the command still succeeds, the combined output contains a Warning, and the branch exists
+func TestStartUnreachableRemoteWarnsAndCreates(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.feature.start.fetch", "true"); err != nil {
+		t.Fatalf("Failed to set fetch config: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "remote", "set-url", "origin", "/nonexistent/repo.git"); err != nil {
+		t.Fatalf("Failed to break remote: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "start", "unreachable-test")
+	if err != nil {
+		t.Fatalf("Expected start to succeed despite fetch failure. Error: %v\nOutput: %s", err, output)
+	}
+
+	// Verify a warning about the failed fetch (combined output)
+	if !strings.Contains(output, "Warning:") {
+		t.Errorf("Expected a Warning about the failed fetch. Output: %s", output)
+	}
+
+	// Verify branch created
+	if !testutil.BranchExists(t, dir, "feature/unreachable-test") {
+		t.Error("Expected feature/unreachable-test branch to exist")
 	}
 }

--- a/test/cmd/start_test.go
+++ b/test/cmd/start_test.go
@@ -764,7 +764,7 @@ func TestStartUnreachableRemoteWarnsAndCreates(t *testing.T) {
 	if _, err := testutil.RunGit(t, dir, "config", "gitflow.feature.start.fetch", "true"); err != nil {
 		t.Fatalf("Failed to set fetch config: %v", err)
 	}
-	if _, err := testutil.RunGit(t, dir, "remote", "set-url", "origin", "/nonexistent/repo.git"); err != nil {
+	if _, err := testutil.RunGit(t, dir, "remote", "set-url", "origin", "./nonexistent-remote-repo.git"); err != nil {
 		t.Fatalf("Failed to break remote: %v", err)
 	}
 

--- a/test/internal/git/repo_test.go
+++ b/test/internal/git/repo_test.go
@@ -1,7 +1,9 @@
 package git_test
 
 import (
+	goerrors "errors"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/gittower/git-flow-next/internal/git"
@@ -649,10 +651,12 @@ func TestFetchBranch(t *testing.T) {
 }
 
 // TestFetchBranchNonExistent tests fetch of a non-existent branch.
+// A missing remote ref is a benign condition that must be classified as ErrRemoteRefNotFound,
+// so the finish preflight can distinguish it from a fatal transport failure.
 // Steps:
 // 1. Sets up a test repository with a remote
 // 2. Calls FetchBranch for a branch that doesn't exist on remote
-// 3. Verifies an error is returned
+// 3. Verifies the error wraps the ErrRemoteRefNotFound sentinel
 func TestFetchBranchNonExistent(t *testing.T) {
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
@@ -666,7 +670,34 @@ func TestFetchBranchNonExistent(t *testing.T) {
 	withGitRepo(t, dir, func() {
 		err := git.FetchBranch("origin", "non-existent-branch")
 		if err == nil {
-			t.Error("Expected error when fetching non-existent branch, got nil")
+			t.Fatal("Expected error when fetching non-existent branch, got nil")
+		}
+		if !goerrors.Is(err, git.ErrRemoteRefNotFound) {
+			t.Errorf("Expected error to wrap ErrRemoteRefNotFound, got: %v", err)
+		}
+	})
+}
+
+// TestFetchBranchTransportFailure tests that a transport/connection failure is NOT misclassified
+// as a benign missing ref. Fetching from a bogus remote (a path that is not a git repository)
+// must return an error that does not wrap ErrRemoteRefNotFound, so the preflight treats it as fatal.
+// Steps:
+// 1. Sets up a test repository (no reachable remote for the bogus target)
+// 2. Calls FetchBranch against a non-existent remote path
+// 3. Verifies an error is returned that does NOT wrap ErrRemoteRefNotFound
+func TestFetchBranchTransportFailure(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	bogusRemote := filepath.Join(dir, "does-not-exist-remote.git")
+
+	withGitRepo(t, dir, func() {
+		err := git.FetchBranch(bogusRemote, "main")
+		if err == nil {
+			t.Fatal("Expected error when fetching from a non-existent remote, got nil")
+		}
+		if goerrors.Is(err, git.ErrRemoteRefNotFound) {
+			t.Errorf("Expected transport failure NOT to wrap ErrRemoteRefNotFound, got: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
Hardens `finish`'s pre-merge fetch and remote sync check — a failed fetch against a reachable remote is now fatal and an out-of-sync topic branch aborts — and moves `start` onto the same shared fetch primitive and config resolver so both commands behave consistently.

This is "Step 0" of the fetch/sync work (foundation for #88, #98, #99). The old `finish` logic swallowed every fetch error as a non-fatal note and let an "ahead" branch merge silently. The new `runFetchSyncPreflight` helper (`cmd/preflight.go`) classifies fetch failures: a missing remote ref (never pushed, or deleted after a remote merge) is benign — the stale tracking ref is pruned and the topic sync check is skipped — while a transport/auth failure is fatal (`FetchFailedError`) unless `--force`. The topic branch is then compared with its remote and any ahead/behind/diverged state aborts with a status-specific `BranchNotInSyncError` (unless `--force`); the parent is fetched best-effort but not sync-checked (reserved for #99). To support this, `git.FetchBranch` now pins `LC_ALL=C` and classifies stderr into the new `ErrRemoteRefNotFound` sentinel, and gains `HasTrackingBranch` and `DeleteRemoteTrackingRef` helpers. The config resolver is generalized into `resolveShouldFetch(cfg, type, cmd, default, flag)`, shared by `finish` (default true) and `start` (default false), and `start` now skips the fetch silently when no remote is configured, treating any fetch failure as a warning since it has no sync gate. Defaults are unchanged. Manpages, CONFIGURATION.md, gitflow-config.5.md, and CHANGELOG are updated for the three behavior changes.

Resolves #134

## Remarks

- No default values change in this step — this is hardening plus a refactor, not a policy change (`fetch=true` for finish, `false` for start are preserved).
- `--force` still attempts the fetch; it only ignores fetch failures and skips the sync check (docs and error text corrected to match).
- `--no-fetch` skips only the fetch; the sync check still runs against existing local tracking data.
- The stderr classifier is locale-pinned (`LC_ALL=C`) so git's English "couldn't find remote ref" phrasing is matched regardless of the user's `LANG`/`LC_*`.

**Review focus:**
- `cmd/preflight.go` — the benign-vs-fatal fetch split and the topic-only sync gate
- `internal/git/repo.go` — `FetchBranch` error classification and the `LC_ALL=C` pin
- `internal/errors/errors.go` — `BranchNotInSyncError` per-status messages and the nested-name short-name handling
- `internal/config/resolver.go` — generalized `resolveShouldFetch` and preserved defaults