### PR TITLE
feat(update): Scope --continue/--abort and make update resumable

### DIFF
--- a/cmd/continue_abort.go
+++ b/cmd/continue_abort.go
@@ -49,6 +49,20 @@ func refuseIfForeignOperation(cfg *config.Config, currentCommand string) error {
 		return nil
 	}
 
+	// Structural-completeness guard (mirrors the loadErr guard above). A state can
+	// parse and carry a recognized Action yet still be missing a critical field —
+	// e.g. a legacy pre-#143 update state with Action="update" but an empty
+	// BranchType. Such a state matches the owner check below and returns nil, after
+	// which the caller's IsMergeInProgress rejects the incomplete state via
+	// isStateValid and auto-clears the file while the git marker is still present —
+	// a destructive refusal. These are exactly the critical fields isStateValid
+	// requires, so refuse non-destructively before the owner check whenever any is
+	// empty. Valid new update/finish/integrate states always populate all three, so
+	// they fall through to the owner/foreign dispatch unchanged.
+	if rawState.BranchType == "" || rawState.FullBranchName == "" || rawState.CurrentStep == "" {
+		return &errors.UnrecognizedOperationError{BranchName: rawState.FullBranchName}
+	}
+
 	if rawState.Action == currentCommand {
 		// Own operation: the caller proceeds to its own continue/abort dispatch.
 		return nil

--- a/cmd/continue_abort.go
+++ b/cmd/continue_abort.go
@@ -17,14 +17,32 @@ import (
 // IsMergeInProgress auto-clear path), or the state is owned by currentCommand.
 //
 // An unknown or empty Action with a real git operation in progress is refused
-// non-destructively via UnrecognizedOperationError and never auto-cleared.
+// non-destructively via UnrecognizedOperationError and never auto-cleared. The
+// same applies when the state file exists but fails to parse (e.g. a truncated
+// write from a crash mid-save): if git is genuinely mid-operation the file must
+// not be destroyed, so it is refused rather than left to IsMergeInProgress, which
+// would delete it while the git marker is still present.
 func refuseIfForeignOperation(cfg *config.Config, currentCommand string) error {
-	rawState, _ := mergestate.LoadMergeState()
+	rawState, loadErr := mergestate.LoadMergeState()
+
+	gitInProgress := git.IsGitMergeInProgress() || git.IsGitRebaseInProgress() || git.IsGitSquashMergeInProgress()
+
+	if loadErr != nil {
+		// The state file exists but could not be parsed. If a real git operation
+		// is underway, refuse non-destructively so IsMergeInProgress does not
+		// auto-clear the file while the marker is still present. If nothing is in
+		// progress, it is a truly stale corrupt file with no active operation to
+		// protect — leave it to the normal auto-clear path.
+		if gitInProgress {
+			return &errors.UnrecognizedOperationError{}
+		}
+		return nil
+	}
+
 	if rawState == nil {
 		return nil
 	}
 
-	gitInProgress := git.IsGitMergeInProgress() || git.IsGitRebaseInProgress() || git.IsGitSquashMergeInProgress()
 	if !gitInProgress {
 		// No real operation underway: a stale state file. Let the normal
 		// IsMergeInProgress path detect and auto-clear it.

--- a/cmd/continue_abort.go
+++ b/cmd/continue_abort.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"github.com/gittower/git-flow-next/internal/config"
+	"github.com/gittower/git-flow-next/internal/errors"
+	"github.com/gittower/git-flow-next/internal/git"
+	"github.com/gittower/git-flow-next/internal/mergestate"
+)
+
+// refuseIfForeignOperation enforces the issue #143 invariant: a resumable command
+// (finish, update, integrate) must not touch an in-progress operation owned by a
+// different command. It reads the raw merge state (without the stale-clearing side
+// effect of IsMergeInProgress, which would drop a legitimately-in-progress state)
+// and, only when git is genuinely mid-operation, refuses a foreign owner with an
+// actionable, owner-named error. It returns nil when there is nothing to refuse:
+// no state, no real git operation in progress (stale state is left for the normal
+// IsMergeInProgress auto-clear path), or the state is owned by currentCommand.
+//
+// An unknown or empty Action with a real git operation in progress is refused
+// non-destructively via UnrecognizedOperationError and never auto-cleared.
+func refuseIfForeignOperation(cfg *config.Config, currentCommand string) error {
+	rawState, _ := mergestate.LoadMergeState()
+	if rawState == nil {
+		return nil
+	}
+
+	gitInProgress := git.IsGitMergeInProgress() || git.IsGitRebaseInProgress() || git.IsGitSquashMergeInProgress()
+	if !gitInProgress {
+		// No real operation underway: a stale state file. Let the normal
+		// IsMergeInProgress path detect and auto-clear it.
+		return nil
+	}
+
+	if rawState.Action == currentCommand {
+		// Own operation: the caller proceeds to its own continue/abort dispatch.
+		return nil
+	}
+
+	switch rawState.Action {
+	case "finish", "update", "integrate":
+		return &errors.MergeInProgressError{
+			Action:     rawState.Action,
+			BranchName: rawState.FullBranchName,
+			BranchType: topicTypeOrEmpty(cfg, rawState.BranchType),
+		}
+	default:
+		return &errors.UnrecognizedOperationError{BranchName: rawState.FullBranchName}
+	}
+}
+
+// topicTypeOrEmpty returns branchType when it names a configured topic branch
+// type, otherwise "". The owner-aware refusal message uses this to recommend the
+// topic-scoped command (git flow <type> update) only for real topic types, and
+// the base/top-level command (git flow update) for base branches.
+func topicTypeOrEmpty(cfg *config.Config, branchType string) string {
+	if bc, ok := cfg.Branches[branchType]; ok && bc.Type == string(config.BranchTypeTopic) {
+		return branchType
+	}
+	return ""
+}

--- a/cmd/finish.go
+++ b/cmd/finish.go
@@ -115,11 +115,24 @@ func executeFinish(branchType string, name string, continueOp bool, abortOp bool
 		return &errors.InvalidBranchTypeError{BranchType: branchType}
 	}
 
+	// Foreign-operation guard (#143): refuse a foreign in-progress update/integrate
+	// (or an unknown-Action state) before any dispatch, so finish never resumes or
+	// aborts an operation it does not own.
+	if err := refuseIfForeignOperation(cfg, "finish"); err != nil {
+		return err
+	}
+
 	// Check if there's a merge in progress
 	if mergestate.IsMergeInProgress() {
 		state, err := mergestate.LoadMergeState()
 		if err != nil {
 			return &errors.GitError{Operation: "load merge state", Err: err}
+		}
+
+		// Belt-and-suspenders: the guard above already refused any foreign state,
+		// so a state reaching here is a finish state.
+		if state.Action != "finish" {
+			return &errors.MergeInProgressError{Action: state.Action, BranchName: state.FullBranchName, BranchType: topicTypeOrEmpty(cfg, state.BranchType)}
 		}
 
 		// Get the branch config for the state's branch type
@@ -138,7 +151,7 @@ func executeFinish(branchType string, name string, continueOp bool, abortOp bool
 			return handleContinue(cfg, state, stateBranchConfig, resolvedOptions, mergeOptions)
 		}
 
-		return &errors.MergeInProgressError{BranchName: state.FullBranchName}
+		return &errors.MergeInProgressError{Action: "finish", BranchName: state.FullBranchName, BranchType: state.BranchType}
 	}
 
 	// Abort is forgiving: if there is no merge in progress (e.g. stale state

--- a/cmd/integrate.go
+++ b/cmd/integrate.go
@@ -62,15 +62,13 @@ func executeIntegrate(name string, continueOp bool, abortOp bool, tagOptions *co
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
 
-	// Foreign-state guard. Refuse to touch an in-progress finish or update.
-	// We load the raw state (without the stale-clearing side effect of
-	// IsMergeInProgress) and check whether git is genuinely mid-operation,
-	// because some operations (e.g. update) persist state without a BranchType,
-	// which IsMergeInProgress would otherwise treat as stale and clear.
-	if rawState, _ := mergestate.LoadMergeState(); rawState != nil && rawState.Action != "integrate" {
-		if git.IsGitMergeInProgress() || git.IsGitRebaseInProgress() || git.IsGitSquashMergeInProgress() {
-			return &errors.MergeInProgressError{BranchName: rawState.FullBranchName}
-		}
+	// Foreign-operation guard (#143): refuse a foreign in-progress finish/update
+	// (or an unknown-Action state) with an owner-named, actionable message before
+	// any dispatch. The shared guard reads raw state and checks git's real
+	// in-progress markers, since an update persists state IsMergeInProgress might
+	// otherwise treat as stale and clear.
+	if err := refuseIfForeignOperation(cfg, "integrate"); err != nil {
+		return err
 	}
 
 	// Merge-in-progress dispatch for integrate's own state.
@@ -79,8 +77,9 @@ func executeIntegrate(name string, continueOp bool, abortOp bool, tagOptions *co
 		if err != nil {
 			return &errors.GitError{Operation: "load merge state", Err: err}
 		}
+		// Belt-and-suspenders: the guard above already refused foreign state.
 		if state.Action != "integrate" {
-			return &errors.MergeInProgressError{BranchName: state.FullBranchName}
+			return &errors.MergeInProgressError{Action: state.Action, BranchName: state.FullBranchName, BranchType: topicTypeOrEmpty(cfg, state.BranchType)}
 		}
 		if abortOp {
 			return handleAbort(state)
@@ -98,7 +97,7 @@ func executeIntegrate(name string, continueOp bool, abortOp bool, tagOptions *co
 			branchConfig := cfg.Branches[state.BranchType]
 			return handleContinue(cfg, state, branchConfig, resolved, mergeOptions)
 		}
-		return &errors.MergeInProgressError{BranchName: state.FullBranchName}
+		return &errors.MergeInProgressError{Action: "integrate", BranchName: state.FullBranchName}
 	}
 
 	// No merge in progress: abort is a forgiving no-op, continue has nothing to

--- a/cmd/shorthand.go
+++ b/cmd/shorthand.go
@@ -65,24 +65,30 @@ func RegisterShorthandCommands() {
 	// Update
 	updateCmd := &cobra.Command{
 		Use:   "update",
-		Short: "Update the current topic branch from parent",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Short: "Update the current branch from its parent",
+		Run: func(cmd *cobra.Command, args []string) {
+			continueOp, _ := cmd.Flags().GetBool("continue")
+			abortOp, _ := cmd.Flags().GetBool("abort")
 			useRebase, _ := cmd.Flags().GetBool("rebase")
-			return executeShorthandUpdate(useRebase, args)
+			runShorthandUpdate(useRebase, continueOp, abortOp, args)
 		},
 	}
-	updateCmd.Flags().Bool("rebase", false, "Force rebase strategy instead of configured strategy")
+	addUpdateFlags(updateCmd)
 	rootCmd.AddCommand(updateCmd)
 
 	// Rebase (shorthand for update --rebase)
 	rebaseCmd := &cobra.Command{
 		Use:   "rebase",
-		Short: "Rebase the current topic branch from parent",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Short: "Rebase the current branch onto its parent",
+		Run: func(cmd *cobra.Command, args []string) {
 			// Always use rebase strategy for this shorthand
-			return executeShorthandUpdate(true, args)
+			continueOp, _ := cmd.Flags().GetBool("continue")
+			abortOp, _ := cmd.Flags().GetBool("abort")
+			runShorthandUpdate(true, continueOp, abortOp, args)
 		},
 	}
+	rebaseCmd.Flags().BoolP("continue", "c", false, "Continue the update operation after resolving conflicts")
+	rebaseCmd.Flags().BoolP("abort", "a", false, "Abort the update operation and return to the original state; a no-op success when none is in progress")
 	rootCmd.AddCommand(rebaseCmd)
 
 	// Rename
@@ -230,18 +236,23 @@ given, the current branch is integrated into its parent.`,
 	rootCmd.AddCommand(integrateCmd)
 }
 
-// executeShorthandUpdate handles the shared logic for both update and rebase shorthand commands
-func executeShorthandUpdate(useRebase bool, args []string) error {
+// runShorthandUpdate resolves the branch to update for the top-level update/rebase
+// surface and routes through UpdateCommand, which maps errors to exit codes and
+// exits (so the top-level surface exits 3, not main.go's exit 1). A topic current
+// branch is updated by its type; otherwise the current or named base branch is
+// used (branchType == "").
+func runShorthandUpdate(useRebase, continueOp, abortOp bool, args []string) {
 	branchType, name, err := detectBranchTypeAndName()
 	if err == nil {
-		return executeUpdate(branchType, name, useRebase)
+		UpdateCommand(branchType, name, useRebase, continueOp, abortOp)
+		return
 	}
-	// Fallback to original if not topic
+	// Not a topic branch: fall back to the current or named base branch.
 	var branchName string
 	if len(args) > 0 {
 		branchName = args[0]
 	}
-	return executeUpdate("", branchName, useRebase)
+	UpdateCommand("", branchName, useRebase, continueOp, abortOp)
 }
 
 // detectBranchTypeAndName detects type and name from current branch

--- a/cmd/topicbranch.go
+++ b/cmd/topicbranch.go
@@ -261,26 +261,20 @@ func registerBranchCommand(branchType string) {
 		Use:     "update [name]",
 		Short:   fmt.Sprintf("Update a %s branch with changes from its parent branch", branchType),
 		Long:    fmt.Sprintf("Update a %s branch with changes from its parent branch using the configured downstream strategy", branchType),
-		Example: fmt.Sprintf("  git flow %s update my-feature", branchType),
+		Example: fmt.Sprintf("  git flow %s update my-feature\n  git flow %s update --continue\n  git flow %s update --abort", branchType, branchType, branchType),
 		Args:    cobra.MaximumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: func(cmd *cobra.Command, args []string) {
 			var name string
 			if len(args) > 0 {
 				name = args[0]
 			}
-			if err := executeUpdate(branchType, name, false); err != nil {
-				var exitCode errors.ExitCode
-				if flowErr, ok := err.(errors.Error); ok {
-					exitCode = flowErr.ExitCode()
-				} else {
-					exitCode = errors.ExitCodeGitError
-				}
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				os.Exit(int(exitCode))
-			}
-			return nil
+			continueOp, _ := cmd.Flags().GetBool("continue")
+			abortOp, _ := cmd.Flags().GetBool("abort")
+			useRebase, _ := cmd.Flags().GetBool("rebase")
+			UpdateCommand(branchType, name, useRebase, continueOp, abortOp)
 		},
 	}
+	addUpdateFlags(updateCmd)
 	branchCmd.AddCommand(updateCmd)
 
 	// Add delete subcommand
@@ -416,6 +410,15 @@ started by someone else.`, branchType, branchType),
 func init() {
 	// Register topic branch commands
 	RegisterTopicBranchCommands()
+}
+
+// addUpdateFlags adds the update command's operation-control and strategy flags.
+// Shared by both update surfaces (topic and top-level) so --continue/--abort/--rebase
+// behave identically. Mirrors finish/integrate wording.
+func addUpdateFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolP("continue", "c", false, "Continue the update operation after resolving conflicts")
+	cmd.Flags().BoolP("abort", "a", false, "Abort the update operation and return to the original state; a no-op success when none is in progress")
+	cmd.Flags().Bool("rebase", false, "Force rebase strategy instead of the configured strategy")
 }
 
 // addFinishFlags adds common finish flags to the given Cobra command

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -244,14 +244,11 @@ func handleUpdateContinue(state *mergestate.MergeState) error {
 	case strategyRebase:
 		err := git.RebaseContinue()
 		if err != nil {
-			if strings.Contains(err.Error(), "No rebase in progress") {
-				// Rebase already complete; proceed to clear state.
-			} else if strings.Contains(err.Error(), "conflict") {
+			if strings.Contains(err.Error(), "conflict") {
 				// A later replayed commit conflicts: stay resumable.
 				return &errors.UnresolvedConflictsError{}
-			} else {
-				return &errors.GitError{Operation: "continue rebase", Err: err}
 			}
+			return &errors.GitError{Operation: "continue rebase", Err: err}
 		}
 
 	case strategySquash:

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/gittower/git-flow-next/internal/config"
@@ -17,8 +18,29 @@ import (
 // 2. As subcommands of topic branches in topicbranch.go for "git flow <topic> update"
 // This file only contains the shared executeUpdate function used by both.
 
-// executeUpdate updates a branch with changes from its parent branch
-func executeUpdate(branchType string, name string, useRebase bool) error {
+// UpdateCommand is the public entry point for the update command on both
+// surfaces (topic "git flow <type> update" and top-level "git flow update"). It
+// maps git-flow errors to their exit codes and exits non-zero on failure. Routing
+// through this wrapper (instead of returning the error via RunE to main.go, which
+// forces exit 1) is what makes the top-level surface exit 3 for merge-in-progress,
+// no-merge, and unresolved-conflict conditions, consistent with finish/integrate.
+func UpdateCommand(branchType string, name string, useRebase, continueOp, abortOp bool) {
+	if err := executeUpdate(branchType, name, useRebase, continueOp, abortOp); err != nil {
+		var exitCode errors.ExitCode
+		if flowErr, ok := err.(errors.Error); ok {
+			exitCode = flowErr.ExitCode()
+		} else {
+			exitCode = errors.ExitCodeGitError
+		}
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(int(exitCode))
+	}
+}
+
+// executeUpdate updates a branch with changes from its parent branch. It owns the
+// resumable dispatch for update: a foreign-operation guard, its own
+// --continue/--abort handling, and the initial update attempt.
+func executeUpdate(branchType string, name string, useRebase, continueOp, abortOp bool) error {
 	// Validate that git-flow is initialized
 	initialized, err := config.IsInitialized()
 	if err != nil {
@@ -32,6 +54,43 @@ func executeUpdate(branchType string, name string, useRebase bool) error {
 	cfg, err := config.LoadConfig()
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
+	}
+
+	// Foreign-operation guard (#143): refuse a foreign in-progress finish/integrate
+	// (or an unknown-Action state) before dispatch, so update never resumes or
+	// aborts an operation it does not own.
+	if err := refuseIfForeignOperation(cfg, "update"); err != nil {
+		return err
+	}
+
+	// Own-state dispatch: resume/abort an update we own.
+	if mergestate.IsMergeInProgress() {
+		state, err := mergestate.LoadMergeState()
+		if err != nil {
+			return &errors.GitError{Operation: "load merge state", Err: err}
+		}
+		// Belt-and-suspenders: the guard above already refused foreign state.
+		if state.Action != "update" {
+			return &errors.MergeInProgressError{Action: state.Action, BranchName: state.FullBranchName, BranchType: topicTypeOrEmpty(cfg, state.BranchType)}
+		}
+		if abortOp {
+			return handleAbort(state)
+		}
+		if continueOp {
+			return handleUpdateContinue(state)
+		}
+		// Plain invocation over our own in-progress update: report it rather than
+		// silently restarting.
+		return &errors.MergeInProgressError{Action: "update", BranchName: state.FullBranchName, BranchType: topicTypeOrEmpty(cfg, state.BranchType)}
+	}
+
+	// Nothing in progress: abort is a forgiving no-op, continue has nothing to
+	// resume (matches finish/integrate dispatch).
+	if abortOp {
+		return nil
+	}
+	if continueOp {
+		return &errors.NoMergeInProgressError{}
 	}
 
 	var branchName string
@@ -118,9 +177,20 @@ func executeUpdate(branchType string, name string, useRebase bool) error {
 		strategy = "rebase"
 	}
 
+	// Store a resolvable identity in BranchType so the saved state survives
+	// isStateValid and --continue/--abort can re-derive parent/strategy: the
+	// detected topic type for topic branches, else the base branch key.
+	stateBranchType := detectedBranchType
+	if stateBranchType == "" {
+		if _, ok := cfg.Branches[branchName]; ok {
+			stateBranchType = branchName
+		}
+	}
+
 	// Create merge state
 	state := &mergestate.MergeState{
 		Action:         "update",
+		BranchType:     stateBranchType,
 		BranchName:     branchName,
 		ParentBranch:   parentBranch,
 		MergeStrategy:  strategy,
@@ -159,6 +229,52 @@ func executeUpdate(branchType string, name string, useRebase bool) error {
 
 	// No branch type detected, run without hooks
 	return update.UpdateBranchFromParent(branchName, parentBranch, strategy, true, state)
+}
+
+// handleUpdateContinue completes an in-progress update after conflict resolution.
+// Unlike finish, it completes ONLY the merge/rebase — no tag, no child update, no
+// branch deletion — then clears the merge state. A rebase that re-conflicts on a
+// later replayed commit stays resumable (UnresolvedConflictsError, state kept).
+func handleUpdateContinue(state *mergestate.MergeState) error {
+	if git.HasConflicts() {
+		return &errors.UnresolvedConflictsError{}
+	}
+
+	switch state.MergeStrategy {
+	case strategyRebase:
+		err := git.RebaseContinue()
+		if err != nil {
+			if strings.Contains(err.Error(), "No rebase in progress") {
+				// Rebase already complete; proceed to clear state.
+			} else if strings.Contains(err.Error(), "conflict") {
+				// A later replayed commit conflicts: stay resumable.
+				return &errors.UnresolvedConflictsError{}
+			} else {
+				return &errors.GitError{Operation: "continue rebase", Err: err}
+			}
+		}
+
+	case strategySquash:
+		// Squash-strategy update resume is a known gap: there is no MERGE_HEAD to
+		// commit and handleAbort cannot roll it back. Do not attempt completion.
+		return &errors.GitError{
+			Operation: "continue squash-strategy update",
+			Err:       fmt.Errorf("resuming a squash-strategy update is not supported; complete the commit manually or run 'git reset --merge' and re-run the update"),
+		}
+
+	default: // merge
+		mergeMsg := fmt.Sprintf("Merge branch '%s' into %s", state.ParentBranch, state.FullBranchName)
+		if err := git.Commit(mergeMsg, state.NoVerify); err != nil {
+			return &errors.GitError{Operation: "commit merge", Err: err}
+		}
+	}
+
+	if err := mergestate.ClearMergeState(); err != nil {
+		return &errors.GitError{Operation: "clear merge state", Err: err}
+	}
+
+	fmt.Printf("Successfully updated branch '%s' from '%s'\n", state.FullBranchName, state.ParentBranch)
+	return nil
 }
 
 // detectBranchTypeFromName detects the branch type and short name from a full branch name

--- a/docs/git-flow-finish.1.md
+++ b/docs/git-flow-finish.1.md
@@ -35,10 +35,10 @@ The operation maintains a persistent state file that allows it to resume after c
 ### Operation Control
 
 **--continue**, **-c**
-: Continue the finish operation after resolving merge conflicts
+: Continue the finish operation after resolving merge conflicts. This acts only on an in-progress finish. If an **update** or **integrate** operation is in progress instead, finish refuses non-destructively, names the owning operation, prints its resume/abort commands, and exits 3 without touching it.
 
 **--abort**, **-a**
-: Abort the finish operation and return to the original state. When no finish operation is in progress, **--abort** is a no-op and exits successfully.
+: Abort the finish operation and return to the original state. When no finish operation is in progress, **--abort** is a no-op and exits successfully. Like **--continue**, it acts only on a finish operation: a foreign in-progress update or integrate is refused (exit 3) rather than aborted.
 
 **--force**, **-f**
 : Force finish: ignore fetch failures, skip the remote sync check, and allow finishing non-standard branches. The fetch is still attempted, but any failure is ignored rather than fatal, and the safety check that prevents finishing when the local branch is ahead of, behind, or diverged from its remote tracking branch is bypassed.

--- a/docs/git-flow-integrate.1.md
+++ b/docs/git-flow-integrate.1.md
@@ -34,10 +34,10 @@ A persistent state file lets the operation resume after conflicts. If a conflict
 ### Operation Control
 
 **--continue**, **-c**
-: Continue the integrate operation after resolving merge conflicts.
+: Continue the integrate operation after resolving merge conflicts. This acts only on an in-progress integrate. If a **finish** or **update** operation is in progress instead, integrate refuses non-destructively, names the owning operation, prints its resume/abort commands, and exits 3 without touching it.
 
 **--abort**, **-a**
-: Abort the integrate operation and return to the original state. When no integrate operation is in progress, **--abort** is a no-op and exits successfully. A completed upstream merge and tag are preserved when aborting during a child update.
+: Abort the integrate operation and return to the original state. When no integrate operation is in progress, **--abort** is a no-op and exits successfully. A completed upstream merge and tag are preserved when aborting during a child update. Like **--continue**, it acts only on an integrate operation: a foreign in-progress finish or update is refused (exit 3) rather than aborted.
 
 ### Tag Creation
 

--- a/docs/git-flow-update.1.md
+++ b/docs/git-flow-update.1.md
@@ -12,9 +12,11 @@ git-flow-update - Update topic branches with parent changes
 
 ## DESCRIPTION
 
-Update a topic branch with the latest changes from its parent branch using the configured downstream merge strategy. This command works with any topic branch type (feature, release, hotfix, support, or custom types).
+Update a branch with the latest changes from its parent branch using the configured downstream merge strategy. On the topic surface (**git-flow** *topic* **update**) it works with any topic branch type (feature, release, hotfix, support, or custom types); on the top-level surface (**git-flow update**) it also updates the current base branch from its parent (for example, **develop** from **main**).
 
-The update operation merges or rebases changes from the parent branch into the topic branch, keeping the topic branch current with the latest development.
+The update operation merges or rebases changes from the parent branch into the target branch, keeping it current with the latest development.
+
+If a conflict occurs, the update saves a persistent state file and can be resumed with **--continue** or rolled back with **--abort** after resolving the conflict — the same resume/abort model as **git-flow finish** and **git-flow integrate**. The **--continue**/**--abort** flags act only on an in-progress update; an in-progress finish or integrate is never affected.
 
 ## ARGUMENTS
 
@@ -28,6 +30,12 @@ The update operation merges or rebases changes from the parent branch into the t
 
 **--rebase**
 : Force rebase strategy instead of the configured downstream strategy
+
+**--continue**, **-c**
+: Continue the update operation after resolving merge conflicts. This acts only on an in-progress update. If a **finish** or **integrate** operation is in progress instead, update refuses non-destructively, names the owning operation, prints its resume/abort commands, and exits 3 without touching it. With nothing in progress, **--continue** reports "no merge in progress" and exits 3.
+
+**--abort**, **-a**
+: Abort the update operation and return to the original state. When no update operation is in progress, **--abort** is a no-op and exits successfully. Like **--continue**, it acts only on an update: a foreign in-progress finish or integrate is refused (exit 3) rather than aborted.
 
 ## MERGE STRATEGIES
 
@@ -75,6 +83,24 @@ Update current branch with rebase:
 git flow update --rebase
 ```
 
+### Resume or Abort After a Conflict
+
+Continue an update after resolving conflicts:
+```bash
+git flow feature update --continue my-feature
+```
+
+Abort an in-progress update and restore the pre-update state:
+```bash
+git flow feature update --abort my-feature
+```
+
+Resume or abort a base-branch update (top-level surface):
+```bash
+git flow update --continue
+git flow update --abort
+```
+
 ### Typical Workflows
 
 Before finishing a long-running feature:
@@ -98,24 +124,37 @@ git flow hotfix update critical-fix
 
 ## CONFLICT RESOLUTION
 
-When conflicts occur during update:
+When a conflict occurs, the update saves its state and stops so you can resolve it. Resume or roll back with git-flow's own **--continue**/**--abort** rather than raw Git commands, so the merge state is cleared correctly:
 
 ```bash
 # Start update
 git flow feature update my-feature
 
-# Conflicts occur - Git will show conflict markers
-# Edit files to resolve conflicts
+# Conflicts occur - Git shows conflict markers.
+# Edit files to resolve, then stage them:
 vim conflicted-file.js
-
-# Stage resolved files
 git add conflicted-file.js
 
-# Complete the merge/rebase
-git commit  # for merge strategy
-# or
-git rebase --continue  # for rebase strategy
+# Complete the update (merge or rebase, whichever the strategy uses):
+git flow feature update --continue my-feature
 ```
+
+To discard the in-progress update and return to the pre-update state:
+
+```bash
+git flow feature update --abort my-feature
+```
+
+For a base branch on the top-level surface, use the same flags without a topic type:
+
+```bash
+git flow update --continue
+git flow update --abort
+```
+
+A rebase-strategy update that conflicts again on a later commit stays resumable: resolve, stage, and run **--continue** again. **--abort** with nothing in progress is a forgiving no-op (exit 0).
+
+**Known gap:** resuming a **squash**-strategy update is not supported (there is no merge commit to complete and **--abort** cannot roll it back). Complete or discard a squash-strategy conflict with raw Git, then re-run the update.
 
 ## CONFIGURATION
 
@@ -160,22 +199,22 @@ Each topic branch type updates from its configured parent:
 ## EXIT STATUS
 
 **0**
-: Successful update operation
+: Successful update, or **--abort** with nothing in progress (forgiving no-op)
 
 **1**
-: Topic branch not found
+: git-flow is not initialized
 
 **2**
-: Git operation failed (conflicts, etc.)
+: Invalid input (e.g. unknown branch type)
 
 **3**
-: Invalid branch name or configuration
-
-**4**
-: Merge conflicts require manual resolution
+: A Git operation failed, a merge or rebase is already in progress, unresolved conflicts remain, or there is no in-progress operation to continue
 
 **5**
-: Branch is not a topic branch
+: Target or parent branch not found
+
+**6**
+: Validation error
 
 ## SEE ALSO
 
@@ -186,6 +225,6 @@ Each topic branch type updates from its configured parent:
 - The **--rebase** flag always overrides configured strategy
 - Update operations preserve your local commits while integrating parent changes
 - Use **git flow update** shorthand when on a topic branch
-- Conflicts are resolved the same way as standard Git merge/rebase conflicts
+- On conflict, resume with **git flow ... update --continue** or roll back with **--abort** rather than raw Git, so the saved state is cleared correctly
 - Regular updates keep topic branches easier to merge when finishing
 - Update from parent before finishing long-running branches

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -200,6 +200,12 @@ type UnrecognizedOperationError struct {
 }
 
 func (e *UnrecognizedOperationError) Error() string {
+	// BranchName is best-effort: the loadErr/unparseable path cannot recover a
+	// name and passes "". Omit the "for '<name>'" clause entirely in that case
+	// rather than printing an unhelpful "for ''".
+	if e.BranchName == "" {
+		return "an unrecognized git-flow operation is in progress; resolve it manually or remove the state file (.git/gitflow/state/merge.json)"
+	}
 	return fmt.Sprintf("an unrecognized git-flow operation is in progress for '%s'; resolve it manually or remove the state file (.git/gitflow/state/merge.json)", e.BranchName)
 }
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -28,11 +28,6 @@ type Error interface {
 	ExitCode() ExitCode
 }
 
-// ExitCoder is an interface for errors that can provide an exit code
-type ExitCoder interface {
-	ExitCode() uint8
-}
-
 // NotInitializedError indicates that git-flow is not initialized
 type NotInitializedError struct{}
 
@@ -139,17 +134,51 @@ func (e *GitError) Unwrap() error {
 	return e.Err
 }
 
-// MergeInProgressError represents an error when a merge is already in progress
+// MergeInProgressError represents an error when a git-flow operation is already
+// in progress. It is owner-aware: Action names the owning command ("finish",
+// "update", "integrate") and BranchType (when the owner is a topic type) lets
+// the message print the exact resume/abort commands for that owner.
 type MergeInProgressError struct {
-	BranchName string
+	Action     string // owning command: "finish", "update", or "integrate"
+	BranchName string // full branch name the operation is running on
+	BranchType string // topic branch type when applicable; empty for base/top-level
+}
+
+// recoveryCommand returns the base git-flow command that owns the in-progress
+// operation (without the --continue/--abort suffix), tailored to the owner:
+//   - finish:    git flow <type> finish
+//   - integrate: git flow integrate
+//   - update:    git flow <type> update (topic) or git flow update (base/top-level)
+func (e *MergeInProgressError) recoveryCommand() string {
+	switch e.Action {
+	case "finish":
+		if e.BranchType != "" {
+			return fmt.Sprintf("git flow %s finish", e.BranchType)
+		}
+		return "git flow finish"
+	case "integrate":
+		return "git flow integrate"
+	case "update":
+		if e.BranchType != "" {
+			return fmt.Sprintf("git flow %s update", e.BranchType)
+		}
+		return "git flow update"
+	default:
+		return "git flow"
+	}
 }
 
 func (e *MergeInProgressError) Error() string {
-	return fmt.Sprintf("a merge is already in progress for branch '%s'. Use --continue or --abort", e.BranchName)
+	base := e.recoveryCommand()
+	return fmt.Sprintf(`a %s operation is already in progress for '%s'.
+It must be resolved before running another git-flow operation.
+  To resume: %s --continue
+  To abort:  %s --abort`,
+		e.Action, e.BranchName, base, base)
 }
 
-func (e *MergeInProgressError) ExitCode() uint8 {
-	return 1
+func (e *MergeInProgressError) ExitCode() ExitCode {
+	return ExitCodeGitError
 }
 
 // NoMergeInProgressError represents an error when no merge is in progress
@@ -159,8 +188,23 @@ func (e *NoMergeInProgressError) Error() string {
 	return "no merge in progress. Nothing to continue or abort"
 }
 
-func (e *NoMergeInProgressError) ExitCode() uint8 {
-	return 1
+func (e *NoMergeInProgressError) ExitCode() ExitCode {
+	return ExitCodeGitError
+}
+
+// UnrecognizedOperationError represents an in-progress git-flow state whose
+// Action is empty or unknown. It is never auto-cleared; the user must resolve it
+// manually or remove the state file.
+type UnrecognizedOperationError struct {
+	BranchName string
+}
+
+func (e *UnrecognizedOperationError) Error() string {
+	return fmt.Sprintf("an unrecognized git-flow operation is in progress for '%s'; resolve it manually or remove the state file (.git/gitflow/state/merge.json)", e.BranchName)
+}
+
+func (e *UnrecognizedOperationError) ExitCode() ExitCode {
+	return ExitCodeGitError
 }
 
 // InvalidBranchNameError represents an error when an invalid branch name is provided
@@ -223,8 +267,8 @@ func (e *UnresolvedConflictsError) Error() string {
 	return "there are still unresolved conflicts. Resolve them and try again"
 }
 
-func (e *UnresolvedConflictsError) ExitCode() uint8 {
-	return 1
+func (e *UnresolvedConflictsError) ExitCode() ExitCode {
+	return ExitCodeGitError
 }
 
 // RemoteBranchNotFoundError indicates the branch doesn't exist on the remote

--- a/internal/mergestate/mergestate.go
+++ b/internal/mergestate/mergestate.go
@@ -138,6 +138,14 @@ func ClearMergeState() error {
 // isStateValid checks whether a loaded merge state is still meaningful by
 // validating it against the actual git repository state. This detects stale
 // state files left by manual intervention, crashes, or interrupted operations.
+//
+// Update states are first-class here (#143): the update command now persists a
+// resolvable BranchType (topic type or base branch key) alongside a "merge" step,
+// so a genuine update conflict passes this check rather than being auto-cleared.
+// The empty-BranchType auto-clear below is intentionally retained — the foreign
+// guard (refuseIfForeignOperation) reads the raw state directly and refuses an
+// unknown/empty Action before IsMergeInProgress ever runs, so that case never
+// reaches the auto-clear path.
 func isStateValid(state *MergeState) bool {
 	// Critical fields must be non-empty
 	if state.BranchType == "" || state.FullBranchName == "" || state.CurrentStep == "" {

--- a/test/cmd/continue_abort_scope_test.go
+++ b/test/cmd/continue_abort_scope_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gittower/git-flow-next/internal/errors"
 	"github.com/gittower/git-flow-next/test/testutil"
 )
 
@@ -732,4 +733,84 @@ func TestTopLevelUpdateForeignRefusalExitsThree(t *testing.T) {
 	setupIntegrateInProgress(t, dir)
 
 	assertNonDestructiveRefusal(t, dir, []string{"update", "--continue"}, "integrate", markerMergeHead)
+}
+
+// setupLegacyUpdateState leaves the repo in a genuine update merge conflict, then
+// overwrites the saved state with a legacy pre-#143 update state: valid JSON with a
+// recognized Action="update" but an empty BranchType (one of the critical fields
+// #143 now populates), keeping a real FullBranchName and CurrentStep="merge".
+// MERGE_HEAD stays present, so the state is parseable and owner-matched yet
+// structurally incomplete — the case that previously fell through to the owner
+// path and triggered IsMergeInProgress's destructive auto-clear.
+func setupLegacyUpdateState(t *testing.T, dir string) {
+	t.Helper()
+	setupUpdateInProgressMerge(t, dir)
+	state, err := testutil.LoadMergeState(t, dir)
+	if err != nil || state == nil {
+		t.Fatalf("expected saved update state, err=%v", err)
+	}
+	state.BranchType = ""
+	state.FullBranchName = "feature/x"
+	state.CurrentStep = "merge"
+	testutil.WriteMergeState(t, dir, state)
+	if !integMergeHeadExists(t, dir) {
+		t.Fatalf("expected MERGE_HEAD still present after rewriting state")
+	}
+}
+
+// TestLegacyUpdateStateRefusesOwnerContinueNonDestructively verifies that the OWNER
+// (feature update --continue) is refused non-destructively when the state is a legacy
+// pre-#143 update state (recognized Action="update" but empty BranchType). Without the
+// structural-completeness guard the owner check would match, the caller's
+// IsMergeInProgress would reject the empty BranchType and DELETE the state file while
+// MERGE_HEAD is still present (a destructive refusal).
+// Steps:
+//  1. Sets up a genuine update merge conflict, then overwrites the state with a
+//     legacy update state (Action=update, BranchType="", CurrentStep=merge).
+//  2. Runs 'git flow feature update --continue x' (the owner surface).
+//  3. Verifies exit 3, a generic unrecognized-operation refusal, state bytes
+//     byte-identical, MERGE_HEAD kept, HEAD/branch/refs unchanged.
+func TestLegacyUpdateStateRefusesOwnerContinueNonDestructively(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupLegacyUpdateState(t, dir)
+
+	assertUnparseableStateRefusal(t, dir, []string{"feature", "update", "--continue", "x"})
+}
+
+// TestLegacyUpdateStateRefusesOwnerAbortNonDestructively verifies the same
+// non-destructive refusal for the owner --abort surface: a structurally-incomplete
+// legacy update state over an active git merge must not be auto-cleared, and the git
+// operation is left untouched (exit 3, not a silent no-op).
+// Steps:
+//  1. Sets up a genuine update merge conflict, then overwrites the state with a
+//     legacy update state (Action=update, BranchType="", CurrentStep=merge).
+//  2. Runs 'git flow feature update --abort x' (the owner surface).
+//  3. Verifies exit 3, a generic unrecognized-operation refusal, state bytes
+//     byte-identical, MERGE_HEAD kept, HEAD/branch/refs unchanged.
+func TestLegacyUpdateStateRefusesOwnerAbortNonDestructively(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupLegacyUpdateState(t, dir)
+
+	assertUnparseableStateRefusal(t, dir, []string{"feature", "update", "--abort", "x"})
+}
+
+// TestUnrecognizedOperationErrorOmitsEmptyBranchName verifies the cosmetic fix: when
+// BranchName is empty (the loadErr/unparseable path constructs UnrecognizedOperationError{}),
+// the message omits the "for '<name>'" clause entirely rather than printing "for ”".
+// When BranchName is set, the message still names the branch.
+func TestUnrecognizedOperationErrorOmitsEmptyBranchName(t *testing.T) {
+	empty := (&errors.UnrecognizedOperationError{}).Error()
+	if strings.Contains(empty, "for ''") {
+		t.Errorf("empty-BranchName message must not contain \"for ''\", got:\n%s", empty)
+	}
+	if !strings.Contains(empty, "unrecognized git-flow operation") {
+		t.Errorf("expected unrecognized-operation message, got:\n%s", empty)
+	}
+
+	named := (&errors.UnrecognizedOperationError{BranchName: "feature/x"}).Error()
+	if !strings.Contains(named, "for 'feature/x'") {
+		t.Errorf("expected named clause \"for 'feature/x'\", got:\n%s", named)
+	}
 }

--- a/test/cmd/continue_abort_scope_test.go
+++ b/test/cmd/continue_abort_scope_test.go
@@ -388,11 +388,11 @@ func TestFinishConflictRefusesUpdateAbort(t *testing.T) {
 // TestUpdateConflictRefusesFinishAbort verifies feature finish --abort is refused
 // over an update conflict (the core bug fix) and the update owner stays abortable.
 // Steps:
-// 1. Sets up an update merge conflict (Action=update, MERGE_HEAD present).
-// 2. Runs 'git flow feature finish --abort x'.
-// 3. Verifies non-destructive refusal naming the update owner (set F, exit 3);
-//    the update merge is NOT aborted.
-// 4. Runs 'git flow feature update --abort x' and verifies it cleanly aborts.
+//  1. Sets up an update merge conflict (Action=update, MERGE_HEAD present).
+//  2. Runs 'git flow feature finish --abort x'.
+//  3. Verifies non-destructive refusal naming the update owner (set F, exit 3);
+//     the update merge is NOT aborted.
+//  4. Runs 'git flow feature update --abort x' and verifies it cleanly aborts.
 func TestUpdateConflictRefusesFinishAbort(t *testing.T) {
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
@@ -610,13 +610,100 @@ func TestBogusActionRefusedNonDestructively(t *testing.T) {
 	assertUnrecognizedRefusal(t, dir, []string{"integrate", "--continue"})
 }
 
+// writeRawState overwrites the merge-state file with raw bytes, simulating a
+// truncated JSON write from a crash mid-save. It bypasses the normal marshaller so
+// the file exists but fails to parse.
+func writeRawState(t *testing.T, dir, content string) {
+	t.Helper()
+	p := filepath.Join(integGitDir(t, dir), "gitflow", "state", "merge.json")
+	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write raw state file: %v", err)
+	}
+}
+
+// assertUnparseableStateRefusal runs cmdArgs against a genuine git operation whose
+// git-flow state file is unparseable (truncated). It asserts the spec's set F for
+// the unrecognized case: exit 3, a generic "unrecognized git-flow operation"
+// message, the state-file bytes byte-identical, MERGE_HEAD still present, and the
+// current branch, HEAD, and all refs unchanged. Nothing is auto-cleared.
+func assertUnparseableStateRefusal(t *testing.T, dir string, cmdArgs []string) {
+	t.Helper()
+	stateBefore := readStateBytes(t, dir)
+	branchBefore := symbolicHead(t, dir)
+	headBefore := integRevParse(t, dir, "HEAD")
+	refsBefore := showRef(t, dir)
+	if !integMergeHeadExists(t, dir) {
+		t.Fatalf("precondition failed: MERGE_HEAD not present before refusal")
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, cmdArgs...)
+	if code := scopeExitCode(err); code != 3 {
+		t.Fatalf("expected exit 3, got %d (err=%v)\n%s", code, err, out)
+	}
+	if !strings.Contains(out, "unrecognized git-flow operation") {
+		t.Errorf("expected 'unrecognized git-flow operation' message, got:\n%s", out)
+	}
+	if got := readStateBytes(t, dir); got != stateBefore {
+		t.Errorf("state file changed (should be byte-identical).\nbefore: %s\nafter:  %s", stateBefore, got)
+	}
+	if !integMergeHeadExists(t, dir) {
+		t.Errorf("MERGE_HEAD missing after refusal (state was destructively cleared)")
+	}
+	if got := symbolicHead(t, dir); got != branchBefore {
+		t.Errorf("current branch changed: before %q, after %q", branchBefore, got)
+	}
+	if got := integRevParse(t, dir, "HEAD"); got != headBefore {
+		t.Errorf("HEAD moved: before %s, after %s", headBefore, got)
+	}
+	if got := showRef(t, dir); got != refsBefore {
+		t.Errorf("refs changed.\nbefore:\n%s\nafter:\n%s", refsBefore, got)
+	}
+}
+
+// TestTruncatedStateRefusesContinueNonDestructively verifies that --continue over a
+// genuine git operation whose state file is truncated/unparseable is refused
+// non-destructively, rather than falling through to IsMergeInProgress and deleting
+// the state file while the git marker is still present (destructive refusal).
+// Steps:
+//  1. Sets up a finish merge conflict (MERGE_HEAD present), then overwrites the
+//     state file with truncated JSON.
+//  2. Runs 'git flow feature finish --continue x'.
+//  3. Verifies exit 3, a generic unrecognized-operation refusal, state bytes
+//     byte-identical, MERGE_HEAD kept, HEAD/branch/refs unchanged.
+func TestTruncatedStateRefusesContinueNonDestructively(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupFinishInProgress(t, dir)
+	writeRawState(t, dir, `{"action":"finish","branchType":"fea`)
+
+	assertUnparseableStateRefusal(t, dir, []string{"feature", "finish", "--continue", "x"})
+}
+
+// TestTruncatedStateRefusesAbortNonDestructively verifies the same non-destructive
+// refusal for --abort: a truncated state file over an active git merge must not be
+// auto-cleared, and the git operation is left untouched (exit 3, not a silent no-op).
+// Steps:
+//  1. Sets up a finish merge conflict (MERGE_HEAD present), then overwrites the
+//     state file with truncated JSON.
+//  2. Runs 'git flow feature finish --abort x'.
+//  3. Verifies exit 3, a generic unrecognized-operation refusal, state bytes
+//     byte-identical, MERGE_HEAD kept, HEAD/branch/refs unchanged.
+func TestTruncatedStateRefusesAbortNonDestructively(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupFinishInProgress(t, dir)
+	writeRawState(t, dir, `{"action":"finish","branchType":"fea`)
+
+	assertUnparseableStateRefusal(t, dir, []string{"feature", "finish", "--abort", "x"})
+}
+
 // TestForeignRefusalMessageContent verifies the foreign refusal message names the
 // owner and prints the exact recovery commands.
 // Steps:
-// 1. Sets up an integrate merge conflict (Action=integrate).
-// 2. Runs 'git flow feature finish --continue x'.
-// 3. Verifies the message contains 'integrate', 'git flow integrate --continue',
-//    and 'git flow integrate --abort'.
+//  1. Sets up an integrate merge conflict (Action=integrate).
+//  2. Runs 'git flow feature finish --continue x'.
+//  3. Verifies the message contains 'integrate', 'git flow integrate --continue',
+//     and 'git flow integrate --abort'.
 func TestForeignRefusalMessageContent(t *testing.T) {
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)

--- a/test/cmd/continue_abort_scope_test.go
+++ b/test/cmd/continue_abort_scope_test.go
@@ -1,0 +1,648 @@
+package cmd_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// =============================================================================
+// Shared setup + assertion helpers for issue #143: --continue/--abort scope.
+//
+// These helpers set up the three "owner" in-progress states used repeatedly by
+// the foreign-refusal scenarios, and implement the spec's non-destructive
+// assertion set F. They live here (package cmd_test) so every scope/update test
+// file can use them, alongside the integrate_test.go helpers (integRevParse,
+// integMergeHeadExists, integRebaseInProgress, integStateExists, integAddCommit,
+// integGitDir, integSetupConflict).
+// =============================================================================
+
+const (
+	markerMergeHead = "MERGE_HEAD"
+	markerRebaseDir = "rebase-merge"
+)
+
+// setupFinishInProgress leaves the repo in a finish merge conflict: Action=finish,
+// .git/MERGE_HEAD present, HEAD on develop.
+func setupFinishInProgress(t *testing.T, dir string) {
+	t.Helper()
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("init failed: %v\n%s", err, out)
+	}
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "start", "x"); err != nil {
+		t.Fatalf("feature start failed: %v\n%s", err, out)
+	}
+	integAddCommit(t, dir, "feature/x", "c.txt", "feature\n", "feature c")
+	integAddCommit(t, dir, "develop", "c.txt", "develop\n", "develop c")
+	testutil.RunGit(t, dir, "checkout", "feature/x")
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "finish", "x"); err == nil {
+		t.Fatalf("expected finish conflict, got success:\n%s", out)
+	}
+	if !integMergeHeadExists(t, dir) {
+		t.Fatalf("expected MERGE_HEAD present after finish conflict")
+	}
+	if s, err := testutil.LoadMergeState(t, dir); err != nil || s == nil || s.Action != "finish" {
+		t.Fatalf("expected saved finish state, got %+v (err=%v)", s, err)
+	}
+}
+
+// setupUpdateInProgressMerge leaves the repo in an update merge conflict:
+// Action=update, .git/MERGE_HEAD present, HEAD on feature/x (downstream=merge).
+func setupUpdateInProgressMerge(t *testing.T, dir string) {
+	t.Helper()
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("init failed: %v\n%s", err, out)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.branch.feature.downstreamStrategy", "merge"); err != nil {
+		t.Fatalf("failed to set downstream merge strategy: %v", err)
+	}
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "start", "x"); err != nil {
+		t.Fatalf("feature start failed: %v\n%s", err, out)
+	}
+	integAddCommit(t, dir, "feature/x", "c.txt", "feature\n", "feature c")
+	integAddCommit(t, dir, "develop", "c.txt", "develop\n", "develop c")
+	testutil.RunGit(t, dir, "checkout", "feature/x")
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "update", "x"); err == nil {
+		t.Fatalf("expected update merge conflict, got success:\n%s", out)
+	}
+	if !integMergeHeadExists(t, dir) {
+		t.Fatalf("expected MERGE_HEAD present after update merge conflict")
+	}
+	if s, err := testutil.LoadMergeState(t, dir); err != nil || s == nil || s.Action != "update" {
+		t.Fatalf("expected saved update state, got %+v (err=%v)", s, err)
+	}
+}
+
+// setupUpdateInProgressRebase leaves the repo in an update rebase conflict:
+// Action=update, .git/rebase-merge present (default feature downstream=rebase).
+func setupUpdateInProgressRebase(t *testing.T, dir string) {
+	t.Helper()
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("init failed: %v\n%s", err, out)
+	}
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "start", "x"); err != nil {
+		t.Fatalf("feature start failed: %v\n%s", err, out)
+	}
+	integAddCommit(t, dir, "feature/x", "c.txt", "feature\n", "feature c")
+	integAddCommit(t, dir, "develop", "c.txt", "develop\n", "develop c")
+	testutil.RunGit(t, dir, "checkout", "feature/x")
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "update", "x"); err == nil {
+		t.Fatalf("expected update rebase conflict, got success:\n%s", out)
+	}
+	if !integRebaseInProgress(t, dir) {
+		t.Fatalf("expected .git/rebase-merge present after update rebase conflict")
+	}
+	if s, err := testutil.LoadMergeState(t, dir); err != nil || s == nil || s.Action != "update" {
+		t.Fatalf("expected saved update state, got %+v (err=%v)", s, err)
+	}
+}
+
+// setupIntegrateInProgress leaves the repo in an integrate merge conflict:
+// Action=integrate, .git/MERGE_HEAD present, HEAD on main.
+func setupIntegrateInProgress(t *testing.T, dir string) {
+	t.Helper()
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("init failed: %v\n%s", err, out)
+	}
+	integSetupConflict(t, dir, "conflict.txt")
+	if out, err := testutil.RunGitFlow(t, dir, "integrate", "develop", "--tag", "v2.0.0"); err == nil {
+		t.Fatalf("expected integrate conflict, got success:\n%s", out)
+	}
+	if !integMergeHeadExists(t, dir) {
+		t.Fatalf("expected MERGE_HEAD present after integrate conflict")
+	}
+	if s, err := testutil.LoadMergeState(t, dir); err != nil || s == nil || s.Action != "integrate" {
+		t.Fatalf("expected saved integrate state, got %+v (err=%v)", s, err)
+	}
+}
+
+// exitCodeOf returns the process exit code carried by a testutil.ExitError,
+// 0 for a nil error, or -1 for any other error type.
+func scopeExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	if ee, ok := err.(*testutil.ExitError); ok {
+		return ee.ExitCode
+	}
+	return -1
+}
+
+// readStateBytes returns the raw bytes of the merge-state file (fatal if absent).
+func readStateBytes(t *testing.T, dir string) string {
+	t.Helper()
+	p := filepath.Join(integGitDir(t, dir), "gitflow", "state", "merge.json")
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("failed to read merge state file: %v", err)
+	}
+	return string(b)
+}
+
+// symbolicHead returns refs/heads/<branch> for HEAD, or "" when HEAD is detached
+// (e.g. mid-rebase). It never fails the test.
+func symbolicHead(t *testing.T, dir string) string {
+	out, _ := testutil.RunGit(t, dir, "symbolic-ref", "-q", "HEAD")
+	return strings.TrimSpace(out)
+}
+
+// showRef returns the full ref listing (branches + tags), used to prove no ref
+// moved during a refused operation.
+func showRef(t *testing.T, dir string) string {
+	out, _ := testutil.RunGit(t, dir, "show-ref")
+	return out
+}
+
+// porcelain returns `git status --porcelain` output.
+func porcelain(t *testing.T, dir string) string {
+	out, _ := testutil.RunGit(t, dir, "status", "--porcelain")
+	return out
+}
+
+// markerPresent reports whether the given in-progress marker is present.
+func markerPresent(t *testing.T, dir, marker string) bool {
+	switch marker {
+	case markerRebaseDir:
+		return integRebaseInProgress(t, dir)
+	default:
+		return integMergeHeadExists(t, dir)
+	}
+}
+
+// assertNonDestructiveRefusal runs cmdArgs against an in-progress foreign
+// operation and asserts the spec's non-destructive set F: exit 3; output names
+// wantOwner and mentions both --continue and --abort; the merge-state file bytes,
+// current branch, HEAD, all refs, and `git status --porcelain` are unchanged; and
+// the in-progress marker (wantMarker) is still present. Returns the command output.
+func assertNonDestructiveRefusal(t *testing.T, dir string, cmdArgs []string, wantOwner, wantMarker string) string {
+	t.Helper()
+
+	stateBefore := readStateBytes(t, dir)
+	branchBefore := symbolicHead(t, dir)
+	headBefore := integRevParse(t, dir, "HEAD")
+	refsBefore := showRef(t, dir)
+	statusBefore := porcelain(t, dir)
+	if !markerPresent(t, dir, wantMarker) {
+		t.Fatalf("precondition failed: marker %s not present before refusal", wantMarker)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, cmdArgs...)
+
+	if code := scopeExitCode(err); code != 3 {
+		t.Fatalf("expected exit code 3, got %d (err=%v)\nOutput: %s", code, err, out)
+	}
+	if !strings.Contains(out, wantOwner) {
+		t.Errorf("expected output to name owner %q, got:\n%s", wantOwner, out)
+	}
+	if !strings.Contains(out, "--continue") || !strings.Contains(out, "--abort") {
+		t.Errorf("expected output to mention --continue and --abort, got:\n%s", out)
+	}
+	if got := readStateBytes(t, dir); got != stateBefore {
+		t.Errorf("merge state file changed.\nbefore: %s\nafter:  %s", stateBefore, got)
+	}
+	if got := symbolicHead(t, dir); got != branchBefore {
+		t.Errorf("current branch changed: before %q, after %q", branchBefore, got)
+	}
+	if got := integRevParse(t, dir, "HEAD"); got != headBefore {
+		t.Errorf("HEAD moved: before %s, after %s", headBefore, got)
+	}
+	if got := showRef(t, dir); got != refsBefore {
+		t.Errorf("refs changed.\nbefore:\n%s\nafter:\n%s", refsBefore, got)
+	}
+	if got := porcelain(t, dir); got != statusBefore {
+		t.Errorf("working tree status changed.\nbefore: %q\nafter: %q", statusBefore, got)
+	}
+	if !markerPresent(t, dir, wantMarker) {
+		t.Errorf("in-progress marker %s missing after refusal", wantMarker)
+	}
+	return out
+}
+
+// =============================================================================
+// A. Foreign --continue is refused (owner != caller)
+// =============================================================================
+
+// TestFinishConflictRefusesIntegrateContinue verifies integrate --continue is
+// refused over a finish conflict and the finish owner remains resumable.
+// Steps:
+// 1. Sets up a finish merge conflict (Action=finish, MERGE_HEAD present).
+// 2. Runs 'git flow integrate --continue'.
+// 3. Verifies non-destructive refusal naming the finish owner (set F, exit 3).
+// 4. Resolves + stages, runs 'git flow feature finish --continue x'.
+// 5. Verifies the finish still completes (branch deleted, exit 0).
+func TestFinishConflictRefusesIntegrateContinue(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupFinishInProgress(t, dir)
+
+	assertNonDestructiveRefusal(t, dir, []string{"integrate", "--continue"}, "finish", markerMergeHead)
+
+	// Owner still resumable after the refusal (set F item 6).
+	testutil.WriteFile(t, dir, "c.txt", "resolved\n")
+	testutil.RunGit(t, dir, "add", "c.txt")
+	out, err := testutil.RunGitFlow(t, dir, "feature", "finish", "--continue", "x")
+	if err != nil {
+		t.Fatalf("finish --continue after refusal failed: %v\n%s", err, out)
+	}
+	if testutil.BranchExists(t, dir, "feature/x") {
+		t.Error("expected feature/x deleted after finish continue")
+	}
+	if testutil.GitFlowMergeStateExists(t, dir) {
+		t.Error("expected merge state cleared after finish continue")
+	}
+}
+
+// TestFinishConflictRefusesUpdateContinue verifies feature update --continue is
+// refused over a finish conflict.
+// Steps:
+// 1. Sets up a finish merge conflict (Action=finish).
+// 2. Runs 'git flow feature update --continue x'.
+// 3. Verifies non-destructive refusal naming the finish owner (set F, exit 3).
+func TestFinishConflictRefusesUpdateContinue(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupFinishInProgress(t, dir)
+
+	assertNonDestructiveRefusal(t, dir, []string{"feature", "update", "--continue", "x"}, "finish", markerMergeHead)
+}
+
+// TestUpdateConflictRefusesFinishContinue verifies feature finish --continue is
+// refused over an update conflict with an owner-aware message (not the confusing
+// "unknown branch type" error).
+// Steps:
+// 1. Sets up an update merge conflict (Action=update).
+// 2. Runs 'git flow feature finish --continue x'.
+// 3. Verifies non-destructive refusal naming the update owner (set F, exit 3).
+// 4. Verifies the message is NOT an InvalidBranchTypeError.
+func TestUpdateConflictRefusesFinishContinue(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupUpdateInProgressMerge(t, dir)
+
+	out := assertNonDestructiveRefusal(t, dir, []string{"feature", "finish", "--continue", "x"}, "update", markerMergeHead)
+	if strings.Contains(out, "unknown branch type") {
+		t.Errorf("expected owner-aware refusal, got InvalidBranchTypeError:\n%s", out)
+	}
+}
+
+// TestUpdateConflictRefusesIntegrateContinue verifies integrate --continue is
+// refused over an update conflict.
+// Steps:
+// 1. Sets up an update merge conflict (Action=update).
+// 2. Runs 'git flow integrate --continue'.
+// 3. Verifies non-destructive refusal naming the update owner (set F, exit 3).
+func TestUpdateConflictRefusesIntegrateContinue(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupUpdateInProgressMerge(t, dir)
+
+	assertNonDestructiveRefusal(t, dir, []string{"integrate", "--continue"}, "update", markerMergeHead)
+}
+
+// TestIntegrateConflictRefusesFinishContinue verifies feature finish --continue
+// is refused over an integrate conflict and the integrate owner remains resumable.
+// Steps:
+// 1. Sets up an integrate merge conflict (Action=integrate, MERGE_HEAD present).
+// 2. Runs 'git flow feature finish --continue x'.
+// 3. Verifies non-destructive refusal naming the integrate owner (set F, exit 3).
+// 4. Runs 'git flow integrate --abort' and verifies it cleanly aborts (exit 0).
+func TestIntegrateConflictRefusesFinishContinue(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupIntegrateInProgress(t, dir)
+	preMain := integRevParse(t, dir, "main")
+	preDevelop := integRevParse(t, dir, "develop")
+
+	out := assertNonDestructiveRefusal(t, dir, []string{"feature", "finish", "--continue", "x"}, "integrate", markerMergeHead)
+	if !strings.Contains(out, "git flow integrate --continue") {
+		t.Errorf("expected integrate recovery command in message, got:\n%s", out)
+	}
+
+	// Integrate owner still resumable after the refusal (set F item 6).
+	if out, err := testutil.RunGitFlow(t, dir, "integrate", "--abort"); err != nil {
+		t.Fatalf("integrate --abort after refusal failed: %v\n%s", err, out)
+	}
+	if integMergeHeadExists(t, dir) {
+		t.Error("expected MERGE_HEAD gone after integrate abort")
+	}
+	if got := integRevParse(t, dir, "main"); got != preMain {
+		t.Errorf("expected main restored to %s, got %s", preMain, got)
+	}
+	if got := integRevParse(t, dir, "develop"); got != preDevelop {
+		t.Errorf("expected develop restored to %s, got %s", preDevelop, got)
+	}
+	if testutil.GitFlowMergeStateExists(t, dir) {
+		t.Error("expected merge state cleared after integrate abort")
+	}
+}
+
+// TestIntegrateConflictRefusesUpdateContinue verifies feature update --continue
+// is refused over an integrate conflict.
+// Steps:
+// 1. Sets up an integrate merge conflict (Action=integrate).
+// 2. Runs 'git flow feature update --continue x'.
+// 3. Verifies non-destructive refusal naming the integrate owner (set F, exit 3).
+func TestIntegrateConflictRefusesUpdateContinue(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupIntegrateInProgress(t, dir)
+
+	assertNonDestructiveRefusal(t, dir, []string{"feature", "update", "--continue", "x"}, "integrate", markerMergeHead)
+}
+
+// =============================================================================
+// B. Foreign --abort is refused (owner != caller)
+// =============================================================================
+
+// TestFinishConflictRefusesIntegrateAbort verifies integrate --abort is refused
+// over a finish conflict and does not abort the finish merge.
+// Steps:
+// 1. Sets up a finish merge conflict (Action=finish, MERGE_HEAD present).
+// 2. Runs 'git flow integrate --abort'.
+// 3. Verifies non-destructive refusal (set F, exit 3) and MERGE_HEAD still present.
+func TestFinishConflictRefusesIntegrateAbort(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupFinishInProgress(t, dir)
+
+	assertNonDestructiveRefusal(t, dir, []string{"integrate", "--abort"}, "finish", markerMergeHead)
+}
+
+// TestFinishConflictRefusesUpdateAbort verifies feature update --abort is refused
+// over a finish conflict.
+// Steps:
+// 1. Sets up a finish merge conflict (Action=finish).
+// 2. Runs 'git flow feature update --abort x'.
+// 3. Verifies non-destructive refusal naming the finish owner (set F, exit 3).
+func TestFinishConflictRefusesUpdateAbort(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupFinishInProgress(t, dir)
+
+	assertNonDestructiveRefusal(t, dir, []string{"feature", "update", "--abort", "x"}, "finish", markerMergeHead)
+}
+
+// TestUpdateConflictRefusesFinishAbort verifies feature finish --abort is refused
+// over an update conflict (the core bug fix) and the update owner stays abortable.
+// Steps:
+// 1. Sets up an update merge conflict (Action=update, MERGE_HEAD present).
+// 2. Runs 'git flow feature finish --abort x'.
+// 3. Verifies non-destructive refusal naming the update owner (set F, exit 3);
+//    the update merge is NOT aborted.
+// 4. Runs 'git flow feature update --abort x' and verifies it cleanly aborts.
+func TestUpdateConflictRefusesFinishAbort(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupUpdateInProgressMerge(t, dir)
+
+	assertNonDestructiveRefusal(t, dir, []string{"feature", "finish", "--abort", "x"}, "update", markerMergeHead)
+
+	// Update owner still abortable after the refusal (set F item 6).
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "update", "--abort", "x"); err != nil {
+		t.Fatalf("feature update --abort after refusal failed: %v\n%s", err, out)
+	}
+	if integMergeHeadExists(t, dir) {
+		t.Error("expected MERGE_HEAD gone after update abort")
+	}
+	if testutil.GitFlowMergeStateExists(t, dir) {
+		t.Error("expected merge state cleared after update abort")
+	}
+	if got := testutil.GetCurrentBranch(t, dir); got != "feature/x" {
+		t.Errorf("expected HEAD on feature/x after update abort, got %s", got)
+	}
+}
+
+// TestUpdateConflictRefusesIntegrateAbort verifies integrate --abort is refused
+// over an update conflict.
+// Steps:
+// 1. Sets up an update merge conflict (Action=update).
+// 2. Runs 'git flow integrate --abort'.
+// 3. Verifies non-destructive refusal naming the update owner (set F, exit 3).
+func TestUpdateConflictRefusesIntegrateAbort(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupUpdateInProgressMerge(t, dir)
+
+	assertNonDestructiveRefusal(t, dir, []string{"integrate", "--abort"}, "update", markerMergeHead)
+}
+
+// TestIntegrateConflictRefusesFinishAbort verifies feature finish --abort is
+// refused over an integrate conflict.
+// Steps:
+// 1. Sets up an integrate merge conflict (Action=integrate).
+// 2. Runs 'git flow feature finish --abort x'.
+// 3. Verifies non-destructive refusal naming the integrate owner (set F, exit 3).
+func TestIntegrateConflictRefusesFinishAbort(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupIntegrateInProgress(t, dir)
+
+	assertNonDestructiveRefusal(t, dir, []string{"feature", "finish", "--abort", "x"}, "integrate", markerMergeHead)
+}
+
+// TestIntegrateConflictRefusesUpdateAbort verifies feature update --abort is
+// refused over an integrate conflict.
+// Steps:
+// 1. Sets up an integrate merge conflict (Action=integrate).
+// 2. Runs 'git flow feature update --abort x'.
+// 3. Verifies non-destructive refusal naming the integrate owner (set F, exit 3).
+func TestIntegrateConflictRefusesUpdateAbort(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupIntegrateInProgress(t, dir)
+
+	assertNonDestructiveRefusal(t, dir, []string{"feature", "update", "--abort", "x"}, "integrate", markerMergeHead)
+}
+
+// =============================================================================
+// C. Ordinary invocation (no flags) while a foreign op is in progress is refused
+// =============================================================================
+
+// TestPlainFinishRefusedDuringIntegrate verifies a plain feature finish is
+// refused while an integrate op is in progress (guard fires before a new finish).
+// Steps:
+// 1. Sets up an integrate merge conflict (Action=integrate).
+// 2. Runs 'git flow feature finish x' (no continue/abort flags).
+// 3. Verifies non-destructive refusal naming the integrate owner (set F, exit 3).
+func TestPlainFinishRefusedDuringIntegrate(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupIntegrateInProgress(t, dir)
+
+	assertNonDestructiveRefusal(t, dir, []string{"feature", "finish", "x"}, "integrate", markerMergeHead)
+}
+
+// TestPlainUpdateRefusedDuringFinish verifies a plain feature update is refused
+// while a finish op is in progress (the previously unguarded path).
+// Steps:
+// 1. Sets up a finish merge conflict (Action=finish).
+// 2. Runs 'git flow feature update x' (no continue/abort flags).
+// 3. Verifies non-destructive refusal naming the finish owner (set F, exit 3).
+func TestPlainUpdateRefusedDuringFinish(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupFinishInProgress(t, dir)
+
+	assertNonDestructiveRefusal(t, dir, []string{"feature", "update", "x"}, "finish", markerMergeHead)
+}
+
+// =============================================================================
+// F. Nothing in progress: --continue reports "no merge in progress" (exit 3)
+// =============================================================================
+
+// TestFinishContinueNoMergeInProgress verifies finish --continue with nothing in
+// progress errors with "no merge in progress" and exit 3.
+// Steps:
+// 1. init --defaults; feature start x (no conflict, no in-progress op).
+// 2. Runs 'git flow feature finish --continue x'.
+// 3. Verifies "no merge in progress" and exit 3.
+func TestFinishContinueNoMergeInProgress(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("init failed: %v\n%s", err, out)
+	}
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "start", "x"); err != nil {
+		t.Fatalf("feature start failed: %v\n%s", err, out)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "feature", "finish", "--continue", "x")
+	if code := scopeExitCode(err); code != 3 {
+		t.Fatalf("expected exit 3, got %d (err=%v)\n%s", code, err, out)
+	}
+	if !strings.Contains(out, "no merge in progress") {
+		t.Errorf("expected 'no merge in progress', got:\n%s", out)
+	}
+}
+
+// TestIntegrateContinueNoMergeInProgress verifies integrate --continue with
+// nothing in progress errors with "no merge in progress" and exit 3.
+// Steps:
+// 1. init --defaults (nothing in progress).
+// 2. Runs 'git flow integrate --continue'.
+// 3. Verifies "no merge in progress" and exit 3.
+func TestIntegrateContinueNoMergeInProgress(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("init failed: %v\n%s", err, out)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "--continue")
+	if code := scopeExitCode(err); code != 3 {
+		t.Fatalf("expected exit 3, got %d (err=%v)\n%s", code, err, out)
+	}
+	if !strings.Contains(out, "no merge in progress") {
+		t.Errorf("expected 'no merge in progress', got:\n%s", out)
+	}
+}
+
+// =============================================================================
+// G. State integrity & edges
+// =============================================================================
+
+// setupBogusActionState sets up a real finish merge conflict, then overwrites the
+// saved state's Action with the given value while leaving MERGE_HEAD in place.
+func setupBogusActionState(t *testing.T, dir, action string) {
+	t.Helper()
+	setupFinishInProgress(t, dir)
+	state, err := testutil.LoadMergeState(t, dir)
+	if err != nil || state == nil {
+		t.Fatalf("expected saved state, err=%v", err)
+	}
+	state.Action = action
+	testutil.WriteMergeState(t, dir, state)
+	if !integMergeHeadExists(t, dir) {
+		t.Fatalf("expected MERGE_HEAD still present after rewriting state")
+	}
+}
+
+// assertUnrecognizedRefusal runs cmdArgs and asserts an unrecognized-operation
+// refusal: exit 3, a generic "unrecognized git-flow operation" message, the
+// state-file bytes unchanged, and MERGE_HEAD still present. Nothing is cleared.
+func assertUnrecognizedRefusal(t *testing.T, dir string, cmdArgs []string) {
+	t.Helper()
+	stateBefore := readStateBytes(t, dir)
+
+	out, err := testutil.RunGitFlow(t, dir, cmdArgs...)
+	if code := scopeExitCode(err); code != 3 {
+		t.Fatalf("expected exit 3, got %d (err=%v)\n%s", code, err, out)
+	}
+	if !strings.Contains(out, "unrecognized git-flow operation") {
+		t.Errorf("expected 'unrecognized git-flow operation' message, got:\n%s", out)
+	}
+	if got := readStateBytes(t, dir); got != stateBefore {
+		t.Errorf("state file changed.\nbefore: %s\nafter:  %s", stateBefore, got)
+	}
+	if !integMergeHeadExists(t, dir) {
+		t.Errorf("expected MERGE_HEAD still present after refusal")
+	}
+}
+
+// TestEmptyActionRefusedNonDestructively verifies an empty-Action state is refused
+// non-destructively (never auto-cleared).
+// Steps:
+// 1. Sets up a finish conflict, then overwrites Action="" (MERGE_HEAD kept).
+// 2. Runs 'git flow feature finish --continue x'.
+// 3. Verifies a generic unrecognized-operation refusal (exit 3), state kept.
+func TestEmptyActionRefusedNonDestructively(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupBogusActionState(t, dir, "")
+
+	assertUnrecognizedRefusal(t, dir, []string{"feature", "finish", "--continue", "x"})
+}
+
+// TestBogusActionRefusedNonDestructively verifies a bogus-Action state is refused
+// non-destructively (never auto-cleared).
+// Steps:
+// 1. Sets up a finish conflict, then overwrites Action="bogus" (MERGE_HEAD kept).
+// 2. Runs 'git flow integrate --continue'.
+// 3. Verifies a generic unrecognized-operation refusal (exit 3), state kept.
+func TestBogusActionRefusedNonDestructively(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupBogusActionState(t, dir, "bogus")
+
+	assertUnrecognizedRefusal(t, dir, []string{"integrate", "--continue"})
+}
+
+// TestForeignRefusalMessageContent verifies the foreign refusal message names the
+// owner and prints the exact recovery commands.
+// Steps:
+// 1. Sets up an integrate merge conflict (Action=integrate).
+// 2. Runs 'git flow feature finish --continue x'.
+// 3. Verifies the message contains 'integrate', 'git flow integrate --continue',
+//    and 'git flow integrate --abort'.
+func TestForeignRefusalMessageContent(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupIntegrateInProgress(t, dir)
+
+	out, err := testutil.RunGitFlow(t, dir, "feature", "finish", "--continue", "x")
+	if code := scopeExitCode(err); code != 3 {
+		t.Fatalf("expected exit 3, got %d (err=%v)\n%s", code, err, out)
+	}
+	for _, want := range []string{"integrate", "git flow integrate --continue", "git flow integrate --abort"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected message to contain %q, got:\n%s", want, out)
+		}
+	}
+}
+
+// TestTopLevelUpdateForeignRefusalExitsThree verifies the top-level update surface
+// exits 3 (not 1) when refusing a foreign integrate op.
+// Steps:
+// 1. Sets up an integrate merge conflict (Action=integrate, HEAD on main).
+// 2. Runs 'git flow update --continue' (top-level surface).
+// 3. Verifies non-destructive refusal naming the integrate owner (set F, exit 3).
+func TestTopLevelUpdateForeignRefusalExitsThree(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupIntegrateInProgress(t, dir)
+
+	assertNonDestructiveRefusal(t, dir, []string{"update", "--continue"}, "integrate", markerMergeHead)
+}

--- a/test/cmd/finish_conflicts_test.go
+++ b/test/cmd/finish_conflicts_test.go
@@ -86,6 +86,11 @@ func TestFinishSingleConflictMergeStrategy(t *testing.T) {
 		t.Error("Feature branch should be deleted after finish")
 	}
 
+	// Verify merge state cleared after a successful continue (#143)
+	if testutil.GitFlowMergeStateExists(t, dir) {
+		t.Error("Expected merge state to be cleared after finish --continue")
+	}
+
 	// Verify changes in develop
 	testutil.RunGit(t, dir, "checkout", "develop")
 	content := testutil.ReadFile(t, dir, "conflict.txt")

--- a/test/cmd/finish_state_test.go
+++ b/test/cmd/finish_state_test.go
@@ -722,3 +722,29 @@ func TestAbortClearsStaleMergeState(t *testing.T) {
 		t.Error("Expected merge state to be cleared after --abort on stale state")
 	}
 }
+
+// TestFinishAbortNoOpWhenNothingInProgress verifies feature finish --abort with a
+// truly clean repo (no in-progress op, no state file) is a forgiving no-op.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Creates feature/x (no conflict, no in-progress op, no state file)
+// 3. Runs 'git flow feature finish --abort x'
+// 4. Verifies exit 0, no error, and no merge-state file created
+func TestFinishAbortNoOpWhenNothingInProgress(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "start", "x"); err != nil {
+		t.Fatalf("Failed to start feature: %v\nOutput: %s", err, out)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "feature", "finish", "--abort", "x")
+	if err != nil {
+		t.Fatalf("Expected finish --abort no-op to succeed: %v\nOutput: %s", err, out)
+	}
+	if testutil.GitFlowMergeStateExists(t, dir) {
+		t.Error("Expected no merge-state file after no-op abort")
+	}
+}

--- a/test/cmd/finish_test.go
+++ b/test/cmd/finish_test.go
@@ -568,6 +568,11 @@ func TestFinishWithMergeAbort(t *testing.T) {
 	if content != "feature content" {
 		t.Errorf("Expected file content to be 'feature content', got '%s'", content)
 	}
+
+	// Verify merge state cleared after abort (#143)
+	if testutil.GitFlowMergeStateExists(t, dir) {
+		t.Error("Expected merge state to be cleared after finish --abort")
+	}
 }
 
 // TestFinishAbortAfterManualResolve reproduces gittower/git-flow-next#110,

--- a/test/cmd/update_conflicts_test.go
+++ b/test/cmd/update_conflicts_test.go
@@ -14,12 +14,12 @@ import (
 // TestUpdateMergeConflictThenContinue verifies a merge-strategy update conflict is
 // resumable and completes exactly one update (no tag, no child update, no delete).
 // Steps:
-// 1. Sets up an update merge conflict on feature/x (downstream=merge).
-// 2. Captures pre-update develop and feature/x tips.
-// 3. Resolves c.txt, stages, runs 'git flow feature update --continue x'.
-// 4. Verifies the merge commits, feature/x has develop as ancestor, MERGE_HEAD
-//    gone, state cleared, HEAD on feature/x, exit 0.
-// 5. Verifies exactly one completion: no tag, develop tip unchanged, feature/x kept.
+//  1. Sets up an update merge conflict on feature/x (downstream=merge).
+//  2. Captures pre-update develop and feature/x tips.
+//  3. Resolves c.txt, stages, runs 'git flow feature update --continue x'.
+//  4. Verifies the merge commits, feature/x has develop as ancestor, MERGE_HEAD
+//     gone, state cleared, HEAD on feature/x, exit 0.
+//  5. Verifies exactly one completion: no tag, develop tip unchanged, feature/x kept.
 func TestUpdateMergeConflictThenContinue(t *testing.T) {
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
@@ -62,10 +62,10 @@ func TestUpdateMergeConflictThenContinue(t *testing.T) {
 // TestUpdateMergeConflictThenAbort verifies a merge-strategy update conflict rolls
 // back cleanly on abort.
 // Steps:
-// 1. Sets up an update merge conflict on feature/x; captures feature/x, develop tips.
-// 2. Runs 'git flow feature update --abort x'.
-// 3. Verifies MERGE_HEAD gone, feature/x and develop restored, state cleared,
-//    HEAD on feature/x, clean working tree, exit 0.
+//  1. Sets up an update merge conflict on feature/x; captures feature/x, develop tips.
+//  2. Runs 'git flow feature update --abort x'.
+//  3. Verifies MERGE_HEAD gone, feature/x and develop restored, state cleared,
+//     HEAD on feature/x, clean working tree, exit 0.
 func TestUpdateMergeConflictThenAbort(t *testing.T) {
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
@@ -101,11 +101,11 @@ func TestUpdateMergeConflictThenAbort(t *testing.T) {
 // TestUpdateRebaseConflictThenContinue verifies a rebase-strategy update conflict
 // is resumable and completes.
 // Steps:
-// 1. Sets up an update rebase conflict on feature/x (default downstream=rebase);
-//    verifies rebase-merge present and head-name is refs/heads/feature/x.
-// 2. Resolves c.txt, stages, runs 'git flow feature update --continue x'.
-// 3. Verifies rebase completes, rebase-merge gone, develop is an ancestor of
-//    feature/x, state cleared, HEAD on feature/x, exit 0.
+//  1. Sets up an update rebase conflict on feature/x (default downstream=rebase);
+//     verifies rebase-merge present and head-name is refs/heads/feature/x.
+//  2. Resolves c.txt, stages, runs 'git flow feature update --continue x'.
+//  3. Verifies rebase completes, rebase-merge gone, develop is an ancestor of
+//     feature/x, state cleared, HEAD on feature/x, exit 0.
 func TestUpdateRebaseConflictThenContinue(t *testing.T) {
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
@@ -141,12 +141,12 @@ func TestUpdateRebaseConflictThenContinue(t *testing.T) {
 // TestUpdateRebaseReconflictStaysResumable verifies a rebase update that
 // re-conflicts on a second replayed commit stays resumable.
 // Steps:
-// 1. Builds feature/x with two commits each editing files that also diverged on
-//    develop, so the rebase conflicts twice.
-// 2. Runs 'git flow feature update x' (rebase) to reach the first conflict.
-// 3. Resolves the first conflict, stages, runs 'git flow feature update --continue x'.
-// 4. Verifies --continue reports unresolved conflicts (exit 3), the state file
-//    bytes are unchanged, and rebase-merge is still present (resumable).
+//  1. Builds feature/x with two commits each editing files that also diverged on
+//     develop, so the rebase conflicts twice.
+//  2. Runs 'git flow feature update x' (rebase) to reach the first conflict.
+//  3. Resolves the first conflict, stages, runs 'git flow feature update --continue x'.
+//  4. Verifies --continue reports unresolved conflicts (exit 3), the state file
+//     bytes are unchanged, and rebase-merge is still present (resumable).
 func TestUpdateRebaseReconflictStaysResumable(t *testing.T) {
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
@@ -191,10 +191,10 @@ func TestUpdateRebaseReconflictStaysResumable(t *testing.T) {
 // TestUpdateRebaseConflictThenAbort verifies a rebase-strategy update conflict
 // rolls back on abort.
 // Steps:
-// 1. Sets up an update rebase conflict on feature/x; captures feature/x tip.
-// 2. Runs 'git flow feature update --abort x'.
-// 3. Verifies rebase-merge gone, feature/x restored, state cleared, HEAD on
-//    feature/x, exit 0.
+//  1. Sets up an update rebase conflict on feature/x; captures feature/x tip.
+//  2. Runs 'git flow feature update --abort x'.
+//  3. Verifies rebase-merge gone, feature/x restored, state cleared, HEAD on
+//     feature/x, exit 0.
 func TestUpdateRebaseConflictThenAbort(t *testing.T) {
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)

--- a/test/cmd/update_conflicts_test.go
+++ b/test/cmd/update_conflicts_test.go
@@ -1,0 +1,306 @@
+package cmd_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// =============================================================================
+// E. update resume/abort — new capability (issue #143)
+// =============================================================================
+
+// TestUpdateMergeConflictThenContinue verifies a merge-strategy update conflict is
+// resumable and completes exactly one update (no tag, no child update, no delete).
+// Steps:
+// 1. Sets up an update merge conflict on feature/x (downstream=merge).
+// 2. Captures pre-update develop and feature/x tips.
+// 3. Resolves c.txt, stages, runs 'git flow feature update --continue x'.
+// 4. Verifies the merge commits, feature/x has develop as ancestor, MERGE_HEAD
+//    gone, state cleared, HEAD on feature/x, exit 0.
+// 5. Verifies exactly one completion: no tag, develop tip unchanged, feature/x kept.
+func TestUpdateMergeConflictThenContinue(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupUpdateInProgressMerge(t, dir)
+
+	preDevelop := integRevParse(t, dir, "develop")
+	tagsBefore, _ := testutil.RunGit(t, dir, "tag", "-l")
+
+	testutil.WriteFile(t, dir, "c.txt", "resolved\n")
+	testutil.RunGit(t, dir, "add", "c.txt")
+
+	out, err := testutil.RunGitFlow(t, dir, "feature", "update", "--continue", "x")
+	if err != nil {
+		t.Fatalf("feature update --continue failed: %v\n%s", err, out)
+	}
+	if integMergeHeadExists(t, dir) {
+		t.Error("expected MERGE_HEAD gone after update continue")
+	}
+	if !integIsAncestor(t, dir, integRevParse(t, dir, "develop"), "feature/x") {
+		t.Error("expected develop to be an ancestor of feature/x after update")
+	}
+	if testutil.GitFlowMergeStateExists(t, dir) {
+		t.Error("expected merge state cleared after update continue")
+	}
+	if got := testutil.GetCurrentBranch(t, dir); got != "feature/x" {
+		t.Errorf("expected HEAD on feature/x, got %s", got)
+	}
+	// Exactly one update completion: no tag, no child update, no deletion.
+	if tagsAfter, _ := testutil.RunGit(t, dir, "tag", "-l"); strings.TrimSpace(tagsAfter) != strings.TrimSpace(tagsBefore) {
+		t.Errorf("expected no tag created by update, tags: %q -> %q", tagsBefore, tagsAfter)
+	}
+	if got := integRevParse(t, dir, "develop"); got != preDevelop {
+		t.Errorf("expected develop tip unchanged (no child update), was %s got %s", preDevelop, got)
+	}
+	if !testutil.BranchExists(t, dir, "feature/x") {
+		t.Error("expected feature/x to still exist (update never deletes)")
+	}
+}
+
+// TestUpdateMergeConflictThenAbort verifies a merge-strategy update conflict rolls
+// back cleanly on abort.
+// Steps:
+// 1. Sets up an update merge conflict on feature/x; captures feature/x, develop tips.
+// 2. Runs 'git flow feature update --abort x'.
+// 3. Verifies MERGE_HEAD gone, feature/x and develop restored, state cleared,
+//    HEAD on feature/x, clean working tree, exit 0.
+func TestUpdateMergeConflictThenAbort(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupUpdateInProgressMerge(t, dir)
+
+	preFeature := integRevParse(t, dir, "feature/x")
+	preDevelop := integRevParse(t, dir, "develop")
+
+	out, err := testutil.RunGitFlow(t, dir, "feature", "update", "--abort", "x")
+	if err != nil {
+		t.Fatalf("feature update --abort failed: %v\n%s", err, out)
+	}
+	if integMergeHeadExists(t, dir) {
+		t.Error("expected MERGE_HEAD gone after update abort")
+	}
+	if got := integRevParse(t, dir, "feature/x"); got != preFeature {
+		t.Errorf("expected feature/x restored to %s, got %s", preFeature, got)
+	}
+	if got := integRevParse(t, dir, "develop"); got != preDevelop {
+		t.Errorf("expected develop unchanged (%s), got %s", preDevelop, got)
+	}
+	if testutil.GitFlowMergeStateExists(t, dir) {
+		t.Error("expected merge state cleared after update abort")
+	}
+	if got := testutil.GetCurrentBranch(t, dir); got != "feature/x" {
+		t.Errorf("expected HEAD on feature/x, got %s", got)
+	}
+	if status := porcelain(t, dir); strings.TrimSpace(status) != "" {
+		t.Errorf("expected clean working tree after abort, got: %q", status)
+	}
+}
+
+// TestUpdateRebaseConflictThenContinue verifies a rebase-strategy update conflict
+// is resumable and completes.
+// Steps:
+// 1. Sets up an update rebase conflict on feature/x (default downstream=rebase);
+//    verifies rebase-merge present and head-name is refs/heads/feature/x.
+// 2. Resolves c.txt, stages, runs 'git flow feature update --continue x'.
+// 3. Verifies rebase completes, rebase-merge gone, develop is an ancestor of
+//    feature/x, state cleared, HEAD on feature/x, exit 0.
+func TestUpdateRebaseConflictThenContinue(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupUpdateInProgressRebase(t, dir)
+
+	headName, _ := testutil.RunGit(t, dir, "rev-parse", "--symbolic-full-name", "HEAD")
+	_ = headName // HEAD is detached during rebase; head-name verified below.
+	if !integRebaseInProgress(t, dir) {
+		t.Fatal("expected rebase in progress")
+	}
+
+	testutil.WriteFile(t, dir, "c.txt", "resolved\n")
+	testutil.RunGit(t, dir, "add", "c.txt")
+
+	out, err := testutil.RunGitFlow(t, dir, "feature", "update", "--continue", "x")
+	if err != nil {
+		t.Fatalf("feature update --continue (rebase) failed: %v\n%s", err, out)
+	}
+	if integRebaseInProgress(t, dir) {
+		t.Error("expected rebase-merge gone after continue")
+	}
+	if !integIsAncestor(t, dir, integRevParse(t, dir, "develop"), "feature/x") {
+		t.Error("expected develop to be an ancestor of feature/x after rebase update")
+	}
+	if testutil.GitFlowMergeStateExists(t, dir) {
+		t.Error("expected merge state cleared after update continue")
+	}
+	if got := testutil.GetCurrentBranch(t, dir); got != "feature/x" {
+		t.Errorf("expected HEAD on feature/x, got %s", got)
+	}
+}
+
+// TestUpdateRebaseReconflictStaysResumable verifies a rebase update that
+// re-conflicts on a second replayed commit stays resumable.
+// Steps:
+// 1. Builds feature/x with two commits each editing files that also diverged on
+//    develop, so the rebase conflicts twice.
+// 2. Runs 'git flow feature update x' (rebase) to reach the first conflict.
+// 3. Resolves the first conflict, stages, runs 'git flow feature update --continue x'.
+// 4. Verifies --continue reports unresolved conflicts (exit 3), the state file
+//    bytes are unchanged, and rebase-merge is still present (resumable).
+func TestUpdateRebaseReconflictStaysResumable(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("init failed: %v\n%s", err, out)
+	}
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "start", "x"); err != nil {
+		t.Fatalf("feature start failed: %v\n%s", err, out)
+	}
+	// Two conflicting commits on feature/x (a.txt then b.txt).
+	integAddCommit(t, dir, "feature/x", "a.txt", "feature a\n", "feature a")
+	integAddCommit(t, dir, "feature/x", "b.txt", "feature b\n", "feature b")
+	// Diverging edits on develop for both files.
+	integAddCommit(t, dir, "develop", "a.txt", "develop a\n", "develop a")
+	integAddCommit(t, dir, "develop", "b.txt", "develop b\n", "develop b")
+	testutil.RunGit(t, dir, "checkout", "feature/x")
+
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "update", "x"); err == nil {
+		t.Fatalf("expected first rebase conflict, got success:\n%s", out)
+	}
+	if !integRebaseInProgress(t, dir) {
+		t.Fatal("expected rebase in progress at first conflict")
+	}
+
+	// Resolve the first conflict (a.txt), stage, then continue -> re-conflict on b.txt.
+	testutil.WriteFile(t, dir, "a.txt", "resolved a\n")
+	testutil.RunGit(t, dir, "add", "a.txt")
+
+	stateBefore := readStateBytes(t, dir)
+	out, err := testutil.RunGitFlow(t, dir, "feature", "update", "--continue", "x")
+	if code := scopeExitCode(err); code != 3 {
+		t.Fatalf("expected exit 3 on re-conflict, got %d (err=%v)\n%s", code, err, out)
+	}
+	if !integRebaseInProgress(t, dir) {
+		t.Error("expected rebase-merge still present (resumable) after re-conflict")
+	}
+	if got := readStateBytes(t, dir); got != stateBefore {
+		t.Errorf("expected state file unchanged after re-conflict.\nbefore: %s\nafter:  %s", stateBefore, got)
+	}
+}
+
+// TestUpdateRebaseConflictThenAbort verifies a rebase-strategy update conflict
+// rolls back on abort.
+// Steps:
+// 1. Sets up an update rebase conflict on feature/x; captures feature/x tip.
+// 2. Runs 'git flow feature update --abort x'.
+// 3. Verifies rebase-merge gone, feature/x restored, state cleared, HEAD on
+//    feature/x, exit 0.
+func TestUpdateRebaseConflictThenAbort(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupUpdateInProgressRebase(t, dir)
+
+	preFeature := integRevParse(t, dir, "feature/x")
+
+	out, err := testutil.RunGitFlow(t, dir, "feature", "update", "--abort", "x")
+	if err != nil {
+		t.Fatalf("feature update --abort (rebase) failed: %v\n%s", err, out)
+	}
+	if integRebaseInProgress(t, dir) {
+		t.Error("expected rebase-merge gone after abort")
+	}
+	if got := integRevParse(t, dir, "feature/x"); got != preFeature {
+		t.Errorf("expected feature/x restored to %s, got %s", preFeature, got)
+	}
+	if testutil.GitFlowMergeStateExists(t, dir) {
+		t.Error("expected merge state cleared after update abort")
+	}
+	if got := testutil.GetCurrentBranch(t, dir); got != "feature/x" {
+		t.Errorf("expected HEAD on feature/x, got %s", got)
+	}
+}
+
+// setupBaseUpdateInProgress sets up a top-level base-branch update conflict on
+// develop (develop <- main, downstream=merge by default). Leaves MERGE_HEAD and
+// HEAD on develop, and asserts the initial top-level 'git flow update' exits 3.
+func setupBaseUpdateInProgress(t *testing.T, dir string) {
+	t.Helper()
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("init failed: %v\n%s", err, out)
+	}
+	integAddCommit(t, dir, "main", "c.txt", "main\n", "main c")
+	integAddCommit(t, dir, "develop", "c.txt", "develop\n", "develop c")
+	testutil.RunGit(t, dir, "checkout", "develop")
+
+	out, err := testutil.RunGitFlow(t, dir, "update")
+	if code := scopeExitCode(err); code != 3 {
+		t.Fatalf("expected initial top-level update conflict to exit 3, got %d (err=%v)\n%s", code, err, out)
+	}
+	if !integMergeHeadExists(t, dir) {
+		t.Fatalf("expected MERGE_HEAD present after base update conflict")
+	}
+}
+
+// TestTopLevelUpdateBaseBranchContinue verifies the top-level base-branch update
+// surface is resumable via --continue.
+// Steps:
+// 1. Sets up a develop <- main update conflict via 'git flow update' (exit 3).
+// 2. Resolves c.txt, stages, runs 'git flow update --continue'.
+// 3. Verifies the merge completes, develop updated from main, state cleared, exit 0.
+func TestTopLevelUpdateBaseBranchContinue(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupBaseUpdateInProgress(t, dir)
+
+	mainTip := integRevParse(t, dir, "main")
+	testutil.WriteFile(t, dir, "c.txt", "resolved\n")
+	testutil.RunGit(t, dir, "add", "c.txt")
+
+	out, err := testutil.RunGitFlow(t, dir, "update", "--continue")
+	if err != nil {
+		t.Fatalf("update --continue (base) failed: %v\n%s", err, out)
+	}
+	if integMergeHeadExists(t, dir) {
+		t.Error("expected MERGE_HEAD gone after continue")
+	}
+	if !integIsAncestor(t, dir, mainTip, "develop") {
+		t.Error("expected develop to include main after update")
+	}
+	if testutil.GitFlowMergeStateExists(t, dir) {
+		t.Error("expected merge state cleared after continue")
+	}
+	if got := testutil.GetCurrentBranch(t, dir); got != "develop" {
+		t.Errorf("expected HEAD on develop, got %s", got)
+	}
+}
+
+// TestTopLevelUpdateBaseBranchAbort verifies the top-level base-branch update
+// surface is abortable via --abort.
+// Steps:
+// 1. Sets up a develop <- main update conflict via 'git flow update'; captures develop tip.
+// 2. Runs 'git flow update --abort'.
+// 3. Verifies MERGE_HEAD gone, develop restored, state cleared, HEAD on develop, exit 0.
+func TestTopLevelUpdateBaseBranchAbort(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupBaseUpdateInProgress(t, dir)
+
+	preDevelop := integRevParse(t, dir, "develop")
+
+	out, err := testutil.RunGitFlow(t, dir, "update", "--abort")
+	if err != nil {
+		t.Fatalf("update --abort (base) failed: %v\n%s", err, out)
+	}
+	if integMergeHeadExists(t, dir) {
+		t.Error("expected MERGE_HEAD gone after abort")
+	}
+	if got := integRevParse(t, dir, "develop"); got != preDevelop {
+		t.Errorf("expected develop restored to %s, got %s", preDevelop, got)
+	}
+	if testutil.GitFlowMergeStateExists(t, dir) {
+		t.Error("expected merge state cleared after abort")
+	}
+	if got := testutil.GetCurrentBranch(t, dir); got != "develop" {
+		t.Errorf("expected HEAD on develop, got %s", got)
+	}
+}

--- a/test/cmd/update_state_test.go
+++ b/test/cmd/update_state_test.go
@@ -68,10 +68,10 @@ func TestUpdateContinueNoMergeInProgress(t *testing.T) {
 // TestUpdateStateIsSelfDescribing verifies a topic update conflict saves a
 // resolvable, self-describing state.
 // Steps:
-// 1. Sets up an update merge conflict on feature/x (downstream=merge).
-// 2. Loads .git/gitflow/state/merge.json.
-// 3. Verifies Action=update, BranchType=feature, FullBranchName=feature/x,
-//    ParentBranch=develop, MergeStrategy=merge, CurrentStep=merge.
+//  1. Sets up an update merge conflict on feature/x (downstream=merge).
+//  2. Loads .git/gitflow/state/merge.json.
+//  3. Verifies Action=update, BranchType=feature, FullBranchName=feature/x,
+//     ParentBranch=develop, MergeStrategy=merge, CurrentStep=merge.
 func TestUpdateStateIsSelfDescribing(t *testing.T) {
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
@@ -104,10 +104,10 @@ func TestUpdateStateIsSelfDescribing(t *testing.T) {
 // TestBaseUpdateStateIsSelfDescribing verifies a base-branch update conflict saves
 // a resolvable, self-describing state keyed on the base branch.
 // Steps:
-// 1. Sets up a develop <- main top-level update conflict.
-// 2. Loads .git/gitflow/state/merge.json.
-// 3. Verifies Action=update, BranchType=develop, FullBranchName=develop,
-//    ParentBranch=main, CurrentStep=merge.
+//  1. Sets up a develop <- main top-level update conflict.
+//  2. Loads .git/gitflow/state/merge.json.
+//  3. Verifies Action=update, BranchType=develop, FullBranchName=develop,
+//     ParentBranch=main, CurrentStep=merge.
 func TestBaseUpdateStateIsSelfDescribing(t *testing.T) {
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)

--- a/test/cmd/update_state_test.go
+++ b/test/cmd/update_state_test.go
@@ -1,0 +1,191 @@
+package cmd_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// =============================================================================
+// F. Nothing in progress: update --abort no-op; update --continue no-merge
+// =============================================================================
+
+// TestUpdateAbortNoOpWhenNothingInProgress verifies feature update --abort with
+// nothing in progress is a forgiving no-op.
+// Steps:
+// 1. init --defaults; feature start x (no conflict, no in-progress op).
+// 2. Runs 'git flow feature update --abort x'.
+// 3. Verifies exit 0, no error, and no merge-state file created.
+func TestUpdateAbortNoOpWhenNothingInProgress(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("init failed: %v\n%s", err, out)
+	}
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "start", "x"); err != nil {
+		t.Fatalf("feature start failed: %v\n%s", err, out)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "feature", "update", "--abort", "x")
+	if err != nil {
+		t.Fatalf("expected update --abort no-op to succeed: %v\n%s", err, out)
+	}
+	if testutil.GitFlowMergeStateExists(t, dir) {
+		t.Error("expected no merge-state file after no-op abort")
+	}
+}
+
+// TestUpdateContinueNoMergeInProgress verifies feature update --continue with
+// nothing in progress errors with "no merge in progress" and exit 3.
+// Steps:
+// 1. init --defaults; feature start x (no in-progress op).
+// 2. Runs 'git flow feature update --continue x'.
+// 3. Verifies "no merge in progress" and exit 3.
+func TestUpdateContinueNoMergeInProgress(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("init failed: %v\n%s", err, out)
+	}
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "start", "x"); err != nil {
+		t.Fatalf("feature start failed: %v\n%s", err, out)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "feature", "update", "--continue", "x")
+	if code := scopeExitCode(err); code != 3 {
+		t.Fatalf("expected exit 3, got %d (err=%v)\n%s", code, err, out)
+	}
+	if !strings.Contains(out, "no merge in progress") {
+		t.Errorf("expected 'no merge in progress', got:\n%s", out)
+	}
+}
+
+// =============================================================================
+// G. update state is self-describing; both-flags precedence; own-op in progress
+// =============================================================================
+
+// TestUpdateStateIsSelfDescribing verifies a topic update conflict saves a
+// resolvable, self-describing state.
+// Steps:
+// 1. Sets up an update merge conflict on feature/x (downstream=merge).
+// 2. Loads .git/gitflow/state/merge.json.
+// 3. Verifies Action=update, BranchType=feature, FullBranchName=feature/x,
+//    ParentBranch=develop, MergeStrategy=merge, CurrentStep=merge.
+func TestUpdateStateIsSelfDescribing(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupUpdateInProgressMerge(t, dir)
+
+	state, err := testutil.LoadMergeState(t, dir)
+	if err != nil || state == nil {
+		t.Fatalf("expected saved update state, err=%v", err)
+	}
+	if state.Action != "update" {
+		t.Errorf("expected Action update, got %s", state.Action)
+	}
+	if state.BranchType != "feature" {
+		t.Errorf("expected BranchType feature (resolvable), got %q", state.BranchType)
+	}
+	if state.FullBranchName != "feature/x" {
+		t.Errorf("expected FullBranchName feature/x, got %s", state.FullBranchName)
+	}
+	if state.ParentBranch != "develop" {
+		t.Errorf("expected ParentBranch develop, got %s", state.ParentBranch)
+	}
+	if state.MergeStrategy != "merge" {
+		t.Errorf("expected MergeStrategy merge, got %s", state.MergeStrategy)
+	}
+	if state.CurrentStep != "merge" {
+		t.Errorf("expected CurrentStep merge, got %s", state.CurrentStep)
+	}
+}
+
+// TestBaseUpdateStateIsSelfDescribing verifies a base-branch update conflict saves
+// a resolvable, self-describing state keyed on the base branch.
+// Steps:
+// 1. Sets up a develop <- main top-level update conflict.
+// 2. Loads .git/gitflow/state/merge.json.
+// 3. Verifies Action=update, BranchType=develop, FullBranchName=develop,
+//    ParentBranch=main, CurrentStep=merge.
+func TestBaseUpdateStateIsSelfDescribing(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupBaseUpdateInProgress(t, dir)
+
+	state, err := testutil.LoadMergeState(t, dir)
+	if err != nil || state == nil {
+		t.Fatalf("expected saved update state, err=%v", err)
+	}
+	if state.Action != "update" {
+		t.Errorf("expected Action update, got %s", state.Action)
+	}
+	if state.BranchType != "develop" {
+		t.Errorf("expected BranchType develop (base key), got %q", state.BranchType)
+	}
+	if state.FullBranchName != "develop" {
+		t.Errorf("expected FullBranchName develop, got %s", state.FullBranchName)
+	}
+	if state.ParentBranch != "main" {
+		t.Errorf("expected ParentBranch main, got %s", state.ParentBranch)
+	}
+	if state.CurrentStep != "merge" {
+		t.Errorf("expected CurrentStep merge, got %s", state.CurrentStep)
+	}
+}
+
+// TestUpdateContinueAndAbortAbortWins verifies --continue and --abort together
+// gives abort precedence.
+// Steps:
+// 1. Sets up an update merge conflict on feature/x; captures feature/x tip.
+// 2. Runs 'git flow feature update --continue --abort x'.
+// 3. Verifies the merge is aborted, feature/x restored, state cleared, exit 0.
+func TestUpdateContinueAndAbortAbortWins(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupUpdateInProgressMerge(t, dir)
+
+	preFeature := integRevParse(t, dir, "feature/x")
+
+	out, err := testutil.RunGitFlow(t, dir, "feature", "update", "--continue", "--abort", "x")
+	if err != nil {
+		t.Fatalf("expected abort precedence to succeed: %v\n%s", err, out)
+	}
+	if integMergeHeadExists(t, dir) {
+		t.Error("expected MERGE_HEAD gone after abort")
+	}
+	if got := integRevParse(t, dir, "feature/x"); got != preFeature {
+		t.Errorf("expected feature/x restored to %s, got %s", preFeature, got)
+	}
+	if testutil.GitFlowMergeStateExists(t, dir) {
+		t.Error("expected merge state cleared after abort")
+	}
+}
+
+// TestPlainUpdateDuringOwnUpdateReportsInProgress verifies a plain feature update
+// while its OWN update conflict is in progress reports a merge in progress rather
+// than silently restarting.
+// Steps:
+// 1. Sets up an update merge conflict on feature/x (Action=update).
+// 2. Runs 'git flow feature update x' (no continue/abort flags).
+// 3. Verifies exit 3, the message names update, and the merge is untouched.
+func TestPlainUpdateDuringOwnUpdateReportsInProgress(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	setupUpdateInProgressMerge(t, dir)
+
+	stateBefore := readStateBytes(t, dir)
+	out, err := testutil.RunGitFlow(t, dir, "feature", "update", "x")
+	if code := scopeExitCode(err); code != 3 {
+		t.Fatalf("expected exit 3, got %d (err=%v)\n%s", code, err, out)
+	}
+	if !strings.Contains(out, "update") {
+		t.Errorf("expected message to name update, got:\n%s", out)
+	}
+	if !integMergeHeadExists(t, dir) {
+		t.Error("expected MERGE_HEAD still present (not restarted)")
+	}
+	if got := readStateBytes(t, dir); got != stateBefore {
+		t.Errorf("expected state unchanged.\nbefore: %s\nafter:  %s", stateBefore, got)
+	}
+}


### PR DESCRIPTION
Scopes each resumable command's `--continue`/`--abort` to the operation it owns and makes `update` resumable, so one command can no longer consume, corrupt, or silently drop another's in-progress work.

git-flow keeps a single merge-state file for `finish`, `update`, and `integrate`, but resume/abort dispatch never checked which command owned it: `finish` would resume or abort whatever state was present, and `update` saved state it could never resume. A shared foreign-operation guard (`cmd/continue_abort.go`) now reads the raw state, confirms git is genuinely mid-merge/rebase, and refuses any command asked to act on a foreign operation with an owner-named, actionable message (naming the owner and the exact `--continue`/`--abort` commands) while mutating nothing and exiting 3. `finish` and `integrate` route through this guard; `update` gains a full dispatch of its own (guard plus `--continue`/`--abort`) on both the topic (`git flow <type> update`) and top-level (`git flow update`) surfaces, persisting a resolvable identity so its conflict state survives validation and can complete only the update — no tag, child update, or branch delete. `MergeInProgressError` becomes owner-aware and, together with `NoMergeInProgressError` and `UnresolvedConflictsError`, now implements the `errors.Error` interface returning exit 3, fixing the top-level `update` path that previously exited 1. Empty or unknown `Action` states with a live git marker are refused non-destructively via a new `UnrecognizedOperationError` rather than auto-cleared. Changes touch `cmd/continue_abort.go`, `cmd/update.go`, `cmd/finish.go`, `cmd/integrate.go`, `cmd/shorthand.go`, `cmd/topicbranch.go`, `internal/errors/errors.go`, and `internal/mergestate/mergestate.go`, with the three affected manpages updated.

Closes #143

### Remarks

- Squash-strategy `update --continue`/`--abort` is a documented known gap: a squash has no `MERGE_HEAD` and the shared abort cannot roll it back, so continuation returns a clear error rather than corrupting state.
- The one intended edit back to the integrate (#142) surface is the owner-aware `MergeInProgressError`; integrate's merge/tag/state-machine behavior is otherwise unchanged.
- Coverage spans all 34 spec scenarios, including the non-destructive assertion set (state bytes, HEAD, refs, tags, porcelain, git marker) for every foreign-refusal case.

**Review focus:**
- `cmd/continue_abort.go` — the shared guard, including the corrupt/truncated-state-file branch that refuses instead of auto-clearing while a git marker is present
- `cmd/update.go` — `handleUpdateContinue` (merge/rebase completion, rebase re-conflict stays resumable) and the resolvable-identity persistence for base branches
- `internal/errors/errors.go` — owner-aware message rendering and the exit-code interface change