### PR TITLE
fix(cli): Validate leaf command arguments

### DIFF
--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -459,6 +459,14 @@ if err := git.BranchExists(branchName); err != nil {
 }
 ```
 
+### Cobra Positional Argument Validation
+
+Every leaf command must declare an explicit Cobra `Args` validator. Use
+`cobra.NoArgs` when the command takes no positional arguments, or a bounded
+validator such as `cobra.ExactArgs`, `cobra.MaximumNArgs`, or
+`cobra.RangeArgs` that matches exactly what the command consumes. Parent and
+dispatch commands that only delegate to subcommands are exempt.
+
 ### Options Struct Pattern
 
 For commands with multiple flags, use structured options:

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -231,6 +231,7 @@ Examples:
 var configListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List current git-flow configuration",
+	Args:  cobra.NoArgs,
 	Long: `List the current git-flow configuration showing all base branches and topic branch types.
 
 Shows the branch hierarchy, merge strategies, and other settings.

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -16,6 +16,7 @@ import (
 var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize git-flow in a repository",
+	Args:  cobra.NoArgs,
 	Long: `Initialize git-flow in a repository.
 This will set up the necessary configuration for git-flow to work.
 

--- a/cmd/overview.go
+++ b/cmd/overview.go
@@ -15,6 +15,7 @@ import (
 var overviewCmd = &cobra.Command{
 	Use:   "overview",
 	Short: "Show an overview of the git-flow configuration and branches",
+	Args:  cobra.NoArgs,
 	Long: `Show an overview of the git-flow configuration and branches.
 This command displays the current git-flow configuration and lists all active topic branches.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/shorthand.go
+++ b/cmd/shorthand.go
@@ -59,8 +59,9 @@ func RegisterShorthandCommands() {
 
 	// Update
 	updateCmd := &cobra.Command{
-		Use:   "update",
+		Use:   "update [base-branch]",
 		Short: "Update the current branch from its parent",
+		Args:  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			continueOp, _ := cmd.Flags().GetBool("continue")
 			abortOp, _ := cmd.Flags().GetBool("abort")
@@ -73,8 +74,9 @@ func RegisterShorthandCommands() {
 
 	// Rebase (shorthand for update --rebase)
 	rebaseCmd := &cobra.Command{
-		Use:   "rebase",
+		Use:   "rebase [base-branch]",
 		Short: "Rebase the current branch onto its parent",
+		Args:  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Always use rebase strategy for this shorthand
 			continueOp, _ := cmd.Flags().GetBool("continue")
@@ -106,6 +108,7 @@ func RegisterShorthandCommands() {
 	publishCmd := &cobra.Command{
 		Use:   "publish",
 		Short: "Publish the current topic branch to remote",
+		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			branchType, name, err := detectBranchTypeAndName()
 			if err != nil {
@@ -125,6 +128,7 @@ func RegisterShorthandCommands() {
 	finishCmd := &cobra.Command{
 		Use:   "finish",
 		Short: "Finish the current topic branch",
+		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			branchType, name, err := detectBranchTypeAndName()
 			if err != nil {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -16,6 +16,7 @@ var (
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Show version information",
+	Args:  cobra.NoArgs,
 	Long:  `Display version information for git-flow-next.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Printf("git-flow-next version %s\n", Version)

--- a/docs/git-flow-update.1.md
+++ b/docs/git-flow-update.1.md
@@ -26,7 +26,10 @@ If a conflict occurs, the update saves a persistent state file and can be resume
 : The topic branch type (feature, release, hotfix, support, or any configured custom type)
 
 *name*
-: Name of the topic branch to update. If omitted, the current branch is used (when using shorthand **git-flow update**)
+: Name of the topic branch to update on the **git-flow** *topic* **update** surface. If omitted, the current topic branch is used.
+
+*base-branch*
+: Base branch to update on the top-level **git-flow update** or **git-flow rebase** surface. If omitted, the current base branch is used.
 
 ## OPTIONS
 

--- a/docs/git-flow-update.1.md
+++ b/docs/git-flow-update.1.md
@@ -8,7 +8,9 @@ git-flow-update - Update topic branches with parent changes
 
 **git-flow** *topic* **update** [*name*] [*options*]
 
-**git-flow update** [*name*] [*options*]
+**git-flow update** [*base-branch*] [*options*]
+
+**git-flow rebase** [*base-branch*] [**--continue**|**--abort**]
 
 ## DESCRIPTION
 

--- a/test/cmd/args_validation_test.go
+++ b/test/cmd/args_validation_test.go
@@ -1,0 +1,87 @@
+package cmd_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+func assertCommandRejectsExtraArgs(t *testing.T, expected string, args ...string) {
+	t.Helper()
+
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	output, err := testutil.RunGitFlow(t, dir, args...)
+	if err == nil {
+		t.Fatalf("Expected command %q to reject extra arguments", strings.Join(args, " "))
+	}
+	if !strings.Contains(output, expected) {
+		t.Fatalf("Expected output to contain %q, got: %s", expected, output)
+	}
+}
+
+// TestShorthandUpdateRejectsExtraArgs verifies update accepts at most one base branch.
+// Steps:
+// 1. Runs the top-level update command with two positional arguments
+// 2. Verifies Cobra rejects the second argument before command execution
+func TestShorthandUpdateRejectsExtraArgs(t *testing.T) {
+	assertCommandRejectsExtraArgs(t, "accepts at most 1 arg(s), received 2", "update", "main", "develop")
+}
+
+// TestShorthandRebaseRejectsExtraArgs verifies rebase accepts at most one base branch.
+// Steps:
+// 1. Runs the top-level rebase command with two positional arguments
+// 2. Verifies Cobra rejects the second argument before command execution
+func TestShorthandRebaseRejectsExtraArgs(t *testing.T) {
+	assertCommandRejectsExtraArgs(t, "accepts at most 1 arg(s), received 2", "rebase", "main", "develop")
+}
+
+// TestShorthandPublishRejectsExtraArgs verifies publish accepts no positional arguments.
+// Steps:
+// 1. Runs the top-level publish command with an unexpected positional argument
+// 2. Verifies Cobra rejects the argument before command execution
+func TestShorthandPublishRejectsExtraArgs(t *testing.T) {
+	assertCommandRejectsExtraArgs(t, `unknown command "extra"`, "publish", "extra")
+}
+
+// TestShorthandFinishRejectsExtraArgs verifies finish accepts no positional arguments.
+// Steps:
+// 1. Runs the top-level finish command with an unexpected positional argument
+// 2. Verifies Cobra rejects the argument before command execution
+func TestShorthandFinishRejectsExtraArgs(t *testing.T) {
+	assertCommandRejectsExtraArgs(t, `unknown command "extra"`, "finish", "extra")
+}
+
+// TestInitRejectsExtraArgs verifies init accepts no positional arguments.
+// Steps:
+// 1. Runs the init command with an unexpected positional argument
+// 2. Verifies Cobra rejects the argument before initialization
+func TestInitRejectsExtraArgs(t *testing.T) {
+	assertCommandRejectsExtraArgs(t, `unknown command "extra"`, "init", "extra")
+}
+
+// TestOverviewRejectsExtraArgs verifies overview accepts no positional arguments.
+// Steps:
+// 1. Runs the overview command with an unexpected positional argument
+// 2. Verifies Cobra rejects the argument before generating output
+func TestOverviewRejectsExtraArgs(t *testing.T) {
+	assertCommandRejectsExtraArgs(t, `unknown command "extra"`, "overview", "extra")
+}
+
+// TestVersionRejectsExtraArgs verifies version accepts no positional arguments.
+// Steps:
+// 1. Runs the version command with an unexpected positional argument
+// 2. Verifies Cobra rejects the argument before printing version information
+func TestVersionRejectsExtraArgs(t *testing.T) {
+	assertCommandRejectsExtraArgs(t, `unknown command "extra"`, "version", "extra")
+}
+
+// TestConfigListRejectsExtraArgs verifies config list accepts no positional arguments.
+// Steps:
+// 1. Runs the config list command with an unexpected positional argument
+// 2. Verifies Cobra rejects the argument before reading configuration
+func TestConfigListRejectsExtraArgs(t *testing.T) {
+	assertCommandRejectsExtraArgs(t, `unknown command "extra"`, "config", "list", "extra")
+}


### PR DESCRIPTION
Rejects unexpected positional arguments across the remaining leaf commands so typos fail before command execution.

The change adds explicit Cobra validators to the eight commands identified in #150, updates the top-level update and rebase usage text and manpage synopsis, documents the leaf-command validator convention, and adds regression coverage for every affected command.

Resolves #150

### Testing

- `go test ./test/cmd -run 'RejectsExtraArgs' -count=1`
- `go vet ./...`
- `go build ./...`

### Remarks

A full `go test ./...` run was also attempted on Windows. Existing platform-dependent tests fail because POSIX executable bits and `sh` are unavailable, some temporary Git repositories remain locked, and the command package reaches its existing 10-minute timeout. The focused command tests above pass on the same environment.