### PR TITLE
fix: Preserve shorthand detection errors

### DIFF
--- a/cmd/shorthand.go
+++ b/cmd/shorthand.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -10,6 +11,14 @@ import (
 	"github.com/gittower/git-flow-next/internal/git"
 	"github.com/spf13/cobra"
 )
+
+type notTopicBranchError struct {
+	branch string
+}
+
+func (err *notTopicBranchError) Error() string {
+	return fmt.Sprintf("current branch '%s' is not a valid topic branch (use explicit command, e.g., git flow feature finish)", err.branch)
+}
 
 // init registers all shorthand commands automatically
 func init() {
@@ -61,11 +70,11 @@ func RegisterShorthandCommands() {
 	updateCmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update the current branch from its parent",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			continueOp, _ := cmd.Flags().GetBool("continue")
 			abortOp, _ := cmd.Flags().GetBool("abort")
 			useRebase, _ := cmd.Flags().GetBool("rebase")
-			runShorthandUpdate(useRebase, continueOp, abortOp, args)
+			return runShorthandUpdate(useRebase, continueOp, abortOp, args)
 		},
 	}
 	addUpdateFlags(updateCmd)
@@ -75,11 +84,11 @@ func RegisterShorthandCommands() {
 	rebaseCmd := &cobra.Command{
 		Use:   "rebase",
 		Short: "Rebase the current branch onto its parent",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			// Always use rebase strategy for this shorthand
 			continueOp, _ := cmd.Flags().GetBool("continue")
 			abortOp, _ := cmd.Flags().GetBool("abort")
-			runShorthandUpdate(true, continueOp, abortOp, args)
+			return runShorthandUpdate(true, continueOp, abortOp, args)
 		},
 	}
 	rebaseCmd.Flags().BoolP("continue", "c", false, "Continue the update operation after resolving conflicts")
@@ -232,15 +241,17 @@ given, the current branch is integrated into its parent.`,
 }
 
 // runShorthandUpdate resolves the branch to update for the top-level update/rebase
-// surface and routes through UpdateCommand, which maps errors to exit codes and
-// exits (so the top-level surface exits 3, not main.go's exit 1). A topic current
-// branch is updated by its type; otherwise the current or named base branch is
-// used (branchType == "").
-func runShorthandUpdate(useRebase, continueOp, abortOp bool, args []string) {
+// surface. A topic current branch is updated by its type; a non-topic current
+// branch falls back to the current or named base branch (branchType == "").
+func runShorthandUpdate(useRebase, continueOp, abortOp bool, args []string) error {
 	branchType, name, err := detectBranchTypeAndName()
 	if err == nil {
 		UpdateCommand(branchType, name, useRebase, continueOp, abortOp)
-		return
+		return nil
+	}
+	var notTopicErr *notTopicBranchError
+	if !errors.As(err, &notTopicErr) {
+		return err
 	}
 	// Not a topic branch: fall back to the current or named base branch.
 	var branchName string
@@ -248,6 +259,7 @@ func runShorthandUpdate(useRebase, continueOp, abortOp bool, args []string) {
 		branchName = args[0]
 	}
 	UpdateCommand("", branchName, useRebase, continueOp, abortOp)
+	return nil
 }
 
 // detectBranchTypeAndName detects type and name from current branch
@@ -273,7 +285,7 @@ func detectBranchTypeAndName() (string, string, error) {
 
 	switch len(matches) {
 	case 0:
-		return "", "", fmt.Errorf("current branch '%s' is not a valid topic branch (use explicit command, e.g., git flow feature finish)", currentBranch)
+		return "", "", &notTopicBranchError{branch: currentBranch}
 	case 1:
 		typ := matches[0].Type
 		name := strings.TrimPrefix(currentBranch, matches[0].Prefix)

--- a/docs/git-flow-update.1.md
+++ b/docs/git-flow-update.1.md
@@ -14,6 +14,8 @@ git-flow-update - Update topic branches with parent changes
 
 Update a branch with the latest changes from its parent branch using the configured downstream merge strategy. On the topic surface (**git-flow** *topic* **update**) it works with any topic branch type (feature, release, hotfix, support, or custom types); on the top-level surface (**git-flow update**) it also updates the current base branch from its parent (for example, **develop** from **main**).
 
+The top-level **update** and **rebase** shorthands use the base-branch fallback only when the current branch is not a topic branch. Other branch-detection errors, including a cancelled ambiguous-branch prompt, stop the command without starting an update.
+
 The update operation merges or rebases changes from the parent branch into the target branch, keeping it current with the latest development.
 
 If a conflict occurs, the update saves a persistent state file and can be resumed with **--continue** or rolled back with **--abort** after resolving the conflict — the same resume/abort model as **git-flow finish** and **git-flow integrate**. The **--continue**/**--abort** flags act only on an in-progress update; an in-progress finish or integrate is never affected.
@@ -202,7 +204,7 @@ Each topic branch type updates from its configured parent:
 : Successful update, or **--abort** with nothing in progress (forgiving no-op)
 
 **1**
-: git-flow is not initialized
+: git-flow is not initialized, or shorthand branch detection failed or was cancelled
 
 **2**
 : Invalid input (e.g. unknown branch type)

--- a/test/cmd/shorthand_test.go
+++ b/test/cmd/shorthand_test.go
@@ -108,6 +108,30 @@ func TestAmbiguousBranchDetection(t *testing.T) {
 	assert.Contains(t, output, "operation cancelled")
 }
 
+func TestShorthandUpdateStopsOnAmbiguousBranch(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	testutil.RunGitFlow(t, dir, "init", "--defaults", "--feature", "feat/", "--hotfix", "feat/")
+
+	testutil.RunGit(t, dir, "checkout", "-b", "feat/ambiguous")
+	output, err := testutil.RunGitFlowWithInput(t, dir, "n\n", "update")
+	assert.Error(t, err)
+	assert.Contains(t, output, "Ambiguous branch")
+	assert.Contains(t, output, "operation cancelled")
+}
+
+func TestShorthandRebaseStopsOnAmbiguousBranch(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	testutil.RunGitFlow(t, dir, "init", "--defaults", "--feature", "feat/", "--hotfix", "feat/")
+
+	testutil.RunGit(t, dir, "checkout", "-b", "feat/ambiguous")
+	output, err := testutil.RunGitFlowWithInput(t, dir, "n\n", "rebase")
+	assert.Error(t, err)
+	assert.Contains(t, output, "Ambiguous branch")
+	assert.Contains(t, output, "operation cancelled")
+}
+
 // Command-Specific Tests
 func TestDeleteAlias(t *testing.T) {
 	dir := testutil.SetupTestRepo(t)


### PR DESCRIPTION
Stops the top-level `update` and `rebase` shorthands when topic-branch detection fails for a reason other than the current branch not being a topic branch.

The non-topic result now has a distinct error type, so the existing base-branch fallback remains available while cancellation, ambiguity, configuration, and Git errors return through Cobra. The regression tests cover declining the ambiguous-branch prompt on both shorthand commands, and the update manpage documents the boundary.

Resolves #149

### Testing

- `go test ./test/cmd -run '^TestShorthand(Update|Rebase)StopsOnAmbiguousBranch$' -count=1`
- `go test ./test/cmd -run '^(TestUpdateAlias|TestRebaseAlias|TestUpdateBaseBranch|TestNonTopicBranchErrorHandling|TestAmbiguousBranchDetection|TestShorthandUpdateStopsOnAmbiguousBranch|TestShorthandRebaseStopsOnAmbiguousBranch)$' -count=1`
- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `git diff --check`
