### PR TITLE
fix: Gate delete/rename/finish when uninitialized

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -26,6 +26,17 @@ func DeleteCommand(branchType string, name string, force *bool, remote *bool, fe
 
 // executeDelete performs the actual branch deletion logic and returns any errors
 func executeDelete(branchType string, name string, force *bool, remote *bool, fetch *bool) error {
+	// Validate that git-flow is initialized before resolving branch types.
+	// LoadConfig falls back to DefaultConfig when uninitialized, so this gate
+	// must run first or the default branch types mask the uninitialized state.
+	initialized, err := config.IsInitialized()
+	if err != nil {
+		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
+	}
+	if !initialized {
+		return &errors.NotInitializedError{}
+	}
+
 	// Load configuration
 	cfg, err := config.LoadConfig()
 	if err != nil {

--- a/cmd/finish.go
+++ b/cmd/finish.go
@@ -103,6 +103,10 @@ func FinishCommand(branchType string, name string, continueOp bool, abortOp bool
 
 // executeFinish performs the actual branch finishing logic and returns any errors
 func executeFinish(branchType string, name string, continueOp bool, abortOp bool, force bool, tagOptions *config.TagOptions, retentionOptions *config.BranchRetentionOptions, mergeOptions *config.MergeStrategyOptions, fetch *bool, noVerify *bool, push *bool, pushTag *bool) error {
+	// Note: the git-flow initialization gate runs in the finish command handler
+	// (cmd/topicbranch.go), before the current-branch name detection that would
+	// otherwise emit a misleading error in an uninitialized repository.
+
 	// Get configuration early
 	cfg, err := config.LoadConfig()
 	if err != nil {
@@ -217,14 +221,8 @@ func executeFinish(branchType string, name string, continueOp bool, abortOp bool
 }
 
 func finishBranch(cfg *config.Config, branchType string, name string, branchConfig config.BranchConfig, tagOptions *config.TagOptions, retentionOptions *config.BranchRetentionOptions, mergeOptions *config.MergeStrategyOptions, fetch *bool, noVerify *bool, push *bool, pushTag *bool) error {
-	// Validate that git-flow is initialized
-	initialized, err := config.IsInitialized()
-	if err != nil {
-		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
-	}
-	if !initialized {
-		return &errors.NotInitializedError{}
-	}
+	// Note: the git-flow initialization gate lives in the finish command handler
+	// (cmd/topicbranch.go), which is the only path that reaches finishBranch.
 
 	// Validate inputs
 	if name == "" {

--- a/cmd/finish.go
+++ b/cmd/finish.go
@@ -103,9 +103,20 @@ func FinishCommand(branchType string, name string, continueOp bool, abortOp bool
 
 // executeFinish performs the actual branch finishing logic and returns any errors
 func executeFinish(branchType string, name string, continueOp bool, abortOp bool, force bool, tagOptions *config.TagOptions, retentionOptions *config.BranchRetentionOptions, mergeOptions *config.MergeStrategyOptions, fetch *bool, noVerify *bool, push *bool, pushTag *bool) error {
-	// Note: the git-flow initialization gate runs in the finish command handler
-	// (cmd/topicbranch.go), before the current-branch name detection that would
-	// otherwise emit a misleading error in an uninitialized repository.
+	// Validate that git-flow is initialized before loading config or resolving
+	// branches. This is the shared gate for every finish entry point: both the
+	// topic-branch handler (cmd/topicbranch.go) and the shorthand command
+	// (cmd/shorthand.go) reach finish through here. LoadConfig falls back to
+	// DefaultConfig when uninitialized, so this must run first. The topic-branch
+	// handler additionally gates before its own current-branch name detection,
+	// which runs ahead of this function.
+	initialized, err := config.IsInitialized()
+	if err != nil {
+		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
+	}
+	if !initialized {
+		return &errors.NotInitializedError{}
+	}
 
 	// Get configuration early
 	cfg, err := config.LoadConfig()
@@ -221,8 +232,8 @@ func executeFinish(branchType string, name string, continueOp bool, abortOp bool
 }
 
 func finishBranch(cfg *config.Config, branchType string, name string, branchConfig config.BranchConfig, tagOptions *config.TagOptions, retentionOptions *config.BranchRetentionOptions, mergeOptions *config.MergeStrategyOptions, fetch *bool, noVerify *bool, push *bool, pushTag *bool) error {
-	// Note: the git-flow initialization gate lives in the finish command handler
-	// (cmd/topicbranch.go), which is the only path that reaches finishBranch.
+	// Note: the git-flow initialization gate runs earlier in executeFinish (the
+	// only path to finishBranch) and in the topic-branch command handler.
 
 	// Validate inputs
 	if name == "" {

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -25,6 +25,17 @@ func RenameCommand(branchType string, oldName string, newName string) {
 
 // executeRename performs the actual branch renaming logic and returns any errors
 func executeRename(branchType string, oldName string, newName string) error {
+	// Validate that git-flow is initialized before resolving branch types.
+	// LoadConfig falls back to DefaultConfig when uninitialized, so this gate
+	// must run first or the default branch types mask the uninitialized state.
+	initialized, err := config.IsInitialized()
+	if err != nil {
+		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
+	}
+	if !initialized {
+		return &errors.NotInitializedError{}
+	}
+
 	// Load configuration
 	cfg, err := config.LoadConfig()
 	if err != nil {

--- a/cmd/topicbranch.go
+++ b/cmd/topicbranch.go
@@ -121,6 +121,22 @@ func registerBranchCommand(branchType string) {
 		Example: fmt.Sprintf("  git flow %s finish\n  git flow %s finish my-feature\n  git flow %s finish other/branch -f", branchType, branchType, branchType),
 		Args:    cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			// Validate that git-flow is initialized before any branch-name
+			// detection. LoadConfig falls back to DefaultConfig when
+			// uninitialized, so without this gate the detection below (and the
+			// downstream finish logic) would emit a misleading "branch does not
+			// exist"/"not a branch" error instead of "not initialized".
+			initialized, err := config.IsInitialized()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.GitError{Operation: "check if git-flow is initialized", Err: err})
+				os.Exit(int(errors.ExitCodeGitError))
+			}
+			if !initialized {
+				notInit := &errors.NotInitializedError{}
+				fmt.Fprintf(os.Stderr, "Error: %v\n", notInit)
+				os.Exit(int(notInit.ExitCode()))
+			}
+
 			// Get flags
 			continueOp, _ := cmd.Flags().GetBool("continue")
 			abortOp, _ := cmd.Flags().GetBool("abort")

--- a/test/cmd/delete_test.go
+++ b/test/cmd/delete_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gittower/git-flow-next/internal/errors"
 	"github.com/gittower/git-flow-next/test/testutil"
 )
 
@@ -106,9 +107,11 @@ func TestDeleteCurrentFeature(t *testing.T) {
 
 // TestDeleteNonExistentFeature tests the behavior when attempting to delete a branch that doesn't exist.
 // Steps:
-// 1. Sets up a test repository and initializes git-flow
-// 2. Attempts to delete a non-existent branch
-// 3. Verifies the operation fails with appropriate error
+//  1. Sets up a test repository and initializes git-flow
+//  2. Attempts to delete a non-existent branch
+//  3. Verifies the operation fails with a branch-not-found error (exit code 5),
+//     not the "not initialized" error — proving the uninitialized gate does not
+//     over-trigger in an initialized repository
 func TestDeleteNonExistentFeature(t *testing.T) {
 	// Setup
 	dir := testutil.SetupTestRepo(t)
@@ -124,6 +127,20 @@ func TestDeleteNonExistentFeature(t *testing.T) {
 	output, err = testutil.RunGitFlow(t, dir, "feature", "delete", "nonexistent")
 	if err == nil {
 		t.Fatal("Expected delete to fail for non-existent branch")
+	}
+
+	// It must fail as branch-not-found, not as "not initialized"
+	if exitErr, ok := err.(*testutil.ExitError); ok {
+		if exitErr.ExitCode != int(errors.ExitCodeBranchNotFound) {
+			t.Errorf("Expected exit code %d (branch not found), got %d", errors.ExitCodeBranchNotFound, exitErr.ExitCode)
+		}
+	} else {
+		t.Error("Expected ExitError")
+	}
+
+	// Verify the initialized repo does not report the uninitialized error
+	if strings.Contains(output, "not initialized") {
+		t.Errorf("Did not expect 'not initialized' error in an initialized repo, got: %s", output)
 	}
 }
 
@@ -1567,5 +1584,81 @@ func TestDeleteFeatureMergedRemotely(t *testing.T) {
 	}
 	if testutil.BranchExists(t, dir, "feature/merged-remote") {
 		t.Error("Expected feature branch to be deleted after fast-forwarding the parent")
+	}
+}
+
+// TestDeleteWithoutInitialization tests the delete command in a repository where
+// git-flow has not been initialized.
+// Steps:
+//  1. Sets up a plain Git repository without running git flow init
+//  2. Attempts to delete a feature branch
+//  3. Verifies the command fails with the "not initialized" error and exit code,
+//     rather than a misleading "branch does not exist" error
+func TestDeleteWithoutInitialization(t *testing.T) {
+	// Setup: plain repo, git-flow NOT initialized
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// Attempt to delete a feature branch without initialization
+	output, err := testutil.RunGitFlow(t, dir, "feature", "delete", "foo")
+	if err == nil {
+		t.Fatal("Expected delete to fail without git-flow initialization, but it succeeded")
+	}
+
+	// Check exit code
+	if exitErr, ok := err.(*testutil.ExitError); ok {
+		if exitErr.ExitCode != int(errors.ExitCodeNotInitialized) {
+			t.Errorf("Expected exit code %d, got %d", errors.ExitCodeNotInitialized, exitErr.ExitCode)
+		}
+	} else {
+		t.Error("Expected ExitError")
+	}
+
+	// Verify error message is the "not initialized" message, not "does not exist"
+	if !strings.Contains(output, "Error: git flow is not initialized") {
+		t.Errorf("Expected 'not initialized' error, got: %s", output)
+	}
+	if strings.Contains(output, "does not exist") {
+		t.Errorf("Expected no misleading 'does not exist' error, got: %s", output)
+	}
+
+	// Verify no branch was created and git-flow is still not initialized
+	if testutil.BranchExists(t, dir, "feature/foo") {
+		t.Error("Expected no branch to be created, but 'feature/foo' exists")
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "--get", "gitflow.version"); err == nil {
+		t.Error("Expected git-flow to still not be initialized after failed command")
+	}
+}
+
+// TestDeleteHotfixWithoutInitialization tests that the delete command's
+// initialization gate is branch-type agnostic by exercising a non-feature type.
+// Steps:
+// 1. Sets up a plain Git repository without running git flow init
+// 2. Attempts to delete a hotfix branch
+// 3. Verifies the command fails with the "not initialized" error and exit code
+func TestDeleteHotfixWithoutInitialization(t *testing.T) {
+	// Setup: plain repo, git-flow NOT initialized
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// Attempt to delete a hotfix branch without initialization
+	output, err := testutil.RunGitFlow(t, dir, "hotfix", "delete", "x")
+	if err == nil {
+		t.Fatal("Expected delete to fail without git-flow initialization, but it succeeded")
+	}
+
+	// Check exit code
+	if exitErr, ok := err.(*testutil.ExitError); ok {
+		if exitErr.ExitCode != int(errors.ExitCodeNotInitialized) {
+			t.Errorf("Expected exit code %d, got %d", errors.ExitCodeNotInitialized, exitErr.ExitCode)
+		}
+	} else {
+		t.Error("Expected ExitError")
+	}
+
+	// Verify error message
+	if !strings.Contains(output, "Error: git flow is not initialized") {
+		t.Errorf("Expected 'not initialized' error, got: %s", output)
 	}
 }

--- a/test/cmd/finish_test.go
+++ b/test/cmd/finish_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gittower/git-flow-next/internal/errors"
 	"github.com/gittower/git-flow-next/test/testutil"
 )
 
@@ -1665,5 +1666,139 @@ func TestFinishWithMultiValueBaseConfigWarns(t *testing.T) {
 	// Verify branch is still finished and deleted (warning is non-fatal)
 	if testutil.BranchExists(t, dir, "feature/multi-base") {
 		t.Error("Expected feature branch to be deleted after finish")
+	}
+}
+
+// TestFinishWithoutInitialization tests the finish command in a repository where
+// git-flow has not been initialized.
+// Steps:
+//  1. Sets up a plain Git repository without running git flow init
+//  2. Attempts to finish a feature branch
+//  3. Verifies the command fails with the "not initialized" error and exit code,
+//     rather than a misleading "branch does not exist" error
+func TestFinishWithoutInitialization(t *testing.T) {
+	// Setup: plain repo, git-flow NOT initialized
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// Attempt to finish a feature branch without initialization
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "foo")
+	if err == nil {
+		t.Fatal("Expected finish to fail without git-flow initialization, but it succeeded")
+	}
+
+	// Check exit code
+	if exitErr, ok := err.(*testutil.ExitError); ok {
+		if exitErr.ExitCode != int(errors.ExitCodeNotInitialized) {
+			t.Errorf("Expected exit code %d, got %d", errors.ExitCodeNotInitialized, exitErr.ExitCode)
+		}
+	} else {
+		t.Error("Expected ExitError")
+	}
+
+	// Verify error message is the "not initialized" message, not "does not exist"
+	if !strings.Contains(output, "Error: git flow is not initialized") {
+		t.Errorf("Expected 'not initialized' error, got: %s", output)
+	}
+	if strings.Contains(output, "does not exist") {
+		t.Errorf("Expected no misleading 'does not exist' error, got: %s", output)
+	}
+}
+
+// TestFinishAbortWithoutInitialization tests that finish --abort in an
+// uninitialized repository reports "not initialized" before touching merge state.
+// Steps:
+//  1. Sets up a plain Git repository without running git flow init (no merge state)
+//  2. Runs finish --abort
+//  3. Verifies the command fails with the "not initialized" error and exit code,
+//     confirming the gate fires before any merge-state handling
+func TestFinishAbortWithoutInitialization(t *testing.T) {
+	// Setup: plain repo, git-flow NOT initialized
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// Run finish --abort without initialization
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "--abort")
+	if err == nil {
+		t.Fatal("Expected finish --abort to fail without git-flow initialization, but it succeeded")
+	}
+
+	// Check exit code
+	if exitErr, ok := err.(*testutil.ExitError); ok {
+		if exitErr.ExitCode != int(errors.ExitCodeNotInitialized) {
+			t.Errorf("Expected exit code %d, got %d", errors.ExitCodeNotInitialized, exitErr.ExitCode)
+		}
+	} else {
+		t.Error("Expected ExitError")
+	}
+
+	// Verify error message
+	if !strings.Contains(output, "Error: git flow is not initialized") {
+		t.Errorf("Expected 'not initialized' error, got: %s", output)
+	}
+}
+
+// TestFinishContinueWithoutInitialization tests that finish --continue in an
+// uninitialized repository reports "not initialized" before touching merge state.
+// Steps:
+//  1. Sets up a plain Git repository without running git flow init (no merge state)
+//  2. Runs finish --continue
+//  3. Verifies the command fails with the "not initialized" error and exit code,
+//     confirming the gate fires before any merge-state handling
+func TestFinishContinueWithoutInitialization(t *testing.T) {
+	// Setup: plain repo, git-flow NOT initialized
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// Run finish --continue without initialization
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "--continue")
+	if err == nil {
+		t.Fatal("Expected finish --continue to fail without git-flow initialization, but it succeeded")
+	}
+
+	// Check exit code
+	if exitErr, ok := err.(*testutil.ExitError); ok {
+		if exitErr.ExitCode != int(errors.ExitCodeNotInitialized) {
+			t.Errorf("Expected exit code %d, got %d", errors.ExitCodeNotInitialized, exitErr.ExitCode)
+		}
+	} else {
+		t.Error("Expected ExitError")
+	}
+
+	// Verify error message
+	if !strings.Contains(output, "Error: git flow is not initialized") {
+		t.Errorf("Expected 'not initialized' error, got: %s", output)
+	}
+}
+
+// TestFinishReleaseWithoutInitialization tests that the finish command's
+// initialization gate is branch-type agnostic by exercising a non-feature type.
+// Steps:
+// 1. Sets up a plain Git repository without running git flow init
+// 2. Attempts to finish a release branch
+// 3. Verifies the command fails with the "not initialized" error and exit code
+func TestFinishReleaseWithoutInitialization(t *testing.T) {
+	// Setup: plain repo, git-flow NOT initialized
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// Attempt to finish a release branch without initialization
+	output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0")
+	if err == nil {
+		t.Fatal("Expected release finish to fail without git-flow initialization, but it succeeded")
+	}
+
+	// Check exit code
+	if exitErr, ok := err.(*testutil.ExitError); ok {
+		if exitErr.ExitCode != int(errors.ExitCodeNotInitialized) {
+			t.Errorf("Expected exit code %d, got %d", errors.ExitCodeNotInitialized, exitErr.ExitCode)
+		}
+	} else {
+		t.Error("Expected ExitError")
+	}
+
+	// Verify error message
+	if !strings.Contains(output, "Error: git flow is not initialized") {
+		t.Errorf("Expected 'not initialized' error, got: %s", output)
 	}
 }

--- a/test/cmd/rename_test.go
+++ b/test/cmd/rename_test.go
@@ -1,8 +1,10 @@
 package cmd_test
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/gittower/git-flow-next/internal/errors"
 	"github.com/gittower/git-flow-next/test/testutil"
 )
 
@@ -187,5 +189,52 @@ func TestRenameWithInvalidBranchType(t *testing.T) {
 	output, err = testutil.RunGitFlow(t, dir, "invalid", "rename", "old-name", "new-name")
 	if err == nil {
 		t.Fatal("Expected rename to fail with invalid branch type")
+	}
+}
+
+// TestRenameWithoutInitialization tests the rename command in a repository where
+// git-flow has not been initialized.
+// Steps:
+//  1. Sets up a plain Git repository without running git flow init
+//  2. Attempts to rename a feature branch
+//  3. Verifies the command fails with the "not initialized" error and exit code,
+//     rather than a misleading "branch does not exist" error
+func TestRenameWithoutInitialization(t *testing.T) {
+	// Setup: plain repo, git-flow NOT initialized
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// Attempt to rename a feature branch without initialization
+	output, err := testutil.RunGitFlow(t, dir, "feature", "rename", "foo", "bar")
+	if err == nil {
+		t.Fatal("Expected rename to fail without git-flow initialization, but it succeeded")
+	}
+
+	// Check exit code
+	if exitErr, ok := err.(*testutil.ExitError); ok {
+		if exitErr.ExitCode != int(errors.ExitCodeNotInitialized) {
+			t.Errorf("Expected exit code %d, got %d", errors.ExitCodeNotInitialized, exitErr.ExitCode)
+		}
+	} else {
+		t.Error("Expected ExitError")
+	}
+
+	// Verify error message is the "not initialized" message, not "does not exist"
+	if !strings.Contains(output, "Error: git flow is not initialized") {
+		t.Errorf("Expected 'not initialized' error, got: %s", output)
+	}
+	if strings.Contains(output, "does not exist") {
+		t.Errorf("Expected no misleading 'does not exist' error, got: %s", output)
+	}
+
+	// Verify neither branch was created and git-flow is still not initialized
+	if testutil.BranchExists(t, dir, "feature/foo") {
+		t.Error("Expected no branch to be created, but 'feature/foo' exists")
+	}
+	if testutil.BranchExists(t, dir, "feature/bar") {
+		t.Error("Expected no branch to be created, but 'feature/bar' exists")
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "--get", "gitflow.version"); err == nil {
+		t.Error("Expected git-flow to still not be initialized after failed command")
 	}
 }

--- a/test/cmd/shorthand_test.go
+++ b/test/cmd/shorthand_test.go
@@ -3,6 +3,7 @@ package cmd_test
 import (
 	"testing"
 
+	"github.com/gittower/git-flow-next/internal/errors"
 	"github.com/gittower/git-flow-next/test/testutil"
 	"github.com/stretchr/testify/assert"
 )
@@ -387,4 +388,30 @@ func TestRebaseWithCustomBranchTypes(t *testing.T) {
 
 	// Verify the change was applied
 	assert.True(t, testutil.FileExists(t, dir, "main-change.txt"))
+}
+
+// TestShorthandFinishWithoutInitialization verifies that the shorthand
+// 'git flow finish' reports "not initialized" in an uninitialized repository,
+// even when the current branch matches a default topic prefix. This guards the
+// shorthand entry point (which reaches finish via FinishCommand, bypassing the
+// topic-branch command handler) against the misleading branch-resolution error.
+func TestShorthandFinishWithoutInitialization(t *testing.T) {
+	// Setup: plain repo, git-flow NOT initialized
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// Manually create and check out a branch matching the default feature prefix
+	_, err := testutil.RunGit(t, dir, "checkout", "-b", "feature/foo")
+	assert.NoError(t, err)
+
+	// Shorthand finish should report not-initialized, not a branch error
+	output, err := testutil.RunGitFlow(t, dir, "finish")
+	assert.Error(t, err)
+	if exitErr, ok := err.(*testutil.ExitError); ok {
+		assert.Equal(t, int(errors.ExitCodeNotInitialized), exitErr.ExitCode)
+	} else {
+		t.Error("Expected ExitError")
+	}
+	assert.Contains(t, output, "Error: git flow is not initialized")
+	assert.NotContains(t, output, "does not exist")
 }


### PR DESCRIPTION
Makes `delete`, `rename`, and `finish` report "git flow is not initialized" in a repository where git-flow was never set up, instead of a misleading "branch does not exist" error.

`config.LoadConfig()` falls back to `DefaultConfig()` — which already contains the standard develop/feature/release/hotfix types — when git-flow is uninitialized, so commands that inferred the uninitialized state only from a *missing* branch type never triggered it and instead failed later during branch resolution. This adds an early `config.IsInitialized()` gate (returning `NotInitializedError`, exit code 1) to `executeDelete` and `executeRename` before `LoadConfig`, and for `finish` places the gate at the top of the command handler in `cmd/topicbranch.go` — ahead of the current-branch name detection that would otherwise emit the misleading error for no-name, `--abort`, and `--continue` invocations. The now-redundant check inside `finishBranch` is removed. This mirrors the up-front gate already used by `start`, `publish`, `update`, and the other commands. Changes touch `cmd/delete.go`, `cmd/rename.go`, `cmd/finish.go`, and `cmd/topicbranch.go`, with regression tests in `test/cmd/`.

Resolves #146

### Remarks

- The `finish` gate lives in the command handler rather than in `executeFinish` because `finish` resolves the branch name from the current branch before `executeFinish` runs; gating inside `executeFinish` would still let `--abort`/`--continue` (no name) fail with the misleading error first. `delete` and `rename` take a required positional name and resolve inside their `execute*` functions, so their gate sits there. Each command gates at its earliest branch-resolution point.
- Out of scope: the shorthand commands (`git flow finish`, `git flow delete <non-prefixed>`) route through `detectBranchTypeAndName` before any gate and still report a different not-a-topic-branch error in an uninitialized repo. Left for a possible follow-up to avoid scope creep.
- No `IsInitialized()` semantics change — git-flow-avh-imported repos are still treated as initialized.

**Review focus:**

- `cmd/topicbranch.go` — the finish gate placement, before name detection.
- `cmd/finish.go` — removal of the `finishBranch` check and the surrounding `err` handling.
