### PR TITLE
feat(integrate): Add git flow integrate command

### DIFF
--- a/cmd/finish.go
+++ b/cmd/finish.go
@@ -66,6 +66,10 @@ const (
 	stepCreateTag      = "create_tag"
 	stepUpdateChildren = "update_children"
 	stepDeleteBranch   = "delete_branch"
+	// stepIntegrateDone is the terminal step for the integrate operation. Unlike
+	// finish, integrate never deletes the integrated branch, so the state
+	// machine terminates here after checking out the parent and clearing state.
+	stepIntegrateDone = "integrate_done"
 )
 
 // Strategy constants
@@ -328,6 +332,8 @@ func executeSteps(cfg *config.Config, state *mergestate.MergeState, branchConfig
 			err = handleUpdateChildrenStep(cfg, state, branchConfig, resolvedOptions)
 		case stepDeleteBranch:
 			return handleDeleteBranchStep(cfg, state, resolvedOptions) // Final step
+		case stepIntegrateDone:
+			return handleIntegrateDoneStep(state) // Final step (integrate)
 		default:
 			return &errors.GitError{Operation: fmt.Sprintf("unknown step '%s'", state.CurrentStep), Err: nil}
 		}
@@ -529,9 +535,29 @@ func handleContinue(cfg *config.Config, state *mergestate.MergeState, branchConf
 }
 
 func handleAbort(state *mergestate.MergeState) error {
-	// Abort the merge based on strategy
+	// Choose which git operation to abort. During the child-update step the
+	// in-progress operation uses the current child's downstream strategy, which
+	// can differ from the parent merge strategy in state.MergeStrategy. Aborting
+	// with the wrong strategy (e.g. a merge-abort while a rebase is in progress)
+	// leaves a stray operation behind, so resolve the child's strategy here.
+	strategy := state.MergeStrategy
+	if state.CurrentStep == stepUpdateChildren {
+		currentChild := state.CurrentChildBranch
+		if currentChild == "" {
+			if cur, curErr := git.GetCurrentBranch(); curErr == nil {
+				currentChild = cur
+			}
+		}
+		if state.ChildStrategies != nil && currentChild != "" {
+			if s, ok := state.ChildStrategies[currentChild]; ok && s != "" {
+				strategy = s
+			}
+		}
+	}
+
+	// Abort the in-progress operation based on the resolved strategy
 	var err error
-	switch state.MergeStrategy {
+	switch strategy {
 	case strategyMerge:
 		err = git.MergeAbort()
 	case strategyRebase:
@@ -688,9 +714,15 @@ func handleUpdateChildrenStep(cfg *config.Config, state *mergestate.MergeState, 
 	// Find next child branch to update
 	nextBranch := findNextBranchToUpdate(state)
 
-	// If no more branches to update, move to final step
+	// If no more branches to update, move to the appropriate terminal step.
+	// Integrate never deletes the integrated branch, so it terminates via
+	// stepIntegrateDone instead of stepDeleteBranch.
 	if nextBranch == "" {
-		state.CurrentStep = stepDeleteBranch
+		if state.Action == "integrate" {
+			state.CurrentStep = stepIntegrateDone
+		} else {
+			state.CurrentStep = stepDeleteBranch
+		}
 		if err := mergestate.SaveMergeState(state); err != nil {
 			return &errors.GitError{Operation: "save merge state", Err: err}
 		}
@@ -840,6 +872,24 @@ func pushFinishedBranches(cfg *config.Config, state *mergestate.MergeState, reso
 		fmt.Printf("  %s (tag) -> %s\n", resolvedOptions.TagName, remote)
 	}
 
+	return nil
+}
+
+// handleIntegrateDoneStep terminates an integrate operation. Unlike finish, it
+// never deletes the integrated branch (base branches are permanent): it checks
+// out the parent branch and clears the merge state.
+func handleIntegrateDoneStep(state *mergestate.MergeState) error {
+	// Ensure we end up on the parent branch.
+	if err := git.Checkout(state.ParentBranch); err != nil {
+		return &errors.GitError{Operation: fmt.Sprintf("checkout parent branch '%s'", state.ParentBranch), Err: err}
+	}
+
+	// Clear the merge state: all merges, tags, and child updates are complete.
+	if err := mergestate.ClearMergeState(); err != nil {
+		return &errors.GitError{Operation: "clear merge state", Err: err}
+	}
+
+	fmt.Printf("Successfully integrated '%s' into '%s' and updated %d child base branch(es)\n", state.FullBranchName, state.ParentBranch, len(state.UpdatedBranches))
 	return nil
 }
 
@@ -1000,8 +1050,14 @@ func isChildUpdated(state *mergestate.MergeState, childName string) bool {
 func generateConflictMessage(state *mergestate.MergeState, cfg *config.Config, resolvedOptions *config.ResolvedFinishOptions) string {
 	var msg strings.Builder
 
+	isIntegrate := state.Action == "integrate"
+
 	// Header
-	msg.WriteString(fmt.Sprintf("Merge conflict detected while finishing %s/%s\n\n", state.BranchType, state.BranchName))
+	if isIntegrate {
+		msg.WriteString(fmt.Sprintf("Merge conflict detected while integrating '%s' into '%s'\n\n", state.FullBranchName, state.ParentBranch))
+	} else {
+		msg.WriteString(fmt.Sprintf("Merge conflict detected while finishing %s/%s\n\n", state.BranchType, state.BranchName))
+	}
 
 	// What happened section
 	msg.WriteString("What happened:\n")
@@ -1018,7 +1074,11 @@ func generateConflictMessage(state *mergestate.MergeState, cfg *config.Config, r
 
 	// Where we are section - show all steps as natural progression
 	msg.WriteString("\nWhere we are:\n")
-	msg.WriteString("  ✓ Started finish operation\n")
+	if isIntegrate {
+		msg.WriteString("  ✓ Started integrate operation\n")
+	} else {
+		msg.WriteString("  ✓ Started finish operation\n")
+	}
 
 	// Merge step
 	if state.CurrentStep == stepMerge {
@@ -1052,19 +1112,26 @@ func generateConflictMessage(state *mergestate.MergeState, cfg *config.Config, r
 		}
 	}
 
-	// Delete branch step
-	if state.CurrentStep == stepDeleteBranch {
-		msg.WriteString(fmt.Sprintf("  ✓ Delete %s branch\n", state.BranchType))
-	} else {
-		msg.WriteString(fmt.Sprintf("  ⧖ Delete %s branch\n", state.BranchType))
+	// Delete branch step (finish only — integrate never deletes the branch)
+	if !isIntegrate {
+		if state.CurrentStep == stepDeleteBranch {
+			msg.WriteString(fmt.Sprintf("  ✓ Delete %s branch\n", state.BranchType))
+		} else {
+			msg.WriteString(fmt.Sprintf("  ⧖ Delete %s branch\n", state.BranchType))
+		}
 	}
 
 	// Resolution instructions
 	msg.WriteString("\nTo continue:\n")
 	msg.WriteString("  1. Resolve the conflicts in your files\n")
 	msg.WriteString("  2. Stage resolved files: git add <files>\n")
-	msg.WriteString(fmt.Sprintf("  3. Continue: git flow %s finish --continue %s\n", state.BranchType, state.BranchName))
-	msg.WriteString(fmt.Sprintf("\nTo abort: git flow %s finish --abort %s", state.BranchType, state.BranchName))
+	if isIntegrate {
+		msg.WriteString("  3. Continue: git flow integrate --continue\n")
+		msg.WriteString("\nTo abort: git flow integrate --abort")
+	} else {
+		msg.WriteString(fmt.Sprintf("  3. Continue: git flow %s finish --continue %s\n", state.BranchType, state.BranchName))
+		msg.WriteString(fmt.Sprintf("\nTo abort: git flow %s finish --abort %s", state.BranchType, state.BranchName))
+	}
 
 	return msg.String()
 }

--- a/cmd/integrate.go
+++ b/cmd/integrate.go
@@ -1,0 +1,252 @@
+// Package cmd — integrate command.
+//
+// The integrate command merges a base branch upstream into its configured
+// parent (e.g. develop -> main), honoring the branch type's upstream merge
+// strategy, optionally tagging the parent, and auto-updating the parent's
+// autoUpdate children. It reuses finish's conflict-resumable merge -> tag ->
+// update-children state machine but OMITS the delete-branch step: base branches
+// are permanent and are never deleted, created, or renamed.
+//
+// Key differences from finish:
+//   - Operates on base branches only (BranchConfig.Type == "base").
+//   - Never deletes the integrated branch; the state machine terminates after
+//     updating children (Action == "integrate").
+//   - --tag <version> is a string flag that both enables tagging and sets the
+//     name; there is no version-derived default, so tagging enabled without a
+//     name errors before merging.
+//   - Tagging and fetching default OFF (fetch is opt-in).
+//   - --continue/--abort gate on state.Action == "integrate" so an in-progress
+//     finish/update is never hijacked.
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gittower/git-flow-next/internal/config"
+	"github.com/gittower/git-flow-next/internal/errors"
+	"github.com/gittower/git-flow-next/internal/git"
+	"github.com/gittower/git-flow-next/internal/mergestate"
+	"github.com/spf13/cobra"
+)
+
+// IntegrateCommand is the public entry point for the integrate command. It maps
+// git-flow errors to their exit codes and exits non-zero on failure.
+func IntegrateCommand(name string, continueOp bool, abortOp bool, tagOptions *config.TagOptions, mergeOptions *config.MergeStrategyOptions, fetch *bool) {
+	if err := executeIntegrate(name, continueOp, abortOp, tagOptions, mergeOptions, fetch); err != nil {
+		var exitCode errors.ExitCode
+		if flowErr, ok := err.(errors.Error); ok {
+			exitCode = flowErr.ExitCode()
+		} else {
+			exitCode = errors.ExitCodeGitError
+		}
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(int(exitCode))
+	}
+}
+
+// executeIntegrate performs the integrate logic and returns any error.
+func executeIntegrate(name string, continueOp bool, abortOp bool, tagOptions *config.TagOptions, mergeOptions *config.MergeStrategyOptions, fetch *bool) error {
+	// Validate that git-flow is initialized.
+	initialized, err := config.IsInitialized()
+	if err != nil {
+		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
+	}
+	if !initialized {
+		return &errors.NotInitializedError{}
+	}
+
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return &errors.GitError{Operation: "load configuration", Err: err}
+	}
+
+	// Foreign-state guard. Refuse to touch an in-progress finish or update.
+	// We load the raw state (without the stale-clearing side effect of
+	// IsMergeInProgress) and check whether git is genuinely mid-operation,
+	// because some operations (e.g. update) persist state without a BranchType,
+	// which IsMergeInProgress would otherwise treat as stale and clear.
+	if rawState, _ := mergestate.LoadMergeState(); rawState != nil && rawState.Action != "integrate" {
+		if git.IsGitMergeInProgress() || git.IsGitRebaseInProgress() || git.IsGitSquashMergeInProgress() {
+			return &errors.MergeInProgressError{BranchName: rawState.FullBranchName}
+		}
+	}
+
+	// Merge-in-progress dispatch for integrate's own state.
+	if mergestate.IsMergeInProgress() {
+		state, err := mergestate.LoadMergeState()
+		if err != nil {
+			return &errors.GitError{Operation: "load merge state", Err: err}
+		}
+		if state.Action != "integrate" {
+			return &errors.MergeInProgressError{BranchName: state.FullBranchName}
+		}
+		if abortOp {
+			return handleAbort(state)
+		}
+		if continueOp {
+			resolved := config.ResolveIntegrateOptions(cfg, state.BranchName, tagOptions, mergeOptions, fetch)
+			// Restore the tag decision made on the initial run: --continue does
+			// not repeat --tag, so re-resolving from CLI would drop the tag.
+			resolved.ShouldTag = state.ShouldTag
+			resolved.TagName = state.TagName
+			resolved.TagMessage = state.TagMessage
+			resolved.MessageFile = state.TagMessageFile
+			resolved.ShouldSign = state.ShouldSign
+			resolved.SigningKey = state.SigningKey
+			branchConfig := cfg.Branches[state.BranchType]
+			return handleContinue(cfg, state, branchConfig, resolved, mergeOptions)
+		}
+		return &errors.MergeInProgressError{BranchName: state.FullBranchName}
+	}
+
+	// No merge in progress: abort is a forgiving no-op, continue has nothing to
+	// resume (matches finish's dispatch).
+	if abortOp {
+		return nil
+	}
+	if continueOp {
+		return &errors.NoMergeInProgressError{}
+	}
+
+	// Resolve the source base branch: explicit argument or the current branch.
+	if name == "" {
+		currentBranch, err := git.GetCurrentBranch()
+		if err != nil {
+			return &errors.GitError{Operation: "get current branch", Err: err}
+		}
+		name = currentBranch
+	}
+
+	canonical, found := cfg.ResolveBranchName(name)
+	if !found {
+		// A real branch that is not a configured base branch is a topic/other
+		// branch; a name that matches no branch at all is simply not found.
+		if git.BranchExists(name) == nil {
+			return &errors.NotBaseBranchError{BranchName: name}
+		}
+		return &errors.BranchNotFoundError{BranchName: name}
+	}
+	name = canonical
+	branchConfig := cfg.Branches[name]
+
+	// Validation gates — all before any branch/tag mutation.
+	if branchConfig.Type != string(config.BranchTypeBase) {
+		return &errors.NotBaseBranchError{BranchName: name}
+	}
+	if branchConfig.Parent == "" {
+		return &errors.NoParentBranchError{BranchName: name}
+	}
+	if branchConfig.Parent == name {
+		return &errors.SelfParentError{BranchName: name}
+	}
+	if branchConfig.UpstreamStrategy == string(config.MergeStrategyNone) {
+		return &errors.NoUpstreamStrategyError{BranchName: name}
+	}
+
+	parent := branchConfig.Parent
+	if err := git.BranchExists(parent); err != nil {
+		return &errors.BranchNotFoundError{BranchName: parent}
+	}
+
+	// Resolve all options once before starting.
+	resolved := config.ResolveIntegrateOptions(cfg, name, tagOptions, mergeOptions, fetch)
+
+	// Tag-name pre-check: base branches have no version-derived default name, so
+	// tagging enabled without a resolvable name must error before merging.
+	if resolved.ShouldTag && resolved.TagName == "" {
+		return &errors.TagEnabledNoNameError{}
+	}
+
+	// Optional fetch (opt-in). Fast-forward the local parent from the remote so
+	// the integration merges against up-to-date remote history; failures are
+	// non-fatal (the remote branch may not exist).
+	if resolved.ShouldFetch && git.RemoteExists(cfg.Remote) {
+		fmt.Printf("Fetching from remote '%s'...\n", cfg.Remote)
+		if err := git.FetchBranch(cfg.Remote, fmt.Sprintf("%s:%s", parent, parent)); err != nil {
+			fmt.Printf("Note: Could not fetch parent branch '%s': %v\n", parent, err)
+		}
+		if err := git.FetchBranch(cfg.Remote, name); err != nil {
+			fmt.Printf("Note: Could not fetch branch '%s': %v\n", name, err)
+		}
+		fmt.Printf("Fetch completed\n")
+	}
+
+	// Discover auto-update child base branches and capture their strategies.
+	childBranches := []string{}
+	childStrategies := make(map[string]string)
+	for branchName, branch := range cfg.Branches {
+		if branch.Type == string(config.BranchTypeBase) && branch.Parent == parent && branch.AutoUpdate {
+			fmt.Printf("Found child base branch '%s' with auto-update enabled\n", branchName)
+			childBranches = append(childBranches, branchName)
+			childStrategies[branchName] = branch.DownstreamStrategy
+		}
+	}
+
+	// Build and persist the integrate merge state. Base branches have no prefix,
+	// so FullBranchName == BranchName == the base name.
+	state := &mergestate.MergeState{
+		Action:          "integrate",
+		BranchType:      name,
+		BranchName:      name,
+		CurrentStep:     stepMerge,
+		ParentBranch:    parent,
+		MergeStrategy:   resolved.MergeStrategy,
+		FullBranchName:  name,
+		ChildBranches:   childBranches,
+		UpdatedBranches: []string{},
+		ChildStrategies: childStrategies,
+		SquashMessage:   resolved.SquashMessage,
+		MergeMessage:    resolved.MergeMessage,
+		UpdateMessage:   resolved.UpdateMessage,
+		// Persist the tag decision so --continue recreates the same tag.
+		ShouldTag:      resolved.ShouldTag,
+		TagName:        resolved.TagName,
+		TagMessage:     resolved.TagMessage,
+		TagMessageFile: resolved.MessageFile,
+		ShouldSign:     resolved.ShouldSign,
+		SigningKey:     resolved.SigningKey,
+	}
+	if err := mergestate.SaveMergeState(state); err != nil {
+		return &errors.GitError{Operation: "save merge state", Err: err}
+	}
+
+	// Drive the shared state machine: merge -> create_tag -> update_children ->
+	// terminate. No delete step.
+	return executeSteps(cfg, state, branchConfig, resolved)
+}
+
+// addIntegrateFlags registers the integrate command's flags. It mirrors
+// addFinishFlags but drops all branch-retention flags (integrate never deletes),
+// and makes --tag a string that both enables tagging and sets the tag name.
+func addIntegrateFlags(cmd *cobra.Command) {
+	// Operation control
+	cmd.Flags().BoolP("continue", "c", false, "Continue the integrate operation after resolving conflicts")
+	cmd.Flags().BoolP("abort", "a", false, "Abort the integrate operation; a no-op success when none is in progress")
+
+	// Tag options (--tag is a string: it both enables tagging and sets the name)
+	cmd.Flags().String("tag", "", "Create a tag with the given name on the parent branch")
+	cmd.Flags().BoolP("notag", "n", false, "Do not create a tag (overrides a configured tag default)")
+	cmd.Flags().BoolP("sign", "s", false, "Sign the tag cryptographically")
+	cmd.Flags().Bool("no-sign", false, "Don't sign the tag cryptographically")
+	cmd.Flags().StringP("signingkey", "u", "", "Use the given GPG key for the digital signature")
+	cmd.Flags().StringP("message", "m", "", "Use the given message for the tag")
+	cmd.Flags().String("messagefile", "", "Use contents of the given file as tag message")
+
+	// Merge strategy
+	cmd.Flags().BoolP("rebase", "r", false, "Rebase the branch onto its parent before merging")
+	cmd.Flags().Bool("no-rebase", false, "Don't rebase (use the configured strategy)")
+	cmd.Flags().BoolP("preserve-merges", "p", false, "Preserve merges during rebase")
+	cmd.Flags().Bool("no-preserve-merges", false, "Flatten merges during rebase")
+	cmd.Flags().Bool("no-ff", false, "Create a merge commit even for a fast-forward")
+	cmd.Flags().Bool("ff", false, "Allow a fast-forward merge when possible")
+	cmd.Flags().BoolP("squash", "S", false, "Squash all commits into a single commit")
+	cmd.Flags().Bool("no-squash", false, "Keep individual commits (don't squash)")
+	cmd.Flags().String("squash-message", "", "Custom commit message for a squash merge")
+	cmd.Flags().StringP("merge-message", "M", "", "Custom commit message for the upstream merge")
+	cmd.Flags().String("update-message", "", "Custom commit message for child branch updates")
+
+	// Fetch (opt-in; default off)
+	cmd.Flags().Bool("fetch", false, "Fetch from remote before integrating")
+	cmd.Flags().Bool("no-fetch", false, "Don't fetch from remote before integrating")
+}

--- a/cmd/integrate.go
+++ b/cmd/integrate.go
@@ -22,6 +22,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/gittower/git-flow-next/internal/config"
 	"github.com/gittower/git-flow-next/internal/errors"
@@ -144,6 +145,13 @@ func executeIntegrate(name string, continueOp bool, abortOp bool, tagOptions *co
 		return &errors.NoUpstreamStrategyError{BranchName: name}
 	}
 
+	// The configured base branch must actually exist as a git branch. A
+	// branch that is configured but has been deleted must error here, before
+	// any fetch/state/checkout mutation, mirroring finish's BranchExists gate.
+	if err := git.BranchExists(name); err != nil {
+		return &errors.BranchNotFoundError{BranchName: name}
+	}
+
 	parent := branchConfig.Parent
 	if err := git.BranchExists(parent); err != nil {
 		return &errors.BranchNotFoundError{BranchName: parent}
@@ -159,17 +167,25 @@ func executeIntegrate(name string, continueOp bool, abortOp bool, tagOptions *co
 	}
 
 	// Optional fetch (opt-in). Fast-forward the local parent from the remote so
-	// the integration merges against up-to-date remote history; failures are
-	// non-fatal (the remote branch may not exist).
+	// the integration merges against up-to-date remote history. The parent:parent
+	// refspec updates the local parent ref, which git refuses when the parent is
+	// currently checked out. Fetch failures stay non-fatal (matching finish), but
+	// we must not claim "Fetch completed" when the parent fast-forward failed —
+	// that would silently integrate stale history.
 	if resolved.ShouldFetch && git.RemoteExists(cfg.Remote) {
 		fmt.Printf("Fetching from remote '%s'...\n", cfg.Remote)
+		parentFetched := true
 		if err := git.FetchBranch(cfg.Remote, fmt.Sprintf("%s:%s", parent, parent)); err != nil {
-			fmt.Printf("Note: Could not fetch parent branch '%s': %v\n", parent, err)
+			parentFetched = false
+			fmt.Printf("Warning: could not fetch parent branch '%s': %v\n", parent, err)
+			fmt.Printf("Warning: integrating against the local '%s', which may be behind the remote\n", parent)
 		}
 		if err := git.FetchBranch(cfg.Remote, name); err != nil {
-			fmt.Printf("Note: Could not fetch branch '%s': %v\n", name, err)
+			fmt.Printf("Note: could not fetch branch '%s': %v\n", name, err)
 		}
-		fmt.Printf("Fetch completed\n")
+		if parentFetched {
+			fmt.Printf("Fetch completed\n")
+		}
 	}
 
 	// Discover auto-update child base branches and capture their strategies.
@@ -182,6 +198,9 @@ func executeIntegrate(name string, continueOp bool, abortOp bool, tagOptions *co
 			childStrategies[branchName] = branch.DownstreamStrategy
 		}
 	}
+	// Ranging a map yields nondeterministic order; sort so children are updated
+	// in a stable, reproducible order (and so tests can assert per-child outcomes).
+	sort.Strings(childBranches)
 
 	// Build and persist the integrate merge state. Base branches have no prefix,
 	// so FullBranchName == BranchName == the base name.

--- a/cmd/shorthand.go
+++ b/cmd/shorthand.go
@@ -171,6 +171,63 @@ func RegisterShorthandCommands() {
 
 	addFinishFlags(finishCmd)
 	rootCmd.AddCommand(finishCmd)
+
+	// Integrate (top-level: merge a base branch into its parent)
+	integrateCmd := &cobra.Command{
+		Use:   "integrate [<branch>]",
+		Short: "Integrate a base branch into its parent",
+		Long: `Integrate merges a base branch upstream into its configured parent
+(e.g. develop into main), honoring the branch type's upstream merge strategy,
+optionally tagging the parent, and auto-updating the parent's children.
+
+Unlike finish, integrate operates on base branches only and never deletes,
+creates, or renames a branch — base branches are permanent. If no branch is
+given, the current branch is integrated into its parent.`,
+		Example: "  git flow integrate develop\n  git flow integrate develop --tag v2.0.0\n  git flow integrate --continue",
+		Args:    cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			name := ""
+			if len(args) > 0 {
+				name = args[0]
+			}
+
+			continueOp, _ := cmd.Flags().GetBool("continue")
+			abortOp, _ := cmd.Flags().GetBool("abort")
+
+			// --tag is a string: setting it both enables tagging and supplies
+			// the tag name; --notag disables tagging.
+			tagOptions := &config.TagOptions{
+				ShouldSign:  getBoolPtr(cmd, "sign", "no-sign"),
+				SigningKey:  cmd.Flag("signingkey").Value.String(),
+				Message:     cmd.Flag("message").Value.String(),
+				MessageFile: cmd.Flag("messagefile").Value.String(),
+			}
+			if cmd.Flags().Changed("tag") {
+				enable := true
+				tagOptions.ShouldTag = &enable
+				tagOptions.TagName = cmd.Flag("tag").Value.String()
+			} else if cmd.Flags().Changed("notag") {
+				disable := false
+				tagOptions.ShouldTag = &disable
+			}
+
+			mergeOptions := &config.MergeStrategyOptions{
+				Rebase:         getBoolPtr(cmd, "rebase", "no-rebase"),
+				PreserveMerges: getBoolPtr(cmd, "preserve-merges", "no-preserve-merges"),
+				NoFF:           getBoolPtr(cmd, "no-ff", "ff"),
+				Squash:         getBoolPtr(cmd, "squash", "no-squash"),
+				SquashMessage:  getStringPtrFromFlag(cmd, "squash-message"),
+				MergeMessage:   getStringPtrFromFlag(cmd, "merge-message"),
+				UpdateMessage:  getStringPtrFromFlag(cmd, "update-message"),
+			}
+
+			fetch := getBoolPtr(cmd, "fetch", "no-fetch")
+
+			IntegrateCommand(name, continueOp, abortOp, tagOptions, mergeOptions, fetch)
+		},
+	}
+	addIntegrateFlags(integrateCmd)
+	rootCmd.AddCommand(integrateCmd)
 }
 
 // executeShorthandUpdate handles the shared logic for both update and rebase shorthand commands

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This directory contains comprehensive manpage-style documentation for all git-fl
 - **git-flow.1.md** - Main git-flow command overview and global options
 - **git-flow-init.1.md** - Repository initialization and workflow setup
 - **git-flow-config.1.md** - Configuration management commands  
+- **git-flow-integrate.1.md** - Integrate a base branch into its parent
 - **git-flow-feature.1.md** - Feature branch management
 - **git-flow-release.1.md** - Release branch management
 - **git-flow-hotfix.1.md** - Hotfix branch management

--- a/docs/git-flow-integrate.1.md
+++ b/docs/git-flow-integrate.1.md
@@ -153,7 +153,7 @@ git flow integrate --abort
 : Invalid input (for example, tagging enabled without a resolvable name).
 
 **3**
-: A Git operation failed, a merge or rebase is already in progress, unresolved conflicts remain, or there is no in-progress operation to continue or abort.
+: A Git operation failed, a merge or rebase is already in progress, unresolved conflicts remain, or there is no in-progress operation to continue.
 
 **5**
 : A required branch (the parent, or the named branch) does not exist.

--- a/docs/git-flow-integrate.1.md
+++ b/docs/git-flow-integrate.1.md
@@ -1,0 +1,184 @@
+# GIT-FLOW-INTEGRATE(1)
+
+## NAME
+
+git-flow-integrate - Integrate a base branch into its parent
+
+## SYNOPSIS
+
+**git-flow integrate** [*branch*] [*options*]
+
+## DESCRIPTION
+
+Integrate merges a **base** branch upstream into its configured parent branch (for example, **develop** into **main**), honoring the branch type's upstream merge strategy, optionally creating a tag on the parent, and auto-updating the parent's `autoUpdate` children.
+
+Unlike **git-flow-finish**(1), which completes and then *deletes* a topic branch, integrate operates on permanent base branches: it **never deletes, creates, or renames** a branch. The integrated base branch remains after the operation.
+
+If *branch* is omitted, the current branch is integrated into its parent.
+
+The integrate operation follows the same conflict-resumable state machine as finish, minus the delete step:
+
+1. **Merge**: Merges the base branch into its parent using the configured upstream strategy.
+2. **Create Tag**: Optionally creates and signs a tag on the parent (off by default; see **--tag**).
+3. **Update Children**: Updates the parent's `autoUpdate=true` child branches using their downstream strategies.
+
+A persistent state file lets the operation resume after conflicts. If a conflict occurs during any merge (the upstream merge or a child update), the state is saved and the operation can be continued with **--continue** or aborted with **--abort**. The **--continue**/**--abort** flags act only on an in-progress integrate; an in-progress finish or update is never affected.
+
+## ARGUMENTS
+
+*branch*
+: Name of the base branch to integrate into its parent. Must be a configured base branch (`gitflow.branch.<name>.type = base`). If omitted, the current branch is used.
+
+## OPTIONS
+
+### Operation Control
+
+**--continue**, **-c**
+: Continue the integrate operation after resolving merge conflicts.
+
+**--abort**, **-a**
+: Abort the integrate operation and return to the original state. When no integrate operation is in progress, **--abort** is a no-op and exits successfully. A completed upstream merge and tag are preserved when aborting during a child update.
+
+### Tag Creation
+
+**--tag** *name*
+: Create an annotated tag *name* on the parent branch after the merge. Unlike finish, this is a single string flag that both enables tagging and supplies the tag name — base branches have no version from which to derive a default name.
+
+**--notag**, **-n**
+: Do not create a tag (overrides a configured tag default).
+
+**--sign**, **-s**
+: Sign the tag cryptographically with GPG.
+
+**--no-sign**
+: Don't sign the tag cryptographically.
+
+**--signingkey** *keyid*, **-u** *keyid*
+: Use the given GPG key for the signature.
+
+**--message** *msg*, **-m** *msg*
+: Use *msg* as the tag message.
+
+**--messagefile** *file*
+: Read the tag message from *file*. Takes precedence over **--message**.
+
+### Merge Strategy
+
+**--rebase**, **-r**
+: Rebase the base branch onto its parent before merging. **Caution:** this rewrites the base branch's history, which is disruptive for a shared, permanent branch — use only when the base branch is not shared.
+
+**--no-rebase**
+: Do not rebase (use the configured strategy).
+
+**--squash**, **-S**
+: Squash all commits into a single commit on the parent.
+
+**--no-squash**
+: Keep individual commits (don't squash).
+
+**--preserve-merges**, **-p**
+: Preserve merges during rebase.
+
+**--no-preserve-merges**
+: Flatten merges during rebase.
+
+**--no-ff**
+: Create a merge commit even when a fast-forward is possible.
+
+**--ff**
+: Allow a fast-forward merge when possible.
+
+**--merge-message** *msg*, **-M** *msg*
+: Custom commit message for the upstream merge.
+
+**--update-message** *msg*
+: Custom commit message for child branch updates.
+
+**--squash-message** *msg*
+: Custom commit message for a squash merge.
+
+### Remote Fetch
+
+**--fetch**
+: Fetch from the remote and fast-forward the local parent before integrating. Fetching is **off by default** (opt-in).
+
+**--no-fetch**
+: Do not fetch from the remote (overrides a configured fetch default).
+
+## CONFIGURATION
+
+Operational defaults are read from the `gitflow.<branch>.integrate.*` namespace, keyed by the base-branch name. See **gitflow-config**(5) for the full list. Note the integrate-specific Layer-1 defaults differ from finish:
+
+- **Tagging is off by default** (base branches have no version-derived tag name).
+- **Fetching is off by default** (opt-in).
+
+The upstream merge strategy resolves through the standard three layers: `gitflow.branch.<name>.upstreamStrategy` (Layer 1), `gitflow.<branch>.integrate.*` (Layer 2), and command-line flags (Layer 3, highest priority).
+
+## EXAMPLES
+
+Integrate develop into main:
+```bash
+git flow integrate develop
+```
+
+Integrate the current branch into its parent:
+```bash
+git flow integrate
+```
+
+Integrate and tag the parent:
+```bash
+git flow integrate develop --tag v2.0.0
+```
+
+Resume after resolving a conflict:
+```bash
+git flow integrate --continue
+```
+
+Abort an in-progress integrate:
+```bash
+git flow integrate --abort
+```
+
+## EXIT STATUS
+
+**0**
+: Success.
+
+**1**
+: git-flow is not initialized, or a merge/rebase is in progress and conflicts remain.
+
+**2**
+: Invalid input (for example, tagging enabled without a resolvable name).
+
+**3**
+: A Git operation failed.
+
+**5**
+: A required branch (the parent, or the named branch) does not exist.
+
+**6**
+: A validation error (not a base branch, no parent, self parent, or no upstream strategy).
+
+## NOTES
+
+- Integrate applies only to base branches. For topic branches (feature, release, hotfix, and custom types), use **git-flow-finish**(1).
+- The **--rebase** strategy rewrites the integrated branch's history. Avoid it on branches that are shared with other collaborators.
+- When aborting during a child update, the already-completed upstream merge and tag on the parent are preserved; only the in-progress child update is rolled back.
+
+## SEE ALSO
+
+**git-flow-finish**(1), **git-flow-update**(1), **git-flow-config**(1), **gitflow-config**(5), **git-flow**(1)
+
+## AUTHORS
+
+git-flow-next is maintained by the Tower team at GitTower GmbH.
+
+## BUGS
+
+Report bugs at https://github.com/gittower/git-flow-next/issues
+
+## COPYRIGHT
+
+This is free software; see the source for copying conditions.

--- a/docs/git-flow-integrate.1.md
+++ b/docs/git-flow-integrate.1.md
@@ -147,13 +147,13 @@ git flow integrate --abort
 : Success.
 
 **1**
-: git-flow is not initialized, or a merge/rebase is in progress and conflicts remain.
+: git-flow is not initialized.
 
 **2**
 : Invalid input (for example, tagging enabled without a resolvable name).
 
 **3**
-: A Git operation failed.
+: A Git operation failed, a merge or rebase is already in progress, unresolved conflicts remain, or there is no in-progress operation to continue or abort.
 
 **5**
 : A required branch (the parent, or the named branch) does not exist.

--- a/docs/git-flow.1.md
+++ b/docs/git-flow.1.md
@@ -91,9 +91,6 @@ Each topic branch type supports these subcommands:
 **publish**
 : Publish current topic branch to remote (planned feature).
 
-**integrate** [*branch*]
-: Integrate current or specified base branch into its parent. See **git-flow-integrate**(1).
-
 ## WORKFLOW PRESETS
 
 git-flow-next supports three workflow presets:

--- a/docs/git-flow.1.md
+++ b/docs/git-flow.1.md
@@ -35,6 +35,9 @@ This implementation maintains compatibility with existing git-flow repositories 
 **overview**
 : Display repository workflow overview. See **git-flow-overview**(1).
 
+**integrate** [*branch*]
+: Integrate a base branch into its parent (e.g. develop into main). See **git-flow-integrate**(1).
+
 **version**
 : Show version information. See **git-flow-version**(1).
 
@@ -87,6 +90,9 @@ Each topic branch type supports these subcommands:
 
 **publish**
 : Publish current topic branch to remote (planned feature).
+
+**integrate** [*branch*]
+: Integrate current or specified base branch into its parent. See **git-flow-integrate**(1).
 
 ## WORKFLOW PRESETS
 
@@ -144,7 +150,7 @@ git flow config add topic bugfix develop --prefix=bug/
 
 ## SEE ALSO
 
-**git-flow-init**(1), **git-flow-config**(1), **git-flow-start**(1), **git-flow-finish**(1), **git-flow-update**(1), **git-flow-delete**(1), **git-flow-track**(1), **gitflow-config**(5), **git**(1)
+**git-flow-init**(1), **git-flow-config**(1), **git-flow-start**(1), **git-flow-finish**(1), **git-flow-integrate**(1), **git-flow-update**(1), **git-flow-delete**(1), **git-flow-track**(1), **gitflow-config**(5), **git**(1)
 
 ## AUTHORS
 

--- a/docs/gitflow-config.5.md
+++ b/docs/gitflow-config.5.md
@@ -544,6 +544,88 @@ These options are useful for teams using commit message validation hooks (e.g., 
     preserve-merges = false
 ```
 
+## INTEGRATE COMMAND CONFIGURATION
+
+The **git-flow-integrate**(1) command reads its operational defaults from the
+`gitflow.<branch>.integrate.*` namespace, keyed by the **base-branch name**
+(the same identifier used as the `gitflow.branch.<name>.*` subsection). Integrate
+applies only to base branches.
+
+The available keys mirror the finish command's merge-strategy, tag, message, and
+fetch options, but the Layer-1 defaults differ.
+
+### Layer-1 Defaults
+
+Unlike finish, integrate defaults tagging and fetching **off**:
+
+- **Tagging is off by default.** Base branches have no version from which to
+  derive a tag name, so tagging must be enabled explicitly (via `--tag <name>`
+  or `integrate.tag` + `integrate.tagname`). Enabling tagging without a
+  resolvable name is an error.
+- **Fetching is off by default** (opt-in), unlike finish where fetch defaults on.
+
+### Tag Options
+
+**gitflow.*branch*.integrate.tag**
+: Enable tag creation on integrate (boolean; default false).
+
+**gitflow.*branch*.integrate.tagname**
+: Tag name to create. Required when tagging is enabled and no `--tag` is given.
+
+**gitflow.*branch*.integrate.sign**
+: Sign the tag cryptographically (boolean).
+
+**gitflow.*branch*.integrate.signingkey**
+: GPG key id to use for the signature.
+
+**gitflow.*branch*.integrate.messagefile**
+: Read the tag message from the given file.
+
+### Merge Strategy Options
+
+**gitflow.*branch*.integrate.squash**, **gitflow.*branch*.integrate.no-squash**
+: Force (or disable) a squash merge.
+
+**gitflow.*branch*.integrate.rebase**, **gitflow.*branch*.integrate.no-rebase**
+: Force (or disable) rebasing the base branch before merging.
+
+**gitflow.*branch*.integrate.preserve-merges**, **gitflow.*branch*.integrate.no-preserve-merges**
+: Preserve or flatten merges during rebase.
+
+**gitflow.*branch*.integrate.no-ff**, **gitflow.*branch*.integrate.ff**
+: Force a merge commit for a fast-forward, or allow fast-forward.
+
+### Message and Fetch Options
+
+**gitflow.*branch*.integrate.mergemessage**
+: Custom commit message for the upstream merge.
+
+**gitflow.*branch*.integrate.updatemessage**
+: Custom commit message for child branch updates.
+
+**gitflow.*branch*.integrate.fetch**
+: Fetch from the remote before integrating (boolean; default false).
+
+### Strategy Precedence
+
+1. **Command-line flags** (Layer 3 — highest priority)
+2. **gitflow.*branch*.integrate.*** configuration (Layer 2)
+3. **gitflow.branch.*branch*.upstreamstrategy** (Layer 1)
+
+### Examples
+
+```ini
+# Tag main whenever develop is integrated
+[gitflow "develop.integrate"]
+    tag = true
+    tagname = latest
+
+# Rebase a private staging branch onto main and fetch first
+[gitflow "staging.integrate"]
+    rebase = true
+    fetch = true
+```
+
 ## MERGE STRATEGY REFERENCE
 
 ### none

--- a/docs/gitflow-config.5.md
+++ b/docs/gitflow-config.5.md
@@ -610,7 +610,7 @@ Unlike finish, integrate defaults tagging and fetching **off**:
 
 1. **Command-line flags** (Layer 3 — highest priority)
 2. **gitflow.*branch*.integrate.*** configuration (Layer 2)
-3. **gitflow.branch.*branch*.upstreamstrategy** (Layer 1)
+3. **gitflow.branch.*branch*.upstreamStrategy** (Layer 1)
 
 ### Examples
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@ Comprehensive manpage-style documentation for git-flow-next commands and configu
 | **git-flow init** | Initialize git-flow | [git-flow-init(1)](git-flow-init.1.md) |
 | **git-flow config** | Manage configuration | [git-flow-config(1)](git-flow-config.1.md) |
 | **git-flow overview** | Repository status | [git-flow-overview(1)](git-flow-overview.1.md) |
+| **git-flow integrate** | Integrate a base branch into its parent | [git-flow-integrate(1)](git-flow-integrate.1.md) |
 
 ## Topic Branch Commands
 

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -85,7 +85,7 @@ func ResolveFinishOptions(cfg *Config, branchType string, branchName string, tag
 	fullBranchName := branchConfig.Prefix + branchName
 
 	// Resolve merge strategy components
-	strategy, useRebase, preserveMerges, noFastForward, useSquash := resolveMergeStrategy(cfg, branchConfig, branchType, mergeOpts)
+	strategy, useRebase, preserveMerges, noFastForward, useSquash := resolveMergeStrategy(cfg, branchConfig, branchType, "finish", mergeOpts)
 
 	// Resolve push options. Order matters: pushTag's default derives from the
 	// resolved pushBranches value, so resolve branches first.
@@ -323,8 +323,10 @@ func getCommandConfigString(cfg *Config, configKey string) string {
 	return value
 }
 
-// resolveMergeStrategy resolves merge strategy using three-layer precedence
-func resolveMergeStrategy(cfg *Config, branchConfig BranchConfig, branchType string, mergeOpts *MergeStrategyOptions) (string, bool, bool, bool, bool) {
+// resolveMergeStrategy resolves merge strategy using three-layer precedence.
+// The command segment (e.g. "finish" or "integrate") selects the Layer-2
+// gitflow.<branchType>.<command>.* config namespace.
+func resolveMergeStrategy(cfg *Config, branchConfig BranchConfig, branchType string, command string, mergeOpts *MergeStrategyOptions) (string, bool, bool, bool, bool) {
 	// Layer 1: Get base strategy from branch configuration
 	baseStrategy := branchConfig.UpstreamStrategy
 	if baseStrategy == "" {
@@ -332,10 +334,10 @@ func resolveMergeStrategy(cfg *Config, branchConfig BranchConfig, branchType str
 	}
 
 	// Layer 2: Check for command-specific overrides
-	rebase := resolveFinishRebase(cfg, branchType, baseStrategy, mergeOpts)
-	squash := resolveFinishSquash(cfg, branchType, baseStrategy, mergeOpts)
-	preserveMerges := resolveFinishPreserveMerges(cfg, branchType, mergeOpts)
-	noFF := resolveFinishNoFF(cfg, branchType, mergeOpts)
+	rebase := resolveFinishRebase(cfg, branchType, command, baseStrategy, mergeOpts)
+	squash := resolveFinishSquash(cfg, branchType, command, baseStrategy, mergeOpts)
+	preserveMerges := resolveFinishPreserveMerges(cfg, branchType, command, mergeOpts)
+	noFF := resolveFinishNoFF(cfg, branchType, command, mergeOpts)
 
 	// Determine final strategy based on precedence: squash > rebase > base strategy
 	var finalStrategy string
@@ -351,16 +353,16 @@ func resolveMergeStrategy(cfg *Config, branchConfig BranchConfig, branchType str
 }
 
 // resolveFinishRebase resolves whether to use rebase strategy
-func resolveFinishRebase(cfg *Config, branchType string, baseStrategy string, mergeOpts *MergeStrategyOptions) bool {
+func resolveFinishRebase(cfg *Config, branchType string, command string, baseStrategy string, mergeOpts *MergeStrategyOptions) bool {
 	// Layer 1: Base strategy determines default
 	useRebase := baseStrategy == "rebase"
 
 	// Layer 2: Command-specific config
-	if rebaseConfig := getCommandConfigBool(cfg, fmt.Sprintf("gitflow.%s.finish.rebase", branchType)); rebaseConfig {
+	if rebaseConfig := getCommandConfigBool(cfg, fmt.Sprintf("gitflow.%s.%s.rebase", branchType, command)); rebaseConfig {
 		useRebase = true
 	}
 	// Check for explicit no-rebase config
-	if noRebaseConfig := getCommandConfigBool(cfg, fmt.Sprintf("gitflow.%s.finish.no-rebase", branchType)); noRebaseConfig {
+	if noRebaseConfig := getCommandConfigBool(cfg, fmt.Sprintf("gitflow.%s.%s.no-rebase", branchType, command)); noRebaseConfig {
 		useRebase = false
 	}
 
@@ -379,16 +381,16 @@ func resolveFinishRebase(cfg *Config, branchType string, baseStrategy string, me
 }
 
 // resolveFinishSquash resolves whether to use squash strategy
-func resolveFinishSquash(cfg *Config, branchType string, baseStrategy string, mergeOpts *MergeStrategyOptions) bool {
+func resolveFinishSquash(cfg *Config, branchType string, command string, baseStrategy string, mergeOpts *MergeStrategyOptions) bool {
 	// Layer 1: Base strategy determines default
 	useSquash := baseStrategy == "squash"
 
 	// Layer 2: Command-specific config
-	if squashConfig := getCommandConfigBool(cfg, fmt.Sprintf("gitflow.%s.finish.squash", branchType)); squashConfig {
+	if squashConfig := getCommandConfigBool(cfg, fmt.Sprintf("gitflow.%s.%s.squash", branchType, command)); squashConfig {
 		useSquash = true
 	}
 	// Check for explicit no-squash config
-	if noSquashConfig := getCommandConfigBool(cfg, fmt.Sprintf("gitflow.%s.finish.no-squash", branchType)); noSquashConfig {
+	if noSquashConfig := getCommandConfigBool(cfg, fmt.Sprintf("gitflow.%s.%s.no-squash", branchType, command)); noSquashConfig {
 		useSquash = false
 	}
 
@@ -407,16 +409,16 @@ func resolveFinishSquash(cfg *Config, branchType string, baseStrategy string, me
 }
 
 // resolveFinishPreserveMerges resolves whether to preserve merges during rebase
-func resolveFinishPreserveMerges(cfg *Config, branchType string, mergeOpts *MergeStrategyOptions) bool {
+func resolveFinishPreserveMerges(cfg *Config, branchType string, command string, mergeOpts *MergeStrategyOptions) bool {
 	// Layer 1: Default is not to preserve merges (flatten)
 	preserveMerges := false
 
 	// Layer 2: Command-specific config
-	if preserveConfig := getCommandConfigBool(cfg, fmt.Sprintf("gitflow.%s.finish.preserve-merges", branchType)); preserveConfig {
+	if preserveConfig := getCommandConfigBool(cfg, fmt.Sprintf("gitflow.%s.%s.preserve-merges", branchType, command)); preserveConfig {
 		preserveMerges = true
 	}
 	// Check for explicit no-preserve-merges config
-	if noPreserveConfig := getCommandConfigBool(cfg, fmt.Sprintf("gitflow.%s.finish.no-preserve-merges", branchType)); noPreserveConfig {
+	if noPreserveConfig := getCommandConfigBool(cfg, fmt.Sprintf("gitflow.%s.%s.no-preserve-merges", branchType, command)); noPreserveConfig {
 		preserveMerges = false
 	}
 
@@ -429,16 +431,16 @@ func resolveFinishPreserveMerges(cfg *Config, branchType string, mergeOpts *Merg
 }
 
 // resolveFinishNoFF resolves whether to create merge commit for fast-forward
-func resolveFinishNoFF(cfg *Config, branchType string, mergeOpts *MergeStrategyOptions) bool {
+func resolveFinishNoFF(cfg *Config, branchType string, command string, mergeOpts *MergeStrategyOptions) bool {
 	// Layer 1: Default is to allow fast-forward (no --no-ff)
 	noFF := false
 
 	// Layer 2: Command-specific config
-	if noFFConfig := getCommandConfigBool(cfg, fmt.Sprintf("gitflow.%s.finish.no-ff", branchType)); noFFConfig {
+	if noFFConfig := getCommandConfigBool(cfg, fmt.Sprintf("gitflow.%s.%s.no-ff", branchType, command)); noFFConfig {
 		noFF = true
 	}
 	// Check for explicit fast-forward config
-	if ffConfig := getCommandConfigBool(cfg, fmt.Sprintf("gitflow.%s.finish.ff", branchType)); ffConfig {
+	if ffConfig := getCommandConfigBool(cfg, fmt.Sprintf("gitflow.%s.%s.ff", branchType, command)); ffConfig {
 		noFF = false
 	}
 
@@ -557,6 +559,167 @@ func resolveSquashMessage(fullBranchName string, mergeOpts *MergeStrategyOptions
 
 	// Default message
 	return fmt.Sprintf("Squashed commit of branch '%s'", fullBranchName)
+}
+
+// ResolveIntegrateOptions resolves all integrate command options using the same
+// three-layer precedence as finish, keyed on the base-branch name and the
+// gitflow.<branch>.integrate.* Layer-2 namespace. It differs from
+// ResolveFinishOptions in its defaults: tagging is OFF by default (base branches
+// have no version-derived tag name) and fetching is OFF by default (opt-in).
+// Retention options are irrelevant to integrate and left unset.
+func ResolveIntegrateOptions(cfg *Config, branchName string, tagOpts *TagOptions, mergeOpts *MergeStrategyOptions, fetch *bool) *ResolvedFinishOptions {
+	branchConfig := cfg.Branches[branchName]
+
+	// Base branches have no prefix, so the full name is just the branch name.
+	fullBranchName := branchName
+
+	strategy, useRebase, preserveMerges, noFastForward, useSquash := resolveMergeStrategy(cfg, branchConfig, branchName, "integrate", mergeOpts)
+
+	tagName := resolveIntegrateTagName(cfg, branchName, tagOpts)
+
+	return &ResolvedFinishOptions{
+		// Tag resolution
+		ShouldTag:   resolveIntegrateShouldTag(cfg, branchName, tagOpts),
+		TagName:     tagName,
+		ShouldSign:  resolveIntegrateShouldSign(cfg, branchName, tagOpts),
+		SigningKey:  resolveIntegrateSigningKey(cfg, branchName, tagOpts),
+		TagMessage:  resolveIntegrateTagMessage(tagName, tagOpts),
+		MessageFile: resolveIntegrateMessageFile(cfg, branchName, tagOpts),
+
+		// Merge strategy resolution
+		MergeStrategy:  strategy,
+		UseRebase:      useRebase,
+		PreserveMerges: preserveMerges,
+		NoFastForward:  noFastForward,
+		UseSquash:      useSquash,
+		SquashMessage:  resolveSquashMessage(fullBranchName, mergeOpts),
+
+		// Fetch resolution (Layer-1 default OFF)
+		ShouldFetch: resolveIntegrateShouldFetch(cfg, branchName, fetch),
+
+		// Merge commit message resolution
+		MergeMessage:  resolveIntegrateMergeMessage(cfg, branchName, mergeOpts),
+		UpdateMessage: resolveIntegrateUpdateMessage(cfg, branchName, mergeOpts),
+	}
+}
+
+// resolveIntegrateShouldTag resolves whether integrate should create a tag.
+// Layer 1 default is OFF (base branches do not tag by branch-type identity).
+func resolveIntegrateShouldTag(cfg *Config, branchName string, tagOpts *TagOptions) bool {
+	// Layer 1: default off
+	shouldTag := false
+
+	// Layer 2: command-specific config
+	if value, exists := cfg.CommandConfig[fmt.Sprintf("gitflow.%s.integrate.tag", branchName)]; exists {
+		shouldTag = value == "true"
+	}
+
+	// Layer 3: command-line flags override config
+	if tagOpts != nil && tagOpts.ShouldTag != nil {
+		shouldTag = *tagOpts.ShouldTag
+	}
+
+	return shouldTag
+}
+
+// resolveIntegrateTagName resolves the tag name. There is no Layer-1 default for
+// base branches; an unresolved name (empty string) signals the driver to error
+// when tagging is enabled.
+func resolveIntegrateTagName(cfg *Config, branchName string, tagOpts *TagOptions) string {
+	// Layer 1: no default name for base branches
+	tagName := ""
+
+	// Layer 2: command-specific configured name
+	if name := getCommandConfigString(cfg, fmt.Sprintf("gitflow.%s.integrate.tagname", branchName)); name != "" {
+		tagName = name
+	}
+
+	// Layer 3: command-line --tag <name> overrides config
+	if tagOpts != nil && tagOpts.TagName != "" {
+		tagName = tagOpts.TagName
+	}
+
+	return tagName
+}
+
+// resolveIntegrateShouldSign resolves whether to sign the tag.
+func resolveIntegrateShouldSign(cfg *Config, branchName string, tagOpts *TagOptions) bool {
+	shouldSign := false
+	if sign := getCommandConfigBool(cfg, fmt.Sprintf("gitflow.%s.integrate.sign", branchName)); sign {
+		shouldSign = true
+	}
+	if tagOpts != nil && tagOpts.ShouldSign != nil {
+		shouldSign = *tagOpts.ShouldSign
+	}
+	return shouldSign
+}
+
+// resolveIntegrateSigningKey resolves the signing key.
+func resolveIntegrateSigningKey(cfg *Config, branchName string, tagOpts *TagOptions) string {
+	signingKey := ""
+	if key := getCommandConfigString(cfg, fmt.Sprintf("gitflow.%s.integrate.signingkey", branchName)); key != "" {
+		signingKey = key
+	}
+	if tagOpts != nil && tagOpts.SigningKey != "" {
+		signingKey = tagOpts.SigningKey
+	}
+	return signingKey
+}
+
+// resolveIntegrateTagMessage resolves the tag message.
+func resolveIntegrateTagMessage(tagName string, tagOpts *TagOptions) string {
+	message := fmt.Sprintf("Integrate %s", tagName)
+	if tagOpts != nil && tagOpts.Message != "" {
+		message = tagOpts.Message
+	}
+	return message
+}
+
+// resolveIntegrateMessageFile resolves the tag message file path.
+func resolveIntegrateMessageFile(cfg *Config, branchName string, tagOpts *TagOptions) string {
+	messageFile := ""
+	if file := getCommandConfigString(cfg, fmt.Sprintf("gitflow.%s.integrate.messagefile", branchName)); file != "" {
+		messageFile = file
+	}
+	if tagOpts != nil && tagOpts.MessageFile != "" {
+		messageFile = tagOpts.MessageFile
+	}
+	return messageFile
+}
+
+// resolveIntegrateShouldFetch resolves whether to fetch before integrating.
+// Layer-1 default is OFF (opt-in), unlike finish.
+func resolveIntegrateShouldFetch(cfg *Config, branchName string, fetch *bool) bool {
+	shouldFetch := false
+	if value, exists := cfg.CommandConfig[fmt.Sprintf("gitflow.%s.integrate.fetch", branchName)]; exists {
+		shouldFetch = value == "true"
+	}
+	if fetch != nil {
+		shouldFetch = *fetch
+	}
+	return shouldFetch
+}
+
+// resolveIntegrateMergeMessage resolves the upstream merge commit message.
+func resolveIntegrateMergeMessage(cfg *Config, branchName string, mergeOpts *MergeStrategyOptions) string {
+	if mergeOpts != nil && mergeOpts.MergeMessage != nil && *mergeOpts.MergeMessage != "" {
+		return *mergeOpts.MergeMessage
+	}
+	if msg := getCommandConfigString(cfg, fmt.Sprintf("gitflow.%s.integrate.mergemessage", branchName)); msg != "" {
+		return msg
+	}
+	return ""
+}
+
+// resolveIntegrateUpdateMessage resolves the child-update commit message.
+func resolveIntegrateUpdateMessage(cfg *Config, branchName string, mergeOpts *MergeStrategyOptions) string {
+	if mergeOpts != nil && mergeOpts.UpdateMessage != nil && *mergeOpts.UpdateMessage != "" {
+		return *mergeOpts.UpdateMessage
+	}
+	if msg := getCommandConfigString(cfg, fmt.Sprintf("gitflow.%s.integrate.updatemessage", branchName)); msg != "" {
+		return msg
+	}
+	return ""
 }
 
 // resolveMergeMessage resolves the merge commit message.

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -354,6 +354,73 @@ func (e *RemoteNotConfiguredError) ExitCode() ExitCode {
 	return ExitCodeGitError
 }
 
+// NotBaseBranchError indicates that integrate was invoked on a branch that is
+// not a base branch (integrate only applies to base branches).
+type NotBaseBranchError struct {
+	BranchName string
+}
+
+func (e *NotBaseBranchError) Error() string {
+	return fmt.Sprintf("branch '%s' is not a base branch; 'git flow integrate' applies only to base branches (use 'git flow finish' for topic branches)", e.BranchName)
+}
+
+func (e *NotBaseBranchError) ExitCode() ExitCode {
+	return ExitCodeValidationError
+}
+
+// NoParentBranchError indicates a base branch has no configured parent to
+// integrate into.
+type NoParentBranchError struct {
+	BranchName string
+}
+
+func (e *NoParentBranchError) Error() string {
+	return fmt.Sprintf("branch '%s' has no configured parent branch to integrate into", e.BranchName)
+}
+
+func (e *NoParentBranchError) ExitCode() ExitCode {
+	return ExitCodeValidationError
+}
+
+// SelfParentError indicates a base branch is configured as its own parent.
+type SelfParentError struct {
+	BranchName string
+}
+
+func (e *SelfParentError) Error() string {
+	return fmt.Sprintf("cannot integrate branch '%s' into itself", e.BranchName)
+}
+
+func (e *SelfParentError) ExitCode() ExitCode {
+	return ExitCodeValidationError
+}
+
+// NoUpstreamStrategyError indicates a base branch has no upstream merge strategy
+// configured, so there is nothing to integrate.
+type NoUpstreamStrategyError struct {
+	BranchName string
+}
+
+func (e *NoUpstreamStrategyError) Error() string {
+	return fmt.Sprintf("branch '%s' has no upstream merge strategy configured to integrate with", e.BranchName)
+}
+
+func (e *NoUpstreamStrategyError) ExitCode() ExitCode {
+	return ExitCodeValidationError
+}
+
+// TagEnabledNoNameError indicates tagging was enabled but no tag name could be
+// resolved (base branches have no version-derived default name).
+type TagEnabledNoNameError struct{}
+
+func (e *TagEnabledNoNameError) Error() string {
+	return "tagging is enabled but no tag name was provided; supply a name with --tag <name> or configure integrate.tagname"
+}
+
+func (e *TagEnabledNoNameError) ExitCode() ExitCode {
+	return ExitCodeInvalidInput
+}
+
 // AlreadyInitializedError indicates git-flow is already configured
 type AlreadyInitializedError struct{}
 

--- a/internal/mergestate/mergestate.go
+++ b/internal/mergestate/mergestate.go
@@ -56,6 +56,16 @@ type MergeState struct {
 	MergeMessage  string `json:"mergeMessage,omitempty"`  // Custom commit message for upstream merge
 	UpdateMessage string `json:"updateMessage,omitempty"` // Custom commit message for child updates
 
+	// Persisted tag decision. The integrate command resolves tagging from CLI
+	// flags and config that are not repeated on --continue, so the decision is
+	// saved here to recreate the same tag when resuming.
+	ShouldTag      bool   `json:"shouldTag,omitempty"`
+	TagName        string `json:"tagName,omitempty"`
+	TagMessage     string `json:"tagMessage,omitempty"`
+	TagMessageFile string `json:"tagMessageFile,omitempty"`
+	ShouldSign     bool   `json:"shouldSign,omitempty"`
+	SigningKey     string `json:"signingKey,omitempty"`
+
 	// Hook options
 	NoVerify bool `json:"noVerify,omitempty"` // Skip pre-commit and commit-msg hooks
 }

--- a/test/cmd/integrate_autoupdate_test.go
+++ b/test/cmd/integrate_autoupdate_test.go
@@ -1,0 +1,135 @@
+package cmd_test
+
+import (
+	"testing"
+
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// TestIntegrateDivergedParentCreatesMergeAndUpdatesChild verifies a diverged
+// parent yields a merge commit and the auto-update child receives the changes.
+//
+// Steps:
+//  1. init --defaults; add X to main and C to develop (diverged).
+//  2. Run: git flow integrate develop.
+//  3. Assert main has a merge commit containing both C and X, develop is
+//     auto-updated to contain X, and HEAD is on main.
+func TestIntegrateDivergedParentCreatesMergeAndUpdatesChild(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	xCommit := integAddCommit(t, dir, "main", "x.txt", "X", "Add X on main")
+	cCommit := integAddCommit(t, dir, "develop", "c.txt", "C", "Add C on develop")
+	preMerges := integMergeCount(t, dir, "main")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop")
+	if err != nil {
+		t.Fatalf("integrate develop failed: %v\nOutput: %s", err, out)
+	}
+
+	if !integIsAncestor(t, dir, cCommit, "main") {
+		t.Errorf("Expected C (%s) to be reachable on main", cCommit)
+	}
+	if !integIsAncestor(t, dir, xCommit, "main") {
+		t.Errorf("Expected X (%s) to be reachable on main", xCommit)
+	}
+	if got := integMergeCount(t, dir, "main"); got != preMerges+1 {
+		t.Errorf("Expected exactly one new merge commit on main, count went %d -> %d", preMerges, got)
+	}
+	if !integIsAncestor(t, dir, xCommit, "develop") {
+		t.Errorf("Expected develop to be auto-updated to contain X (%s)", xCommit)
+	}
+	if got := testutil.GetCurrentBranch(t, dir); got != "main" {
+		t.Errorf("Expected HEAD on main, got %s", got)
+	}
+}
+
+// TestIntegrateMultipleChildrenMixedStrategies verifies distinct child update
+// strategies and auto-update filtering across several base branches.
+//
+// Steps:
+//  1. init --defaults; add base branch staging (autoUpdate, rebase) with its own
+//     commit S, and base branch legacy (autoUpdate=false). develop keeps merge.
+//  2. Give develop commit C not on main; capture staging/legacy/develop tips.
+//  3. Run: git flow integrate develop.
+//  4. Assert main gains C; staging is rebased (S replayed, hash changed, no merge
+//     commit); develop merge is a no-op; legacy is untouched; nothing deleted.
+func TestIntegrateMultipleChildrenMixedStrategies(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	// staging: base child of main, auto-update via rebase, with its own commit S.
+	if _, err := testutil.RunGit(t, dir, "checkout", "-b", "staging", "main"); err != nil {
+		t.Fatalf("Failed to create staging: %v", err)
+	}
+	testutil.RunGit(t, dir, "config", "gitflow.branch.staging.type", "base")
+	testutil.RunGit(t, dir, "config", "gitflow.branch.staging.parent", "main")
+	testutil.RunGit(t, dir, "config", "gitflow.branch.staging.autoUpdate", "true")
+	testutil.RunGit(t, dir, "config", "gitflow.branch.staging.downstreamStrategy", "rebase")
+	originalStaging := integAddCommit(t, dir, "staging", "staging.txt", "S", "Add S on staging")
+
+	// legacy: base child of main with auto-update disabled.
+	if _, err := testutil.RunGit(t, dir, "checkout", "-b", "legacy", "main"); err != nil {
+		t.Fatalf("Failed to create legacy: %v", err)
+	}
+	testutil.RunGit(t, dir, "config", "gitflow.branch.legacy.type", "base")
+	testutil.RunGit(t, dir, "config", "gitflow.branch.legacy.parent", "main")
+	testutil.RunGit(t, dir, "config", "gitflow.branch.legacy.autoUpdate", "false")
+	originalLegacy := integRevParse(t, dir, "legacy")
+
+	// develop keeps its merge downstream strategy and auto-update.
+	testutil.RunGit(t, dir, "config", "gitflow.branch.develop.autoUpdate", "true")
+	testutil.RunGit(t, dir, "config", "gitflow.branch.develop.downstreamStrategy", "merge")
+	cCommit := integAddCommit(t, dir, "develop", "develop.txt", "C", "Add C on develop")
+	originalDevelop := integRevParse(t, dir, "develop")
+
+	preStagingMerges := integMergeCount(t, dir, "staging")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop")
+	if err != nil {
+		t.Fatalf("integrate develop failed: %v\nOutput: %s", err, out)
+	}
+
+	// main advanced to include C.
+	if !integIsAncestor(t, dir, cCommit, "main") {
+		t.Errorf("Expected C (%s) reachable on main", cCommit)
+	}
+
+	// staging rebased: main's tip is now an ancestor of staging, S was rewritten,
+	// and no merge commit was introduced.
+	mainTip := integRevParse(t, dir, "main")
+	if !integIsAncestor(t, dir, mainTip, "staging") {
+		t.Error("Expected staging to be rebased onto main's new tip")
+	}
+	if integRevParse(t, dir, "staging") == originalStaging {
+		t.Error("Expected staging's S commit to be rewritten by rebase")
+	}
+	if got := integMergeCount(t, dir, "staging"); got != preStagingMerges {
+		t.Errorf("Expected no merge commit on staging (rebase), count went %d -> %d", preStagingMerges, got)
+	}
+
+	// develop merge is a no-op (already == main after fast-forward).
+	if got := integRevParse(t, dir, "develop"); got != originalDevelop {
+		t.Errorf("Expected develop unchanged (no-op merge), was %s got %s", originalDevelop, got)
+	}
+
+	// legacy is not moved.
+	if got := integRevParse(t, dir, "legacy"); got != originalLegacy {
+		t.Errorf("Expected legacy untouched (%s), got %s", originalLegacy, got)
+	}
+
+	// Nothing deleted.
+	for _, b := range []string{"main", "develop", "staging", "legacy"} {
+		if !testutil.BranchExists(t, dir, b) {
+			t.Errorf("Expected branch %s to still exist", b)
+		}
+	}
+}

--- a/test/cmd/integrate_conflicts_test.go
+++ b/test/cmd/integrate_conflicts_test.go
@@ -1,0 +1,589 @@
+package cmd_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// integSetupConflict creates a diverged modify/modify conflict on the given file
+// between main and develop. It seeds a shared base version of the file, then
+// edits it differently on each branch. Returns (xCommit on main, cCommit on
+// develop) and leaves HEAD on develop.
+func integSetupConflict(t *testing.T, dir, file string) (xCommit, cCommit string) {
+	t.Helper()
+	integAddCommit(t, dir, "main", file, "base\n", "Add "+file+" base on main")
+	if _, err := testutil.RunGit(t, dir, "checkout", "develop"); err != nil {
+		t.Fatalf("Failed to checkout develop: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "merge", "main"); err != nil {
+		t.Fatalf("Failed to fast-forward develop from main: %v", err)
+	}
+	xCommit = integAddCommit(t, dir, "main", file, "main version\n", "Edit "+file+" on main")
+	cCommit = integAddCommit(t, dir, "develop", file, "develop version\n", "Edit "+file+" on develop")
+	return xCommit, cCommit
+}
+
+// TestIntegrateMergeConflictThenContinue verifies a merge conflict is resumable.
+//
+// Steps:
+//  1. init --defaults; create a diverged conflict on conflict.txt.
+//  2. Run: git flow integrate develop --tag v2.0.0 (conflicts).
+//  3. Assert Git is in a real merge-conflict state and integrate state is saved.
+//  4. Resolve + stage, then git flow integrate --continue.
+//  5. Assert the merge completes, tag is created, children updated, state cleared.
+func TestIntegrateMergeConflictThenContinue(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+	integSetupConflict(t, dir, "conflict.txt")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop", "--tag", "v2.0.0")
+	if err == nil {
+		t.Fatalf("Expected merge conflict, got success.\nOutput: %s", out)
+	}
+	if !strings.Contains(out, "conflict") {
+		t.Errorf("Expected conflict message, got: %s", out)
+	}
+	if !integMergeHeadExists(t, dir) {
+		t.Error("Expected .git/MERGE_HEAD to exist during merge conflict")
+	}
+	if status, _ := testutil.RunGit(t, dir, "status", "--porcelain"); !strings.Contains(status, "UU") {
+		t.Errorf("Expected a UU conflict entry, got: %s", status)
+	}
+	state, err := testutil.LoadMergeState(t, dir)
+	if err != nil || state == nil {
+		t.Fatalf("Expected saved merge state, err=%v", err)
+	}
+	if state.Action != "integrate" {
+		t.Errorf("Expected Action integrate, got %s", state.Action)
+	}
+	if state.CurrentStep != "merge" {
+		t.Errorf("Expected CurrentStep merge, got %s", state.CurrentStep)
+	}
+	if state.MergeStrategy != "merge" {
+		t.Errorf("Expected MergeStrategy merge, got %s", state.MergeStrategy)
+	}
+
+	testutil.WriteFile(t, dir, "conflict.txt", "resolved\n")
+	testutil.RunGit(t, dir, "add", "conflict.txt")
+
+	out, err = testutil.RunGitFlow(t, dir, "integrate", "--continue")
+	if err != nil {
+		t.Fatalf("integrate --continue failed: %v\nOutput: %s", err, out)
+	}
+	if integMergeHeadExists(t, dir) {
+		t.Error("Expected .git/MERGE_HEAD to be gone after continue")
+	}
+	if !integTagExists(t, dir, "v2.0.0") || !integTagIsAnnotated(t, dir, "v2.0.0") {
+		t.Error("Expected annotated tag v2.0.0 after continue")
+	}
+	if integRevParse(t, dir, "v2.0.0^{commit}") != integRevParse(t, dir, "main") {
+		t.Error("Expected v2.0.0 on main's tip")
+	}
+	if !integIsAncestor(t, dir, integRevParse(t, dir, "main"), "develop") {
+		t.Error("Expected develop to be auto-updated from main")
+	}
+	if integStateExists(t, dir) {
+		t.Error("Expected merge state to be cleared after continue")
+	}
+	if got := testutil.GetCurrentBranch(t, dir); got != "main" {
+		t.Errorf("Expected HEAD on main, got %s", got)
+	}
+}
+
+// TestIntegrateMergeConflictThenAbort verifies a merge conflict fully rolls back
+// on abort.
+//
+// Steps:
+//  1. init --defaults; create a diverged conflict; capture pre-integrate tips.
+//  2. Run: git flow integrate develop --tag v2.0.0 (conflicts).
+//  3. Run: git flow integrate --abort.
+//  4. Assert MERGE_HEAD gone, main/develop restored, no tag, state cleared,
+//     HEAD on develop, working tree clean.
+func TestIntegrateMergeConflictThenAbort(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+	integSetupConflict(t, dir, "conflict.txt")
+	preMain := integRevParse(t, dir, "main")
+	preDevelop := integRevParse(t, dir, "develop")
+
+	if out, err := testutil.RunGitFlow(t, dir, "integrate", "develop", "--tag", "v2.0.0"); err == nil {
+		t.Fatalf("Expected merge conflict, got success.\nOutput: %s", out)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "--abort")
+	if err != nil {
+		t.Fatalf("integrate --abort failed: %v\nOutput: %s", err, out)
+	}
+	if integMergeHeadExists(t, dir) {
+		t.Error("Expected .git/MERGE_HEAD to be gone after abort")
+	}
+	if got := integRevParse(t, dir, "main"); got != preMain {
+		t.Errorf("Expected main restored to %s, got %s", preMain, got)
+	}
+	if got := integRevParse(t, dir, "develop"); got != preDevelop {
+		t.Errorf("Expected develop unchanged (%s), got %s", preDevelop, got)
+	}
+	if integTagExists(t, dir, "v2.0.0") {
+		t.Error("Expected no tag v2.0.0 after abort")
+	}
+	if integStateExists(t, dir) {
+		t.Error("Expected merge state cleared after abort")
+	}
+	if got := testutil.GetCurrentBranch(t, dir); got != "develop" {
+		t.Errorf("Expected HEAD on develop after abort, got %s", got)
+	}
+	if status, _ := testutil.RunGit(t, dir, "status", "--porcelain"); strings.TrimSpace(status) != "" {
+		t.Errorf("Expected clean working tree after abort, got: %s", status)
+	}
+}
+
+// TestIntegrateRebaseConflictThenContinue verifies a rebase conflict is resumable.
+//
+// Steps:
+//  1. init --defaults; create a diverged conflict on f.txt.
+//  2. Run: git flow integrate develop --rebase (conflicts during replay).
+//  3. Assert rebase-merge state present and integrate state saved (rebase).
+//  4. Resolve + stage, then git flow integrate --continue.
+//  5. Assert rebase-merge gone, develop rewritten onto X, main advanced, no merge
+//     commit, state cleared, HEAD on main.
+func TestIntegrateRebaseConflictThenContinue(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+	xCommit, originalC := integSetupConflict(t, dir, "f.txt")
+	preMerges := integMergeCount(t, dir, "main")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop", "--rebase")
+	if err == nil {
+		t.Fatalf("Expected rebase conflict, got success.\nOutput: %s", out)
+	}
+	if !integRebaseInProgress(t, dir) {
+		t.Error("Expected .git/rebase-merge to be present during rebase conflict")
+	}
+	state, err := testutil.LoadMergeState(t, dir)
+	if err != nil || state == nil {
+		t.Fatalf("Expected saved merge state, err=%v", err)
+	}
+	if state.Action != "integrate" {
+		t.Errorf("Expected Action integrate, got %s", state.Action)
+	}
+	if state.MergeStrategy != "rebase" {
+		t.Errorf("Expected MergeStrategy rebase, got %s", state.MergeStrategy)
+	}
+
+	testutil.WriteFile(t, dir, "f.txt", "resolved\n")
+	testutil.RunGit(t, dir, "add", "f.txt")
+
+	out, err = testutil.RunGitFlow(t, dir, "integrate", "--continue")
+	if err != nil {
+		t.Fatalf("integrate --continue failed: %v\nOutput: %s", err, out)
+	}
+	if integRebaseInProgress(t, dir) {
+		t.Error("Expected .git/rebase-merge to be gone after continue")
+	}
+	if content := testutil.ReadFile(t, dir, "f.txt"); !strings.Contains(content, "resolved") {
+		t.Errorf("Expected resolved content present, got: %s", content)
+	}
+	if !integIsAncestor(t, dir, xCommit, "develop") {
+		t.Error("Expected develop rewritten on top of X")
+	}
+	if integRevParse(t, dir, "develop") == originalC {
+		t.Error("Expected develop's C to be rewritten by rebase")
+	}
+	if !integIsAncestor(t, dir, integRevParse(t, dir, "develop"), "main") {
+		t.Error("Expected main to include the rebased develop tip")
+	}
+	if got := integMergeCount(t, dir, "main"); got != preMerges {
+		t.Errorf("Expected no merge commit, count went %d -> %d", preMerges, got)
+	}
+	if integStateExists(t, dir) {
+		t.Error("Expected merge state cleared after continue")
+	}
+	if got := testutil.GetCurrentBranch(t, dir); got != "main" {
+		t.Errorf("Expected HEAD on main, got %s", got)
+	}
+}
+
+// TestIntegrateRebaseConflictThenAbort verifies a rebase conflict rolls back on
+// abort.
+//
+// Steps:
+//  1. init --defaults; create a diverged conflict; capture pre-integrate tips.
+//  2. Run: git flow integrate develop --rebase (conflicts).
+//  3. Run: git flow integrate --abort.
+//  4. Assert rebase aborted, main/develop restored, no tag, state cleared,
+//     HEAD on develop.
+func TestIntegrateRebaseConflictThenAbort(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+	integSetupConflict(t, dir, "f.txt")
+	preMain := integRevParse(t, dir, "main")
+	preDevelop := integRevParse(t, dir, "develop")
+
+	if out, err := testutil.RunGitFlow(t, dir, "integrate", "develop", "--rebase"); err == nil {
+		t.Fatalf("Expected rebase conflict, got success.\nOutput: %s", out)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "--abort")
+	if err != nil {
+		t.Fatalf("integrate --abort failed: %v\nOutput: %s", err, out)
+	}
+	if integRebaseInProgress(t, dir) {
+		t.Error("Expected .git/rebase-merge to be gone after abort")
+	}
+	if got := integRevParse(t, dir, "main"); got != preMain {
+		t.Errorf("Expected main restored to %s, got %s", preMain, got)
+	}
+	if got := integRevParse(t, dir, "develop"); got != preDevelop {
+		t.Errorf("Expected develop restored to %s, got %s", preDevelop, got)
+	}
+	if integTagExists(t, dir, "v2.0.0") {
+		t.Error("Expected no tag after abort")
+	}
+	if integStateExists(t, dir) {
+		t.Error("Expected merge state cleared after abort")
+	}
+	if got := testutil.GetCurrentBranch(t, dir); got != "develop" {
+		t.Errorf("Expected HEAD on develop after abort, got %s", got)
+	}
+}
+
+// TestIntegrateChildUpdateConflictThenContinue verifies a conflict during child
+// auto-update is resumable without redoing the parent merge or tag.
+//
+// Steps:
+//  1. init --defaults; add base child staging (auto-update, merge) with commit S.
+//  2. Add commit C to develop creating conflict.txt (clean into main).
+//  3. Run: git flow integrate develop --tag v2.0.0. Parent merge + tag succeed;
+//     updating staging from main conflicts on conflict.txt.
+//  4. Capture main tip and tag object; resolve + stage; git flow integrate
+//     --continue.
+//  5. Assert main tip and tag object unchanged, no duplicate merge on main,
+//     staging carries main's content, state cleared.
+func TestIntegrateChildUpdateConflictThenContinue(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	if _, err := testutil.RunGit(t, dir, "checkout", "-b", "staging", "main"); err != nil {
+		t.Fatalf("Failed to create staging: %v", err)
+	}
+	testutil.RunGit(t, dir, "config", "gitflow.branch.staging.type", "base")
+	testutil.RunGit(t, dir, "config", "gitflow.branch.staging.parent", "main")
+	testutil.RunGit(t, dir, "config", "gitflow.branch.staging.autoUpdate", "true")
+	testutil.RunGit(t, dir, "config", "gitflow.branch.staging.downstreamStrategy", "merge")
+	integAddCommit(t, dir, "staging", "conflict.txt", "staging content\n", "Add S on staging")
+
+	integAddCommit(t, dir, "develop", "conflict.txt", "develop content\n", "Add C on develop")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop", "--tag", "v2.0.0")
+	if err == nil {
+		t.Fatalf("Expected child update conflict, got success.\nOutput: %s", out)
+	}
+	if !integMergeHeadExists(t, dir) {
+		t.Error("Expected .git/MERGE_HEAD during child merge conflict")
+	}
+	state, err := testutil.LoadMergeState(t, dir)
+	if err != nil || state == nil {
+		t.Fatalf("Expected saved merge state, err=%v", err)
+	}
+	if state.Action != "integrate" {
+		t.Errorf("Expected Action integrate, got %s", state.Action)
+	}
+	if state.CurrentStep != "update_children" {
+		t.Errorf("Expected CurrentStep update_children, got %s", state.CurrentStep)
+	}
+
+	mainAtConflict := integRevParse(t, dir, "main")
+	tagAtConflict := integRevParse(t, dir, "v2.0.0")
+	mergesAtConflict := integMergeCount(t, dir, "main")
+
+	testutil.WriteFile(t, dir, "conflict.txt", "resolved\n")
+	testutil.RunGit(t, dir, "add", "conflict.txt")
+
+	out, err = testutil.RunGitFlow(t, dir, "integrate", "--continue")
+	if err != nil {
+		t.Fatalf("integrate --continue failed: %v\nOutput: %s", err, out)
+	}
+	if got := integRevParse(t, dir, "main"); got != mainAtConflict {
+		t.Errorf("Expected main tip unchanged on continue (%s), got %s", mainAtConflict, got)
+	}
+	if got := integRevParse(t, dir, "v2.0.0"); got != tagAtConflict {
+		t.Errorf("Expected tag object unchanged on continue (%s), got %s", tagAtConflict, got)
+	}
+	if got := integMergeCount(t, dir, "main"); got != mergesAtConflict {
+		t.Errorf("Expected no duplicate merge on main, count went %d -> %d", mergesAtConflict, got)
+	}
+	if !integIsAncestor(t, dir, mainAtConflict, "staging") {
+		t.Error("Expected staging to carry main's content after continue")
+	}
+	if integStateExists(t, dir) {
+		t.Error("Expected merge state cleared after continue")
+	}
+}
+
+// TestIntegrateChildUpdateConflictThenAbort verifies aborting during a child
+// update uses the child's strategy and preserves the completed parent merge/tag.
+//
+// Steps:
+//  1. init --defaults (parent integrate strategy = merge). Add base children
+//     early (auto-update, merge) and staging (auto-update, rebase).
+//  2. Add clean commit C to develop; staging carries a commit that conflicts with
+//     main after the integrate (so its rebase replay conflicts).
+//  3. Run: git flow integrate develop --tag v2.0.0. Parent merge + tag succeed;
+//     staging's rebase update conflicts.
+//  4. Capture main tip, tag object, early tip; confirm rebase-merge present.
+//  5. Run: git flow integrate --abort.
+//  6. Assert merge + tag preserved, early untouched, rebase-merge gone (proving
+//     child-strategy-aware abort), state cleared.
+func TestIntegrateChildUpdateConflictThenAbort(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	// early: clean auto-update via merge, with its own history so its update is
+	// a real, observable change.
+	if _, err := testutil.RunGit(t, dir, "checkout", "-b", "early", "main"); err != nil {
+		t.Fatalf("Failed to create early: %v", err)
+	}
+	testutil.RunGit(t, dir, "config", "gitflow.branch.early.type", "base")
+	testutil.RunGit(t, dir, "config", "gitflow.branch.early.parent", "main")
+	testutil.RunGit(t, dir, "config", "gitflow.branch.early.autoUpdate", "true")
+	testutil.RunGit(t, dir, "config", "gitflow.branch.early.downstreamStrategy", "merge")
+	integAddCommit(t, dir, "early", "early.txt", "early\n", "Add early.txt on early")
+
+	// staging: auto-update via rebase, carries a commit that conflicts with main.
+	if _, err := testutil.RunGit(t, dir, "checkout", "-b", "staging", "main"); err != nil {
+		t.Fatalf("Failed to create staging: %v", err)
+	}
+	testutil.RunGit(t, dir, "config", "gitflow.branch.staging.type", "base")
+	testutil.RunGit(t, dir, "config", "gitflow.branch.staging.parent", "main")
+	testutil.RunGit(t, dir, "config", "gitflow.branch.staging.autoUpdate", "true")
+	testutil.RunGit(t, dir, "config", "gitflow.branch.staging.downstreamStrategy", "rebase")
+	integAddCommit(t, dir, "staging", "conflict.txt", "staging content\n", "Add S on staging")
+
+	// develop: clean commit C that creates conflict.txt (integrates into main
+	// cleanly, but makes staging's rebase replay conflict).
+	integAddCommit(t, dir, "develop", "conflict.txt", "develop content\n", "Add C on develop")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop", "--tag", "v2.0.0")
+	if err == nil {
+		t.Fatalf("Expected staging rebase conflict, got success.\nOutput: %s", out)
+	}
+	if !integRebaseInProgress(t, dir) {
+		t.Error("Expected .git/rebase-merge present at staging rebase conflict")
+	}
+	state, err := testutil.LoadMergeState(t, dir)
+	if err != nil || state == nil {
+		t.Fatalf("Expected saved merge state, err=%v", err)
+	}
+	if state.CurrentStep != "update_children" {
+		t.Errorf("Expected CurrentStep update_children, got %s", state.CurrentStep)
+	}
+	if state.MergeStrategy != "merge" {
+		t.Errorf("Expected parent MergeStrategy merge, got %s", state.MergeStrategy)
+	}
+
+	mainAtConflict := integRevParse(t, dir, "main")
+	tagAtConflict := integRevParse(t, dir, "v2.0.0")
+	earlyAtConflict := integRevParse(t, dir, "early")
+
+	out, err = testutil.RunGitFlow(t, dir, "integrate", "--abort")
+	if err != nil {
+		t.Fatalf("integrate --abort failed: %v\nOutput: %s", err, out)
+	}
+	// The bug this catches: aborting with state.MergeStrategy (merge) instead of
+	// the child's strategy (rebase) would leave a stray rebase-merge behind.
+	if integRebaseInProgress(t, dir) {
+		t.Error("Expected .git/rebase-merge gone after child-strategy-aware abort")
+	}
+	if got := integRevParse(t, dir, "main"); got != mainAtConflict {
+		t.Errorf("Expected completed parent merge preserved (%s), got %s", mainAtConflict, got)
+	}
+	if got := integRevParse(t, dir, "v2.0.0"); got != tagAtConflict {
+		t.Errorf("Expected tag preserved (%s), got %s", tagAtConflict, got)
+	}
+	if got := integRevParse(t, dir, "early"); got != earlyAtConflict {
+		t.Errorf("Expected early child untouched by abort (%s), got %s", earlyAtConflict, got)
+	}
+	if integStateExists(t, dir) {
+		t.Error("Expected merge state cleared after abort")
+	}
+}
+
+// TestIntegrateContinueRejectsFinishState verifies integrate --continue refuses
+// to resume a foreign finish operation.
+//
+// Steps:
+//  1. init --defaults; start a feature finish that conflicts (Action = finish).
+//  2. Run: git flow integrate --continue.
+//  3. Assert non-zero exit and the finish state remains (Action still finish).
+func TestIntegrateContinueRejectsFinishState(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	// Conflicting feature finish (feature vs develop merge).
+	integAddCommit(t, dir, "develop", "conflict.txt", "develop\n", "develop base")
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "start", "foo"); err != nil {
+		t.Fatalf("Failed to start feature: %v\nOutput: %s", err, out)
+	}
+	integAddCommit(t, dir, "feature/foo", "conflict.txt", "feature\n", "feature change")
+	integAddCommit(t, dir, "develop", "conflict.txt", "develop updated\n", "develop change")
+	testutil.RunGit(t, dir, "checkout", "feature/foo")
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "finish", "foo"); err == nil {
+		t.Fatalf("Expected feature finish to conflict.\nOutput: %s", out)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "--continue")
+	if err == nil {
+		t.Fatalf("Expected integrate --continue to reject a finish state.\nOutput: %s", out)
+	}
+	state, err := testutil.LoadMergeState(t, dir)
+	if err != nil || state == nil {
+		t.Fatalf("Expected finish state to remain, err=%v", err)
+	}
+	if state.Action != "finish" {
+		t.Errorf("Expected finish state left intact, got Action %s", state.Action)
+	}
+}
+
+// TestIntegrateContinueRejectsUpdateState verifies integrate --continue refuses
+// to resume a foreign update operation.
+//
+// Steps:
+//  1. init --defaults; start a feature update that conflicts (Action = update).
+//  2. Run: git flow integrate --continue.
+//  3. Assert non-zero exit and the update state remains (Action still update).
+func TestIntegrateContinueRejectsUpdateState(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	// Conflicting feature update (develop into feature).
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "start", "foo"); err != nil {
+		t.Fatalf("Failed to start feature: %v\nOutput: %s", err, out)
+	}
+	integAddCommit(t, dir, "feature/foo", "conflict.txt", "feature\n", "feature change")
+	integAddCommit(t, dir, "develop", "conflict.txt", "develop\n", "develop change")
+	testutil.RunGit(t, dir, "checkout", "feature/foo")
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "update", "foo"); err == nil {
+		t.Fatalf("Expected feature update to conflict.\nOutput: %s", out)
+	}
+	state, err := testutil.LoadMergeState(t, dir)
+	if err != nil || state == nil || state.Action != "update" {
+		t.Fatalf("Expected update state to exist, got %+v (err=%v)", state, err)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "--continue")
+	if err == nil {
+		t.Fatalf("Expected integrate --continue to reject an update state.\nOutput: %s", out)
+	}
+	state, err = testutil.LoadMergeState(t, dir)
+	if err != nil || state == nil {
+		t.Fatalf("Expected update state to remain, err=%v", err)
+	}
+	if state.Action != "update" {
+		t.Errorf("Expected update state left intact, got Action %s", state.Action)
+	}
+}
+
+// TestIntegrateAbortRejectsFinishState verifies integrate --abort refuses to
+// abort a foreign finish operation.
+//
+// Steps:
+//  1. init --defaults; start a feature finish that conflicts (Action = finish).
+//  2. Run: git flow integrate --abort.
+//  3. Assert non-zero exit, finish MERGE_HEAD and state remain.
+func TestIntegrateAbortRejectsFinishState(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	integAddCommit(t, dir, "develop", "conflict.txt", "develop\n", "develop base")
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "start", "foo"); err != nil {
+		t.Fatalf("Failed to start feature: %v\nOutput: %s", err, out)
+	}
+	integAddCommit(t, dir, "feature/foo", "conflict.txt", "feature\n", "feature change")
+	integAddCommit(t, dir, "develop", "conflict.txt", "develop updated\n", "develop change")
+	testutil.RunGit(t, dir, "checkout", "feature/foo")
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "finish", "foo"); err == nil {
+		t.Fatalf("Expected feature finish to conflict.\nOutput: %s", out)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "--abort")
+	if err == nil {
+		t.Fatalf("Expected integrate --abort to reject a finish state.\nOutput: %s", out)
+	}
+	if !integMergeHeadExists(t, dir) {
+		t.Error("Expected finish MERGE_HEAD to remain after rejected abort")
+	}
+	state, err := testutil.LoadMergeState(t, dir)
+	if err != nil || state == nil {
+		t.Fatalf("Expected finish state to remain, err=%v", err)
+	}
+	if state.Action != "finish" {
+		t.Errorf("Expected finish state left intact, got Action %s", state.Action)
+	}
+}
+
+// TestIntegrateAbortNoOp verifies integrate --abort with nothing in progress is
+// a forgiving no-op.
+//
+// Steps:
+//  1. init --defaults (nothing in progress).
+//  2. Run: git flow integrate --abort.
+//  3. Assert exit 0 and nothing mutated.
+func TestIntegrateAbortNoOp(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+	preMain := integRevParse(t, dir, "main")
+	preDevelop := integRevParse(t, dir, "develop")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "--abort")
+	if err != nil {
+		t.Fatalf("Expected integrate --abort no-op to succeed: %v\nOutput: %s", err, out)
+	}
+	if got := integRevParse(t, dir, "main"); got != preMain {
+		t.Errorf("Expected main unchanged, got %s", got)
+	}
+	if got := integRevParse(t, dir, "develop"); got != preDevelop {
+		t.Errorf("Expected develop unchanged, got %s", got)
+	}
+}

--- a/test/cmd/integrate_conflicts_test.go
+++ b/test/cmd/integrate_conflicts_test.go
@@ -389,6 +389,11 @@ func TestIntegrateChildUpdateConflictThenAbort(t *testing.T) {
 	// cleanly, but makes staging's rebase replay conflict).
 	integAddCommit(t, dir, "develop", "conflict.txt", "develop content\n", "Add C on develop")
 
+	// Capture early's tip before integrating so we can prove it was genuinely
+	// updated (not left untouched) before the later staging conflict. Child
+	// discovery is sorted, so "early" is updated before "staging".
+	earlyBefore := integRevParse(t, dir, "early")
+
 	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop", "--tag", "v2.0.0")
 	if err == nil {
 		t.Fatalf("Expected staging rebase conflict, got success.\nOutput: %s", out)
@@ -410,6 +415,17 @@ func TestIntegrateChildUpdateConflictThenAbort(t *testing.T) {
 	mainAtConflict := integRevParse(t, dir, "main")
 	tagAtConflict := integRevParse(t, dir, "v2.0.0")
 	earlyAtConflict := integRevParse(t, dir, "early")
+
+	// early must have actually been updated before the staging conflict: its tip
+	// moved and now carries main's completed merge. Without deterministic ordering
+	// (or if early were skipped) this assertion would not hold, so it guards
+	// against a false pass where the earlier child was never touched.
+	if earlyAtConflict == earlyBefore {
+		t.Errorf("Expected early child updated before staging conflict, but tip is unchanged (%s)", earlyBefore)
+	}
+	if !integIsAncestor(t, dir, mainAtConflict, "early") {
+		t.Error("Expected early to carry main's completed merge after its update")
+	}
 
 	out, err = testutil.RunGitFlow(t, dir, "integrate", "--abort")
 	if err != nil {

--- a/test/cmd/integrate_errors_test.go
+++ b/test/cmd/integrate_errors_test.go
@@ -204,6 +204,46 @@ func TestIntegrateParentMissing(t *testing.T) {
 	}
 }
 
+// TestIntegrateSourceBranchDeleted verifies a configured-but-deleted base branch
+// errors cleanly before any state mutation, rather than saving state and checking
+// out the parent before the merge fails.
+//
+// Steps:
+//  1. init --defaults; checkout main; delete the configured develop branch.
+//  2. Run: git flow integrate develop.
+//  3. Assert non-zero exit, error mentions the branch does not exist, no merge
+//     state was written, and main is unchanged.
+func TestIntegrateSourceBranchDeleted(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+	if _, err := testutil.RunGit(t, dir, "checkout", "main"); err != nil {
+		t.Fatalf("Failed to checkout main: %v", err)
+	}
+	// develop remains configured as a base branch, but the git branch is gone.
+	if _, err := testutil.RunGit(t, dir, "branch", "-D", "develop"); err != nil {
+		t.Fatalf("Failed to delete develop: %v", err)
+	}
+	preMain := integRevParse(t, dir, "main")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop")
+	if err == nil {
+		t.Fatalf("Expected integrate of deleted source branch to fail.\nOutput: %s", out)
+	}
+	if !strings.Contains(out, "does not exist") {
+		t.Errorf("Expected error to report the branch does not exist, got: %s", out)
+	}
+	if integStateExists(t, dir) {
+		t.Error("Expected no merge state written when the source branch is missing")
+	}
+	if got := integRevParse(t, dir, "main"); got != preMain {
+		t.Errorf("Expected main unchanged (%s), got %s", preMain, got)
+	}
+}
+
 // TestIntegrateNotInitialized verifies integrate errors when git-flow is not
 // initialized.
 //

--- a/test/cmd/integrate_errors_test.go
+++ b/test/cmd/integrate_errors_test.go
@@ -1,0 +1,225 @@
+package cmd_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// TestIntegrateRejectsTopicBranch verifies integrate refuses a topic branch and
+// points at finish.
+//
+// Steps:
+//  1. init --defaults; git flow feature start foo.
+//  2. Run: git flow integrate feature/foo.
+//  3. Assert non-zero exit, message mentions base branches and finish, no mutation.
+func TestIntegrateRejectsTopicBranch(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "start", "foo"); err != nil {
+		t.Fatalf("Failed to start feature: %v\nOutput: %s", err, out)
+	}
+	preMain := integRevParse(t, dir, "main")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "feature/foo")
+	if err == nil {
+		t.Fatalf("Expected integrate on a topic branch to fail.\nOutput: %s", out)
+	}
+	if !strings.Contains(out, "base branch") || !strings.Contains(out, "finish") {
+		t.Errorf("Expected error to mention base branches and finish, got: %s", out)
+	}
+	if got := integRevParse(t, dir, "main"); got != preMain {
+		t.Errorf("Expected main unchanged, got %s", got)
+	}
+	if tags, _ := testutil.RunGit(t, dir, "tag", "-l"); strings.TrimSpace(tags) != "" {
+		t.Errorf("Expected no tag, got: %s", tags)
+	}
+}
+
+// TestIntegrateNoParent verifies integrating a branch with no configured parent
+// errors.
+//
+// Steps:
+//  1. init --defaults (main has no parent).
+//  2. Run: git flow integrate main.
+//  3. Assert non-zero exit, error mentions parent, nothing mutated.
+func TestIntegrateNoParent(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+	preMain := integRevParse(t, dir, "main")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "main")
+	if err == nil {
+		t.Fatalf("Expected integrate main (no parent) to fail.\nOutput: %s", out)
+	}
+	if !strings.Contains(out, "parent") {
+		t.Errorf("Expected error to mention parent, got: %s", out)
+	}
+	if got := integRevParse(t, dir, "main"); got != preMain {
+		t.Errorf("Expected main unchanged, got %s", got)
+	}
+}
+
+// TestIntegrateSelfParent verifies a branch configured as its own parent errors
+// before any mutation.
+//
+// Steps:
+//  1. init --defaults; set gitflow.branch.develop.parent develop.
+//  2. Run: git flow integrate develop.
+//  3. Assert non-zero exit, self-parent error, nothing mutated.
+func TestIntegrateSelfParent(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+	testutil.RunGit(t, dir, "config", "gitflow.branch.develop.parent", "develop")
+	preDevelop := integRevParse(t, dir, "develop")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop")
+	if err == nil {
+		t.Fatalf("Expected integrate with self-parent to fail.\nOutput: %s", out)
+	}
+	if !strings.Contains(out, "itself") {
+		t.Errorf("Expected self-parent error, got: %s", out)
+	}
+	if got := integRevParse(t, dir, "develop"); got != preDevelop {
+		t.Errorf("Expected develop unchanged, got %s", got)
+	}
+}
+
+// TestIntegrateUpstreamStrategyNone verifies a base branch whose upstream
+// strategy is none cannot be integrated.
+//
+// Steps:
+//  1. init --defaults; set gitflow.branch.develop.upstreamStrategy none.
+//  2. Run: git flow integrate develop.
+//  3. Assert non-zero exit, strategy error, nothing merged.
+func TestIntegrateUpstreamStrategyNone(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+	testutil.RunGit(t, dir, "config", "gitflow.branch.develop.upstreamStrategy", "none")
+	preMain := integRevParse(t, dir, "main")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop")
+	if err == nil {
+		t.Fatalf("Expected integrate with upstream strategy none to fail.\nOutput: %s", out)
+	}
+	if !strings.Contains(out, "strategy") {
+		t.Errorf("Expected upstream strategy error, got: %s", out)
+	}
+	if got := integRevParse(t, dir, "main"); got != preMain {
+		t.Errorf("Expected main unchanged, got %s", got)
+	}
+}
+
+// TestIntegrateUnknownBranch verifies integrating an unknown branch errors.
+//
+// Steps:
+//  1. init --defaults.
+//  2. Run: git flow integrate nonexistent.
+//  3. Assert non-zero exit.
+func TestIntegrateUnknownBranch(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "nonexistent")
+	if err == nil {
+		t.Fatalf("Expected integrate of unknown branch to fail.\nOutput: %s", out)
+	}
+}
+
+// TestIntegrateCurrentBranchNotBase verifies integrate with no arg on a non-base
+// current branch errors.
+//
+// Steps:
+//  1. init --defaults; git flow feature start foo (HEAD on feature/foo).
+//  2. Run: git flow integrate (no arg).
+//  3. Assert non-zero exit, error mentions base branch.
+func TestIntegrateCurrentBranchNotBase(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "start", "foo"); err != nil {
+		t.Fatalf("Failed to start feature: %v\nOutput: %s", err, out)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate")
+	if err == nil {
+		t.Fatalf("Expected integrate on non-base current branch to fail.\nOutput: %s", out)
+	}
+	if !strings.Contains(out, "base branch") {
+		t.Errorf("Expected error to mention base branch, got: %s", out)
+	}
+}
+
+// TestIntegrateParentMissing verifies a missing parent branch errors.
+//
+// Steps:
+//  1. init --defaults; checkout develop; delete main locally.
+//  2. Run: git flow integrate develop.
+//  3. Assert non-zero exit, nothing mutated.
+func TestIntegrateParentMissing(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+	if _, err := testutil.RunGit(t, dir, "checkout", "develop"); err != nil {
+		t.Fatalf("Failed to checkout develop: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "branch", "-D", "main"); err != nil {
+		t.Fatalf("Failed to delete main: %v", err)
+	}
+	preDevelop := integRevParse(t, dir, "develop")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop")
+	if err == nil {
+		t.Fatalf("Expected integrate with missing parent to fail.\nOutput: %s", out)
+	}
+	if got := integRevParse(t, dir, "develop"); got != preDevelop {
+		t.Errorf("Expected develop unchanged, got %s", got)
+	}
+}
+
+// TestIntegrateNotInitialized verifies integrate errors when git-flow is not
+// initialized.
+//
+// Steps:
+//  1. SetupTestRepo without git flow init.
+//  2. Run: git flow integrate develop.
+//  3. Assert non-zero exit with a not-initialized error.
+func TestIntegrateNotInitialized(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop")
+	if err == nil {
+		t.Fatalf("Expected integrate in uninitialized repo to fail.\nOutput: %s", out)
+	}
+	if !strings.Contains(out, "not initialized") {
+		t.Errorf("Expected not-initialized error, got: %s", out)
+	}
+}

--- a/test/cmd/integrate_strategy_test.go
+++ b/test/cmd/integrate_strategy_test.go
@@ -1,0 +1,196 @@
+package cmd_test
+
+import (
+	"testing"
+
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// TestIntegrateSquashOverride verifies --squash lands multiple source commits as
+// a single squashed commit on the parent.
+//
+// Steps:
+//  1. init --defaults; add commits C1 and C2 to develop (not on main).
+//  2. Run: git flow integrate develop --squash.
+//  3. Assert main gains exactly one new commit (not C1/C2 by hash) carrying both
+//     files, with no merge commit.
+func TestIntegrateSquashOverride(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	c1 := integAddCommit(t, dir, "develop", "a.txt", "1", "Add a.txt on develop")
+	c2 := integAddCommit(t, dir, "develop", "b.txt", "2", "Add b.txt on develop")
+	preMerges := integMergeCount(t, dir, "main")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop", "--squash")
+	if err != nil {
+		t.Fatalf("integrate develop --squash failed: %v\nOutput: %s", err, out)
+	}
+
+	mainTip := integRevParse(t, dir, "main")
+	if mainTip == c1 || mainTip == c2 {
+		t.Errorf("Expected a new squashed commit distinct from C1/C2, got %s", mainTip)
+	}
+	if !testutil.FileExists(t, dir, "a.txt") || !testutil.FileExists(t, dir, "b.txt") {
+		t.Error("Expected both a.txt and b.txt to be present on main after squash")
+	}
+	if got := integMergeCount(t, dir, "main"); got != preMerges {
+		t.Errorf("Expected no merge commit from squash, merge count changed from %d to %d", preMerges, got)
+	}
+}
+
+// TestIntegrateRebaseOverrideRewritesSource verifies --rebase replays the source
+// branch onto the parent, rewriting its history.
+//
+// Steps:
+//  1. init --defaults; add X to main and C to develop (diverged).
+//  2. Run: git flow integrate develop --rebase.
+//  3. Assert develop's C sits on top of X (X ancestor of develop, C hash changed),
+//     main advanced to include the rebased C, and no merge commit was created.
+func TestIntegrateRebaseOverrideRewritesSource(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	xCommit := integAddCommit(t, dir, "main", "x.txt", "X", "Add X on main")
+	originalC := integAddCommit(t, dir, "develop", "c.txt", "C", "Add C on develop")
+	preMerges := integMergeCount(t, dir, "main")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop", "--rebase")
+	if err != nil {
+		t.Fatalf("integrate develop --rebase failed: %v\nOutput: %s", err, out)
+	}
+
+	if !integIsAncestor(t, dir, xCommit, "develop") {
+		t.Errorf("Expected X (%s) to be an ancestor of the rewritten develop", xCommit)
+	}
+	if integRevParse(t, dir, "develop") == originalC {
+		t.Error("Expected develop's C commit to be rewritten (new hash) by rebase")
+	}
+	if !integIsAncestor(t, dir, integRevParse(t, dir, "develop"), "main") {
+		t.Error("Expected main to include the rebased develop tip")
+	}
+	if got := integMergeCount(t, dir, "main"); got != preMerges {
+		t.Errorf("Expected no merge commit from rebase, merge count changed from %d to %d", preMerges, got)
+	}
+}
+
+// TestIntegrateConfiguredUpstreamStrategy verifies a Layer-1 branch-type
+// upstream strategy is honored without a CLI flag.
+//
+// Steps:
+//  1. init --defaults; set gitflow.branch.develop.upstreamStrategy squash.
+//  2. Add commits C1, C2 to develop.
+//  3. Run: git flow integrate develop (no strategy flag).
+//  4. Assert a single squashed commit on main.
+func TestIntegrateConfiguredUpstreamStrategy(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.branch.develop.upstreamStrategy", "squash"); err != nil {
+		t.Fatalf("Failed to set upstreamStrategy: %v", err)
+	}
+
+	c1 := integAddCommit(t, dir, "develop", "a.txt", "1", "Add a.txt on develop")
+	c2 := integAddCommit(t, dir, "develop", "b.txt", "2", "Add b.txt on develop")
+	preMerges := integMergeCount(t, dir, "main")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop")
+	if err != nil {
+		t.Fatalf("integrate develop failed: %v\nOutput: %s", err, out)
+	}
+
+	mainTip := integRevParse(t, dir, "main")
+	if mainTip == c1 || mainTip == c2 {
+		t.Errorf("Expected a squashed commit (Layer-1 config), got %s", mainTip)
+	}
+	if !testutil.FileExists(t, dir, "a.txt") || !testutil.FileExists(t, dir, "b.txt") {
+		t.Error("Expected both files present on main after squash")
+	}
+	if got := integMergeCount(t, dir, "main"); got != preMerges {
+		t.Errorf("Expected no merge commit, merge count changed from %d to %d", preMerges, got)
+	}
+}
+
+// TestIntegrateLayer2OverridesLayer1Strategy verifies a Layer-2
+// gitflow.<branch>.integrate.squash overrides the Layer-1 merge default.
+//
+// Steps:
+//  1. init --defaults (Layer-1 develop.upstreamStrategy = merge).
+//  2. Set gitflow.develop.integrate.squash true.
+//  3. Add commits C1, C2 to develop; run integrate develop (no flag).
+//  4. Assert a single squashed commit on main (Layer-2 beats Layer-1).
+func TestIntegrateLayer2OverridesLayer1Strategy(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.develop.integrate.squash", "true"); err != nil {
+		t.Fatalf("Failed to set integrate.squash config: %v", err)
+	}
+
+	c1 := integAddCommit(t, dir, "develop", "a.txt", "1", "Add a.txt on develop")
+	c2 := integAddCommit(t, dir, "develop", "b.txt", "2", "Add b.txt on develop")
+	preMerges := integMergeCount(t, dir, "main")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop")
+	if err != nil {
+		t.Fatalf("integrate develop failed: %v\nOutput: %s", err, out)
+	}
+
+	mainTip := integRevParse(t, dir, "main")
+	if mainTip == c1 || mainTip == c2 {
+		t.Errorf("Expected squashed commit (Layer-2 over Layer-1), got %s", mainTip)
+	}
+	if got := integMergeCount(t, dir, "main"); got != preMerges {
+		t.Errorf("Expected no merge commit, merge count changed from %d to %d", preMerges, got)
+	}
+}
+
+// TestIntegrateLayer2SquashOverriddenByFlag verifies a CLI --no-squash beats a
+// configured integrate.squash=true default.
+//
+// Steps:
+//  1. init --defaults; set gitflow.develop.integrate.squash true.
+//  2. Add commits C1, C2 to develop.
+//  3. Run: git flow integrate develop --no-squash.
+//  4. Assert a normal merge/fast-forward: both C1 and C2 reachable on main by
+//     their original hashes (not squashed).
+func TestIntegrateLayer2SquashOverriddenByFlag(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.develop.integrate.squash", "true"); err != nil {
+		t.Fatalf("Failed to set integrate.squash config: %v", err)
+	}
+
+	c1 := integAddCommit(t, dir, "develop", "a.txt", "1", "Add a.txt on develop")
+	c2 := integAddCommit(t, dir, "develop", "b.txt", "2", "Add b.txt on develop")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop", "--no-squash")
+	if err != nil {
+		t.Fatalf("integrate develop --no-squash failed: %v\nOutput: %s", err, out)
+	}
+
+	if !integIsAncestor(t, dir, c1, "main") {
+		t.Errorf("Expected C1 (%s) reachable on main by original hash", c1)
+	}
+	if !integIsAncestor(t, dir, c2, "main") {
+		t.Errorf("Expected C2 (%s) reachable on main by original hash", c2)
+	}
+}

--- a/test/cmd/integrate_tags_test.go
+++ b/test/cmd/integrate_tags_test.go
@@ -1,0 +1,315 @@
+package cmd_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// TestIntegrateWithTag verifies --tag creates an annotated tag on the parent tip.
+//
+// Steps:
+//  1. init --defaults; add commit C to develop.
+//  2. Run: git flow integrate develop --tag v2.0.0.
+//  3. Assert main advanced to C and annotated tag v2.0.0 points at main's tip.
+func TestIntegrateWithTag(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	cCommit := integAddCommit(t, dir, "develop", "c.txt", "C", "Add C on develop")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop", "--tag", "v2.0.0")
+	if err != nil {
+		t.Fatalf("integrate develop --tag failed: %v\nOutput: %s", err, out)
+	}
+
+	if got := integRevParse(t, dir, "main"); got != cCommit {
+		t.Errorf("Expected main to advance to C (%s), got %s", cCommit, got)
+	}
+	if !integTagExists(t, dir, "v2.0.0") {
+		t.Fatal("Expected tag v2.0.0 to exist")
+	}
+	if !integTagIsAnnotated(t, dir, "v2.0.0") {
+		t.Error("Expected v2.0.0 to be an annotated tag")
+	}
+	if integRevParse(t, dir, "v2.0.0^{commit}") != integRevParse(t, dir, "main") {
+		t.Error("Expected v2.0.0 to point at main's tip")
+	}
+	if got := testutil.GetCurrentBranch(t, dir); got != "main" {
+		t.Errorf("Expected HEAD on main, got %s", got)
+	}
+}
+
+// TestIntegrateSignedTag verifies --sign produces a GPG-signed annotated tag.
+// The test is skipped when GPG is unavailable or key generation fails.
+//
+// Steps:
+//  1. init --defaults; add commit C to develop; configure an ephemeral GPG key.
+//  2. Run: git flow integrate develop --tag v2.0.0 --sign.
+//  3. Assert v2.0.0 is a signed annotated tag on main's tip.
+func TestIntegrateSignedTag(t *testing.T) {
+	if _, err := exec.LookPath("gpg"); err != nil {
+		t.Skip("gpg not available; skipping signed tag test")
+	}
+
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	// Ephemeral GPG home so we never touch the developer's keyring.
+	gnupgHome := t.TempDir()
+	if err := os.Chmod(gnupgHome, 0700); err != nil {
+		t.Skipf("cannot secure GNUPGHOME: %v", err)
+	}
+	prev, hadPrev := os.LookupEnv("GNUPGHOME")
+	os.Setenv("GNUPGHOME", gnupgHome)
+	defer func() {
+		if hadPrev {
+			os.Setenv("GNUPGHOME", prev)
+		} else {
+			os.Unsetenv("GNUPGHOME")
+		}
+	}()
+
+	genCmd := exec.Command("gpg", "--batch", "--pinentry-mode", "loopback", "--passphrase", "",
+		"--quick-generate-key", "Test Signer <test@example.com>", "default", "default", "0")
+	genCmd.Env = append(os.Environ(), "GNUPGHOME="+gnupgHome)
+	if out, err := genCmd.CombinedOutput(); err != nil {
+		t.Skipf("gpg key generation failed, skipping: %v\nOutput: %s", err, out)
+	}
+
+	if _, err := testutil.RunGit(t, dir, "config", "user.signingkey", "test@example.com"); err != nil {
+		t.Fatalf("Failed to configure signing key: %v", err)
+	}
+
+	integAddCommit(t, dir, "develop", "c.txt", "C", "Add C on develop")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop", "--tag", "v2.0.0", "--sign")
+	if err != nil {
+		t.Fatalf("integrate develop --tag --sign failed: %v\nOutput: %s", err, out)
+	}
+
+	if !integTagExists(t, dir, "v2.0.0") {
+		t.Fatal("Expected tag v2.0.0 to exist")
+	}
+	tagObj, err := testutil.RunGit(t, dir, "cat-file", "-p", "v2.0.0")
+	if err != nil {
+		t.Fatalf("Failed to read tag object: %v", err)
+	}
+	if !strings.Contains(tagObj, "-----BEGIN PGP SIGNATURE-----") {
+		t.Errorf("Expected v2.0.0 to carry a PGP signature, got:\n%s", tagObj)
+	}
+	if integRevParse(t, dir, "v2.0.0^{commit}") != integRevParse(t, dir, "main") {
+		t.Error("Expected v2.0.0 to point at main's tip")
+	}
+}
+
+// TestIntegrateNotagOverridesConfig verifies --notag suppresses a configured tag.
+//
+// Steps:
+//  1. init --defaults; add C to develop; set integrate.tag true and
+//     integrate.tagname v9.
+//  2. Run: git flow integrate develop --notag.
+//  3. Assert main advanced to C but no tag was created.
+func TestIntegrateNotagOverridesConfig(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	cCommit := integAddCommit(t, dir, "develop", "c.txt", "C", "Add C on develop")
+	testutil.RunGit(t, dir, "config", "gitflow.develop.integrate.tag", "true")
+	testutil.RunGit(t, dir, "config", "gitflow.develop.integrate.tagname", "v9")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop", "--notag")
+	if err != nil {
+		t.Fatalf("integrate develop --notag failed: %v\nOutput: %s", err, out)
+	}
+
+	if got := integRevParse(t, dir, "main"); got != cCommit {
+		t.Errorf("Expected main to advance to C (%s), got %s", cCommit, got)
+	}
+	if tags, _ := testutil.RunGit(t, dir, "tag", "-l"); strings.TrimSpace(tags) != "" {
+		t.Errorf("Expected no tag with --notag, got: %s", tags)
+	}
+}
+
+// TestIntegrateTagEnabledNoNameErrors verifies tagging enabled by config without
+// a resolvable name errors before merging.
+//
+// Steps:
+//  1. init --defaults; add C to develop; set integrate.tag true (no tagname, no --tag).
+//  2. Run: git flow integrate develop.
+//  3. Assert non-zero exit, main unchanged, no tag created.
+func TestIntegrateTagEnabledNoNameErrors(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	integAddCommit(t, dir, "develop", "c.txt", "C", "Add C on develop")
+	preMain := integRevParse(t, dir, "main")
+	testutil.RunGit(t, dir, "config", "gitflow.develop.integrate.tag", "true")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop")
+	if err == nil {
+		t.Fatalf("Expected integrate to fail when tagging is enabled without a name.\nOutput: %s", out)
+	}
+	if got := integRevParse(t, dir, "main"); got != preMain {
+		t.Errorf("Expected main unchanged before the error (%s), got %s", preMain, got)
+	}
+	if tags, _ := testutil.RunGit(t, dir, "tag", "-l"); strings.TrimSpace(tags) != "" {
+		t.Errorf("Expected no tag, got: %s", tags)
+	}
+}
+
+// TestIntegrateMessagefileWinsOverMessage verifies --messagefile takes precedence
+// over --message for the tag message.
+//
+// Steps:
+//  1. init --defaults; add C to develop; write msg.txt with distinct content.
+//  2. Run: git flow integrate develop --tag v2.0.0 --message "inline"
+//     --messagefile msg.txt.
+//  3. Assert the tag message comes from msg.txt, not "inline".
+func TestIntegrateMessagefileWinsOverMessage(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	integAddCommit(t, dir, "develop", "c.txt", "C", "Add C on develop")
+	msgPath := filepath.Join(dir, "msg.txt")
+	if err := os.WriteFile(msgPath, []byte("message from file"), 0644); err != nil {
+		t.Fatalf("Failed to write msg.txt: %v", err)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop", "--tag", "v2.0.0",
+		"--message", "inline", "--messagefile", msgPath)
+	if err != nil {
+		t.Fatalf("integrate with message + messagefile failed: %v\nOutput: %s", err, out)
+	}
+
+	msg := integTagMessage(t, dir, "v2.0.0")
+	if !strings.Contains(msg, "message from file") {
+		t.Errorf("Expected tag message from file, got: %s", msg)
+	}
+	if strings.Contains(msg, "inline") {
+		t.Errorf("Expected --messagefile to win over --message, got: %s", msg)
+	}
+}
+
+// TestIntegrateLayer2TagCreatesConfiguredTag verifies Layer-2 tag config alone
+// creates the configured tag.
+//
+// Steps:
+//  1. init --defaults; add C to develop; set integrate.tag true and
+//     integrate.tagname v3.0.0 (no --tag/--notag).
+//  2. Run: git flow integrate develop.
+//  3. Assert annotated tag v3.0.0 on main's tip.
+func TestIntegrateLayer2TagCreatesConfiguredTag(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	integAddCommit(t, dir, "develop", "c.txt", "C", "Add C on develop")
+	testutil.RunGit(t, dir, "config", "gitflow.develop.integrate.tag", "true")
+	testutil.RunGit(t, dir, "config", "gitflow.develop.integrate.tagname", "v3.0.0")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop")
+	if err != nil {
+		t.Fatalf("integrate develop failed: %v\nOutput: %s", err, out)
+	}
+
+	if !integTagExists(t, dir, "v3.0.0") {
+		t.Fatal("Expected configured tag v3.0.0 to be created")
+	}
+	if !integTagIsAnnotated(t, dir, "v3.0.0") {
+		t.Error("Expected v3.0.0 to be an annotated tag")
+	}
+	if integRevParse(t, dir, "v3.0.0^{commit}") != integRevParse(t, dir, "main") {
+		t.Error("Expected v3.0.0 to point at main's tip")
+	}
+}
+
+// TestIntegrateCliTagNameOverridesConfig verifies a CLI --tag name overrides a
+// configured integrate.tagname.
+//
+// Steps:
+//  1. init --defaults; add C to develop; set integrate.tag true and
+//     integrate.tagname v3.0.0.
+//  2. Run: git flow integrate develop --tag v4.0.0.
+//  3. Assert v4.0.0 exists on main and configured v3.0.0 does not.
+func TestIntegrateCliTagNameOverridesConfig(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	integAddCommit(t, dir, "develop", "c.txt", "C", "Add C on develop")
+	testutil.RunGit(t, dir, "config", "gitflow.develop.integrate.tag", "true")
+	testutil.RunGit(t, dir, "config", "gitflow.develop.integrate.tagname", "v3.0.0")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop", "--tag", "v4.0.0")
+	if err != nil {
+		t.Fatalf("integrate develop --tag v4.0.0 failed: %v\nOutput: %s", err, out)
+	}
+
+	if !integTagExists(t, dir, "v4.0.0") {
+		t.Error("Expected CLI tag v4.0.0 to exist")
+	}
+	if integTagExists(t, dir, "v3.0.0") {
+		t.Error("Expected configured tag v3.0.0 to be absent when CLI --tag wins")
+	}
+	if integRevParse(t, dir, "v4.0.0^{commit}") != integRevParse(t, dir, "main") {
+		t.Error("Expected v4.0.0 to point at main's tip")
+	}
+}
+
+// TestIntegrateMessageSetsTagMessage verifies a lone --message reaches the tag.
+//
+// Steps:
+//  1. init --defaults; add C to develop.
+//  2. Run: git flow integrate develop --tag v2.0.0 --message "integrate note".
+//  3. Assert the tag message contains "integrate note".
+func TestIntegrateMessageSetsTagMessage(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	integAddCommit(t, dir, "develop", "c.txt", "C", "Add C on develop")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop", "--tag", "v2.0.0", "--message", "integrate note")
+	if err != nil {
+		t.Fatalf("integrate develop --tag --message failed: %v\nOutput: %s", err, out)
+	}
+
+	msg := integTagMessage(t, dir, "v2.0.0")
+	if !strings.Contains(msg, "integrate note") {
+		t.Errorf("Expected tag message to contain 'integrate note', got: %s", msg)
+	}
+}

--- a/test/cmd/integrate_test.go
+++ b/test/cmd/integrate_test.go
@@ -1,0 +1,360 @@
+package cmd_test
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// =============================================================================
+// Shared helpers for the integrate command tests. These live here so all
+// integrate_*_test.go files (package cmd_test) can use them.
+// =============================================================================
+
+// integRevParse returns the resolved commit hash for a ref.
+func integRevParse(t *testing.T, dir, ref string) string {
+	t.Helper()
+	out, err := testutil.RunGit(t, dir, "rev-parse", ref)
+	if err != nil {
+		t.Fatalf("Failed to rev-parse %s: %v", ref, err)
+	}
+	return strings.TrimSpace(out)
+}
+
+// integMergeCount returns the number of merge commits reachable from ref.
+func integMergeCount(t *testing.T, dir, ref string) int {
+	t.Helper()
+	out, err := testutil.RunGit(t, dir, "rev-list", "--merges", "--count", ref)
+	if err != nil {
+		t.Fatalf("Failed to count merges on %s: %v", ref, err)
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		t.Fatalf("Failed to parse merge count %q: %v", out, err)
+	}
+	return n
+}
+
+// integIsAncestor reports whether ancestor is an ancestor of (or equal to)
+// descendant. Returns false when either ref is unknown to the repository.
+func integIsAncestor(t *testing.T, dir, ancestor, descendant string) bool {
+	t.Helper()
+	_, err := testutil.RunGit(t, dir, "merge-base", "--is-ancestor", ancestor, descendant)
+	return err == nil
+}
+
+// integTagExists reports whether a tag with the given name exists.
+func integTagExists(t *testing.T, dir, name string) bool {
+	t.Helper()
+	out, _ := testutil.RunGit(t, dir, "tag", "-l", name)
+	return strings.TrimSpace(out) == name
+}
+
+// integTagIsAnnotated reports whether the named tag is an annotated (tag object)
+// rather than a lightweight tag.
+func integTagIsAnnotated(t *testing.T, dir, name string) bool {
+	t.Helper()
+	out, err := testutil.RunGit(t, dir, "cat-file", "-t", name)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(out) == "tag"
+}
+
+// integTagMessage returns the message body of an annotated tag.
+func integTagMessage(t *testing.T, dir, name string) string {
+	t.Helper()
+	out, err := testutil.RunGit(t, dir, "tag", "-l", "--format=%(contents)", name)
+	if err != nil {
+		t.Fatalf("Failed to read tag message for %s: %v", name, err)
+	}
+	return out
+}
+
+// integAddCommit checks out branch, writes file with content, commits, and
+// returns the resulting commit hash.
+func integAddCommit(t *testing.T, dir, branch, file, content, msg string) string {
+	t.Helper()
+	if _, err := testutil.RunGit(t, dir, "checkout", branch); err != nil {
+		t.Fatalf("Failed to checkout %s: %v", branch, err)
+	}
+	if err := testutil.WriteFile(t, dir, file, content); err != nil {
+		t.Fatalf("Failed to write %s: %v", file, err)
+	}
+	if _, err := testutil.RunGit(t, dir, "add", file); err != nil {
+		t.Fatalf("Failed to add %s: %v", file, err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", msg); err != nil {
+		t.Fatalf("Failed to commit on %s: %v", branch, err)
+	}
+	return integRevParse(t, dir, "HEAD")
+}
+
+// integGitDir returns the repository's .git directory (worktree-aware).
+func integGitDir(t *testing.T, dir string) string {
+	t.Helper()
+	out, err := testutil.RunGit(t, dir, "rev-parse", "--git-dir")
+	if err != nil {
+		t.Fatalf("Failed to resolve git dir: %v", err)
+	}
+	gd := strings.TrimSpace(out)
+	if !filepath.IsAbs(gd) {
+		gd = filepath.Join(dir, gd)
+	}
+	return gd
+}
+
+// integRebaseInProgress reports whether a rebase is in progress (rebase-merge dir).
+func integRebaseInProgress(t *testing.T, dir string) bool {
+	t.Helper()
+	_, err := os.Stat(filepath.Join(integGitDir(t, dir), "rebase-merge"))
+	return err == nil
+}
+
+// integMergeHeadExists reports whether .git/MERGE_HEAD is present.
+func integMergeHeadExists(t *testing.T, dir string) bool {
+	t.Helper()
+	_, err := os.Stat(filepath.Join(integGitDir(t, dir), "MERGE_HEAD"))
+	return err == nil
+}
+
+// integStateExists reports whether the git-flow merge state file exists.
+func integStateExists(t *testing.T, dir string) bool {
+	t.Helper()
+	_, err := os.Stat(filepath.Join(integGitDir(t, dir), "gitflow", "state", "merge.json"))
+	return err == nil
+}
+
+// =============================================================================
+// Happy paths
+// =============================================================================
+
+// TestIntegrateFastForwardNoTag verifies a linear integrate fast-forwards the
+// parent without a merge commit or tag, and the auto-update child is a no-op.
+//
+// Steps:
+//  1. init --defaults; checkout develop and add commit C (develop ahead of main).
+//  2. Run: git flow integrate develop.
+//  3. Assert main fast-forwarded to C with no merge commit, no tag, develop
+//     unchanged (== main), HEAD on main, both branches still present.
+func TestIntegrateFastForwardNoTag(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	cCommit := integAddCommit(t, dir, "develop", "c.txt", "C", "Add C on develop")
+	preMerges := integMergeCount(t, dir, "main")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop")
+	if err != nil {
+		t.Fatalf("integrate develop failed: %v\nOutput: %s", err, out)
+	}
+
+	if got := integRevParse(t, dir, "main"); got != cCommit {
+		t.Errorf("Expected main to fast-forward to C (%s), got %s", cCommit, got)
+	}
+	if got := integMergeCount(t, dir, "main"); got != preMerges {
+		t.Errorf("Expected no new merge commit on main, merge count changed from %d to %d", preMerges, got)
+	}
+	if tags, _ := testutil.RunGit(t, dir, "tag", "-l"); strings.TrimSpace(tags) != "" {
+		t.Errorf("Expected no tag to be created, got: %s", tags)
+	}
+	if integRevParse(t, dir, "develop") != integRevParse(t, dir, "main") {
+		t.Error("Expected develop auto-update to be a no-op (develop == main)")
+	}
+	if got := testutil.GetCurrentBranch(t, dir); got != "main" {
+		t.Errorf("Expected HEAD on main, got %s", got)
+	}
+	if !testutil.BranchExists(t, dir, "main") || !testutil.BranchExists(t, dir, "develop") {
+		t.Error("Expected both main and develop to still exist")
+	}
+}
+
+// TestIntegrateCurrentBranch verifies integrate with no argument resolves the
+// target from the current branch's parent.
+//
+// Steps:
+//  1. init --defaults; add commit C to develop and leave HEAD on develop.
+//  2. Run: git flow integrate (no argument).
+//  3. Assert main fast-forwarded to C, HEAD on main.
+func TestIntegrateCurrentBranch(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	cCommit := integAddCommit(t, dir, "develop", "c.txt", "C", "Add C on develop")
+	if got := testutil.GetCurrentBranch(t, dir); got != "develop" {
+		t.Fatalf("Expected HEAD on develop before integrate, got %s", got)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate")
+	if err != nil {
+		t.Fatalf("integrate (no arg) failed: %v\nOutput: %s", err, out)
+	}
+
+	if got := integRevParse(t, dir, "main"); got != cCommit {
+		t.Errorf("Expected main to fast-forward to C (%s), got %s", cCommit, got)
+	}
+	if got := testutil.GetCurrentBranch(t, dir); got != "main" {
+		t.Errorf("Expected HEAD on main, got %s", got)
+	}
+}
+
+// TestIntegrateNothingToIntegrate verifies an already-up-to-date integrate is a
+// clean no-op.
+//
+// Steps:
+//  1. init --defaults (develop == main, nothing ahead).
+//  2. Run: git flow integrate develop.
+//  3. Assert exit 0, main unchanged, no tag, both branches present, HEAD on main.
+func TestIntegrateNothingToIntegrate(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	preMain := integRevParse(t, dir, "main")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop")
+	if err != nil {
+		t.Fatalf("integrate develop (no-op) failed: %v\nOutput: %s", err, out)
+	}
+
+	if got := integRevParse(t, dir, "main"); got != preMain {
+		t.Errorf("Expected main unchanged (%s), got %s", preMain, got)
+	}
+	if tags, _ := testutil.RunGit(t, dir, "tag", "-l"); strings.TrimSpace(tags) != "" {
+		t.Errorf("Expected no tag, got: %s", tags)
+	}
+	if !testutil.BranchExists(t, dir, "develop") {
+		t.Error("Expected develop to still exist")
+	}
+	if got := testutil.GetCurrentBranch(t, dir); got != "main" {
+		t.Errorf("Expected HEAD on main, got %s", got)
+	}
+}
+
+// TestIntegrateNothingToIntegrateWithTag verifies the tag is still created even
+// when the merge itself is a no-op.
+//
+// Steps:
+//  1. init --defaults (develop == main).
+//  2. Run: git flow integrate develop --tag v1.0.0.
+//  3. Assert exit 0 and annotated tag v1.0.0 exists on main.
+func TestIntegrateNothingToIntegrateWithTag(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop", "--tag", "v1.0.0")
+	if err != nil {
+		t.Fatalf("integrate develop --tag failed: %v\nOutput: %s", err, out)
+	}
+
+	if !integTagExists(t, dir, "v1.0.0") {
+		t.Error("Expected tag v1.0.0 to be created even for a no-op merge")
+	}
+	if !integTagIsAnnotated(t, dir, "v1.0.0") {
+		t.Error("Expected v1.0.0 to be an annotated tag")
+	}
+	if integRevParse(t, dir, "v1.0.0^{commit}") != integRevParse(t, dir, "main") {
+		t.Error("Expected v1.0.0 to point at main's tip")
+	}
+}
+
+// TestIntegrateFetchPullsRemoteChanges verifies --fetch incorporates remote
+// parent commits before integrating.
+//
+// Steps:
+//  1. SetupTestRepoWithRemote; clone the remote and push commit R to main.
+//  2. Give the original develop commit C not on local main; leave HEAD on develop.
+//  3. Run: git flow integrate develop --fetch.
+//  4. Assert main contains both R (fetched) and C.
+func TestIntegrateFetchPullsRemoteChanges(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	// Second working copy that pushes R to main on the remote.
+	secondDir := t.TempDir()
+	if _, err := testutil.RunGit(t, secondDir, "clone", remoteDir, "."); err != nil {
+		t.Fatalf("Failed to clone remote: %v", err)
+	}
+	testutil.ConfigureGitIdentity(t, secondDir)
+	rCommit := integAddCommit(t, secondDir, "main", "remote.txt", "R", "Add R on remote main")
+	if _, err := testutil.RunGit(t, secondDir, "push", "origin", "main"); err != nil {
+		t.Fatalf("Failed to push R to remote: %v", err)
+	}
+
+	// Local develop gets commit C not on local main.
+	cCommit := integAddCommit(t, dir, "develop", "c.txt", "C", "Add C on develop")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop", "--fetch")
+	if err != nil {
+		t.Fatalf("integrate develop --fetch failed: %v\nOutput: %s", err, out)
+	}
+
+	if !integIsAncestor(t, dir, rCommit, "main") {
+		t.Errorf("Expected fetched commit R (%s) to be present on main", rCommit)
+	}
+	if !integIsAncestor(t, dir, cCommit, "main") {
+		t.Errorf("Expected commit C (%s) to be present on main", cCommit)
+	}
+}
+
+// TestIntegrateNoFetchOverridesConfig verifies --no-fetch overrides a configured
+// integrate.fetch=true default.
+//
+// Steps:
+//  1. SetupTestRepoWithRemote; set gitflow.develop.integrate.fetch true.
+//  2. Push commit R to main via a second clone; give local develop commit C.
+//  3. Run: git flow integrate develop --no-fetch.
+//  4. Assert R is absent from main; main advanced only by C.
+func TestIntegrateNoFetchOverridesConfig(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.develop.integrate.fetch", "true"); err != nil {
+		t.Fatalf("Failed to set integrate.fetch config: %v", err)
+	}
+
+	secondDir := t.TempDir()
+	if _, err := testutil.RunGit(t, secondDir, "clone", remoteDir, "."); err != nil {
+		t.Fatalf("Failed to clone remote: %v", err)
+	}
+	testutil.ConfigureGitIdentity(t, secondDir)
+	rCommit := integAddCommit(t, secondDir, "main", "remote.txt", "R", "Add R on remote main")
+	if _, err := testutil.RunGit(t, secondDir, "push", "origin", "main"); err != nil {
+		t.Fatalf("Failed to push R to remote: %v", err)
+	}
+
+	cCommit := integAddCommit(t, dir, "develop", "c.txt", "C", "Add C on develop")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop", "--no-fetch")
+	if err != nil {
+		t.Fatalf("integrate develop --no-fetch failed: %v\nOutput: %s", err, out)
+	}
+
+	if integIsAncestor(t, dir, rCommit, "main") {
+		t.Errorf("Expected fetched commit R (%s) to be ABSENT from main with --no-fetch", rCommit)
+	}
+	if !integIsAncestor(t, dir, cCommit, "main") {
+		t.Errorf("Expected commit C (%s) to be present on main", cCommit)
+	}
+}

--- a/test/cmd/integrate_test.go
+++ b/test/cmd/integrate_test.go
@@ -358,3 +358,57 @@ func TestIntegrateNoFetchOverridesConfig(t *testing.T) {
 		t.Errorf("Expected commit C (%s) to be present on main", cCommit)
 	}
 }
+
+// TestIntegrateFetchParentCheckedOutSurfacesFailure verifies that when the
+// parent branch is checked out, the parent:parent fetch refspec git refuses is
+// surfaced honestly: integrate warns and does NOT print "Fetch completed", so a
+// stale local parent is not integrated silently. The operation stays non-fatal.
+//
+// Steps:
+//  1. SetupTestRepoWithRemote; push commit R to main via a second clone.
+//  2. Give local develop commit C; check out main locally so the parent is HEAD.
+//  3. Run: git flow integrate develop --fetch.
+//  4. Assert exit 0, a Warning is printed, "Fetch completed" is NOT printed,
+//     C is integrated into main, and R (unfetchable) is absent from local main.
+func TestIntegrateFetchParentCheckedOutSurfacesFailure(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	secondDir := t.TempDir()
+	if _, err := testutil.RunGit(t, secondDir, "clone", remoteDir, "."); err != nil {
+		t.Fatalf("Failed to clone remote: %v", err)
+	}
+	testutil.ConfigureGitIdentity(t, secondDir)
+	rCommit := integAddCommit(t, secondDir, "main", "remote.txt", "R", "Add R on remote main")
+	if _, err := testutil.RunGit(t, secondDir, "push", "origin", "main"); err != nil {
+		t.Fatalf("Failed to push R to remote: %v", err)
+	}
+
+	cCommit := integAddCommit(t, dir, "develop", "c.txt", "C", "Add C on develop")
+
+	// Check out the parent so the parent:parent refspec is refused by git.
+	if _, err := testutil.RunGit(t, dir, "checkout", "main"); err != nil {
+		t.Fatalf("Failed to checkout main: %v", err)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop", "--fetch")
+	if err != nil {
+		t.Fatalf("integrate develop --fetch should stay non-fatal: %v\nOutput: %s", err, out)
+	}
+
+	if !strings.Contains(out, "Warning") {
+		t.Errorf("Expected a warning surfacing the failed parent fetch, got:\n%s", out)
+	}
+	if strings.Contains(out, "Fetch completed") {
+		t.Errorf("Expected NO \"Fetch completed\" when the parent fast-forward failed, got:\n%s", out)
+	}
+	// C still integrates into local main; R could not be fetched into the
+	// checked-out parent, so it is honestly absent rather than silently claimed.
+	if !integIsAncestor(t, dir, cCommit, "main") {
+		t.Errorf("Expected commit C (%s) integrated into main", cCommit)
+	}
+	if integIsAncestor(t, dir, rCommit, "main") {
+		t.Errorf("Expected R (%s) absent from local main after the refused fetch", rCommit)
+	}
+}


### PR DESCRIPTION
Adds a first-class `git flow integrate [<branch>]` command that merges a base branch upstream into its configured parent (e.g. `develop` → `main`) — the base-branch counterpart to `finish`, and the inverse of `update`.

`integrate` reuses finish's conflict-resumable merge → tag → auto-update machinery but never deletes, creates, or renames a branch, since base branches are permanent. It honors the branch type's resolved upstream strategy (overridable with `--squash`/`--rebase`), optionally tags the parent (`--tag <version>` both enables tagging and sets the name, `--notag` disables, and a configured tag with no resolvable name errors before merging), and auto-updates every `autoUpdate` child of the parent using each child's own downstream strategy. Merge state is persisted under a distinct `integrate` action so `--continue`/`--abort` resume correctly and never hijack an in-progress finish or update. An opt-in `--fetch` (default off) is the only remote interaction — no sync guard, no force. New surface is `cmd/integrate.go` plus integrate-specific option resolution in `internal/config/resolver.go` (reading the `gitflow.<branch>.integrate.*` namespace), typed validation errors in `internal/errors/errors.go`, and a parameterized finish step machine (`cmd/finish.go`) that terminates after child update instead of at branch deletion. Documented in a new `docs/git-flow-integrate.1.md` with config/index updates, and covered by 33 tests across six files spanning all 27 spec scenarios.

Closes #26
Refs #77

### Remarks

- Three-layer config precedence is respected: base branches default tag and fetch OFF (Layer 1, branch-type identity), `gitflow.<branch>.integrate.*` supplies operational defaults (Layer 2), and CLI flags always win (Layer 3).
- Known follow-up — reverse cross-command state guard is deliberately out of scope. `integrate` gates its own `--continue`/`--abort` on `state.Action == "integrate"`, but `finish`/`update` do not yet check `state.Action`, so they could resume an in-progress integrate. The spec lists changing finish/update behavior as Out of Scope, so this mirror-direction guard is deferred and should be tracked as a separate issue.
- `--rebase` on a permanent, shared base branch rewrites shared history. It is supported but intentionally flagged as a potentially disruptive effect.

**Review focus:**
- `cmd/integrate.go` — validation gates, source-branch existence check, state dispatch, and tag-name pre-check
- `cmd/finish.go` — the parameterized terminal step (`stepIntegrateDone`) and child-strategy-aware abort shared with finish
- `internal/config/resolver.go` — integrate-namespace resolution and integrate-specific Layer-1 defaults