### PR TITLE
feat(start): fetch by default before creating a branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `finish` now aborts when the topic branch is ahead of its remote (was a silent note that proceeded and merged)
 - `finish` renders a diverged-specific message when the topic branch has diverged (previously reused the "behind" wording)
 - `start` now skips the fetch silently when no remote is configured, and shares the unified fetch resolution (default → config → flag) with `finish`
+- `start` now fetches by default before creating a branch. Users who relied on `start` never touching the network will now see a fetch unless they set `gitflow.<type>.start.fetch false` or pass `--no-fetch`.
 
 ## [1.1.0] - 2026-04-06
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -159,7 +159,7 @@ The finish command supports per-branch-type configuration:
 | `keepremote` | Keep remote branch | `true`, `false` | `false` |
 | `keeplocal` | Keep local branch | `true`, `false` | `false` |
 | `force-delete` | Force delete branch | `true`, `false` | `false` |
-| `fetch` | Fetch before operation (`gitflow.<type>.<cmd>.fetch`; default → config → `--fetch`/`--no-fetch`) | `true`, `false` | `true` for `finish`, `false` for `start` |
+| `fetch` | Fetch before operation (`gitflow.<type>.<cmd>.fetch`; default → config → `--fetch`/`--no-fetch`) | `true`, `false` | `true` for both `finish` and `start` |
 | `push` | Push finished branches to remote | `true`, `false` | `false` |
 | `pushtag` | Push created tag to remote | `true`, `false` | Follows `push` |
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -112,7 +112,7 @@ func start(branchType string, name string, base string, shouldFetch *bool) error
 
 // executeStart performs the actual start operation (called within hooks wrapper)
 func executeStart(branchType string, name string, base string, shouldFetch *bool, cfg *config.Config, branchConfig config.BranchConfig, fullBranchName string, startPoint string) error {
-	// Determine if we should fetch using the shared resolver (default false for start):
+	// Determine if we should fetch using the shared resolver (default true for start):
 	// Layer 1 default -> gitflow.<type>.start.fetch config -> CLI flag.
 	remoteName := cfg.Remote
 	if config.ResolveStartShouldFetch(cfg, branchType, shouldFetch) {

--- a/docs/git-flow-start.1.md
+++ b/docs/git-flow-start.1.md
@@ -14,7 +14,7 @@ Create and checkout a new topic branch of the specified type. This command works
 
 The new branch is created from the configured starting point for the topic branch type, or from the specified base commit/branch if provided.
 
-By default, start fetches from the remote before creating the branch so it starts from up-to-date remote state. Opt out with **--no-fetch** or by setting `gitflow.<type>.start.fetch false`. If no remote is configured, the fetch is skipped silently, and a fetch failure is a non-fatal warning — the branch is still created (start has no sync gate).
+By default, start fetches from the remote before creating the branch, so its remote-tracking refs are current first. (The branch is still created from the configured local start point; the fetch refreshes remote-tracking refs but does not fast-forward that start point.) Opt out with **--no-fetch** or by setting `gitflow.<type>.start.fetch false`. If no remote is configured, the fetch is skipped silently, and a fetch failure is a non-fatal warning — the branch is still created (start has no sync gate).
 
 ## ARGUMENTS
 
@@ -105,7 +105,7 @@ git flow hotfix start 1.1.1 v1.1.0
 
 ### Without Remote Synchronization
 
-Start is fetched by default; skip the fetch to work offline or avoid touching the network:
+Start fetches by default; skip the fetch to work offline or avoid touching the network:
 ```bash
 git flow feature start new-api --no-fetch
 ```
@@ -157,7 +157,7 @@ The start command performs several validations:
 
 ### Remote Workflow
 ```bash
-# Start (fetches latest remote state by default) and immediately publish
+# Start (fetches from the remote by default) and immediately publish
 git flow feature start new-api
 git push -u origin feature/new-api
 ```

--- a/docs/git-flow-start.1.md
+++ b/docs/git-flow-start.1.md
@@ -14,6 +14,8 @@ Create and checkout a new topic branch of the specified type. This command works
 
 The new branch is created from the configured starting point for the topic branch type, or from the specified base commit/branch if provided.
 
+By default, start fetches from the remote before creating the branch so it starts from up-to-date remote state. Opt out with **--no-fetch** or by setting `gitflow.<type>.start.fetch false`. If no remote is configured, the fetch is skipped silently, and a fetch failure is a non-fatal warning — the branch is still created (start has no sync gate).
+
 ## ARGUMENTS
 
 *topic*
@@ -28,10 +30,10 @@ The new branch is created from the configured starting point for the topic branc
 ## OPTIONS
 
 **--fetch**
-: Fetch from remote before creating branch to ensure latest state. If no remote is configured, the fetch is skipped silently. A fetch failure is a non-fatal warning — the branch is still created (start has no sync gate). Overrides git config setting `gitflow.<type>.start.fetch`.
+: Fetch from remote before creating branch to ensure latest state (this is the default). If no remote is configured, the fetch is skipped silently. A fetch failure is a non-fatal warning — the branch is still created (start has no sync gate). Overrides git config setting `gitflow.<type>.start.fetch`.
 
 **--no-fetch**
-: Don't fetch from remote before creating branch (default behavior). Overrides git config setting `gitflow.<type>.start.fetch`.
+: Don't fetch from remote before creating branch. Use this to opt out of the default fetch. Overrides git config setting `gitflow.<type>.start.fetch`.
 
 ## BRANCH NAMING
 
@@ -101,11 +103,11 @@ Start hotfix from specific tag:
 git flow hotfix start 1.1.1 v1.1.0
 ```
 
-### With Remote Synchronization
+### Without Remote Synchronization
 
-Fetch latest changes before starting:
+Start is fetched by default; skip the fetch to work offline or avoid touching the network:
 ```bash
-git flow feature start new-api --fetch
+git flow feature start new-api --no-fetch
 ```
 
 ## CONFIGURATION
@@ -128,11 +130,11 @@ git config gitflow.branch.hotfix.prefix hotfix/
 
 ### Command Overrides
 ```bash
-# Always fetch before starting features
-git config gitflow.feature.start.fetch true
+# Never fetch before starting features (opt out of the default)
+git config gitflow.feature.start.fetch false
 
-# Always fetch before starting releases
-git config gitflow.release.start.fetch true
+# Never fetch before starting releases (opt out of the default)
+git config gitflow.release.start.fetch false
 ```
 
 ## VALIDATION
@@ -155,15 +157,15 @@ The start command performs several validations:
 
 ### Remote Workflow
 ```bash
-# Start and immediately publish
-git flow feature start new-api --fetch
+# Start (fetches latest remote state by default) and immediately publish
+git flow feature start new-api
 git push -u origin feature/new-api
 ```
 
 ### Team Workflow
 ```bash
-# Ensure latest state before starting
-git flow feature start team-feature --fetch
+# Start fetches by default, so you begin from the latest state
+git flow feature start team-feature
 ```
 
 ## EXIT STATUS
@@ -193,7 +195,7 @@ git flow feature start team-feature --fetch
 ## NOTES
 
 - Branch names should not include the prefix (it's added automatically)
-- Use **--fetch** in team environments to ensure you start from latest changes
+- Start fetches by default so you begin from the latest changes; use **--no-fetch** (or `gitflow.<type>.start.fetch false`) to opt out
 - Custom topic branch types work exactly like built-in types
 - The base argument overrides the configured starting point for this specific branch
 - Branch creation fails if a branch with the same full name already exists

--- a/docs/gitflow-config.5.md
+++ b/docs/gitflow-config.5.md
@@ -207,7 +207,7 @@ These are operational settings that adjust command behavior. Some can override L
 
 **fetch**
 : Fetch from remote before the operation. This is a Layer 2 operational setting only (there is no Layer 1 branch-type knob). Resolution is uniform across commands: per-command default, then `gitflow.<type>.<cmd>.fetch`, then the `--fetch`/`--no-fetch` CLI flag (which always wins).
-: *Default*: **true** for both `finish` (so the sync check runs against fresh data) and `start` (so branches begin from up-to-date remote state).
+: *Default*: **true** for both `finish` (so the sync check runs against fresh data) and `start` (so remote-tracking refs are refreshed before the branch is created).
 
 **keep**
 : Keep branch after finishing (finish command only).

--- a/docs/gitflow-config.5.md
+++ b/docs/gitflow-config.5.md
@@ -207,7 +207,7 @@ These are operational settings that adjust command behavior. Some can override L
 
 **fetch**
 : Fetch from remote before the operation. This is a Layer 2 operational setting only (there is no Layer 1 branch-type knob). Resolution is uniform across commands: per-command default, then `gitflow.<type>.<cmd>.fetch`, then the `--fetch`/`--no-fetch` CLI flag (which always wins).
-: *Default*: **true** for `finish` (so the sync check runs against fresh data), **false** for `start`.
+: *Default*: **true** for both `finish` (so the sync check runs against fresh data) and `start` (so branches begin from up-to-date remote state).
 
 **keep**
 : Keep branch after finishing (finish command only).

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -454,7 +454,7 @@ func resolveFinishNoFF(cfg *Config, branchType string, command string, mergeOpts
 
 // resolveShouldFetch resolves whether to fetch from the remote before a command runs, using the
 // standard precedence: Layer-1 default (per command) -> gitflow.<type>.<cmd>.fetch config ->
-// CLI flag. Shared by finish (default true) and start (default false).
+// CLI flag. Shared by finish (default true) and start (default true).
 func resolveShouldFetch(cfg *Config, branchType, cmd string, defaultFetch bool, fetch *bool) bool {
 	// Layer 1: Command default
 	shouldFetch := defaultFetch
@@ -480,9 +480,9 @@ func resolveFinishShouldFetch(cfg *Config, branchType string, fetch *bool) bool 
 }
 
 // ResolveStartShouldFetch resolves whether to fetch from remote before starting a branch.
-// The default is false (start does not fetch unless explicitly enabled).
+// The default is true (start fetches unless opted out via config false or --no-fetch).
 func ResolveStartShouldFetch(cfg *Config, branchType string, fetch *bool) bool {
-	return resolveShouldFetch(cfg, branchType, "start", false, fetch)
+	return resolveShouldFetch(cfg, branchType, "start", true, fetch)
 }
 
 // resolveFinishNoVerify resolves whether to skip pre-commit and commit-msg hooks

--- a/test/cmd/start_test.go
+++ b/test/cmd/start_test.go
@@ -397,33 +397,99 @@ func TestStartWithoutInitialization(t *testing.T) {
 	}
 }
 
-// TestStartWithoutFetch tests Scenario 19: the default start behavior does not fetch (default false).
-// Uses a remote-backed fixture so the absence of "Fetching" reflects the default, not a missing remote.
+// TestStartFetchesByDefault tests Scenario 1 (#98): with no fetch config and no flag, start
+// fetches from the remote by default and the remote advance becomes visible locally.
+// This is the regression guard for the fetch-on-by-default change: origin/develop advancing
+// OLD -> NEW is the only observable proof the default fetch actually ran. The advance is made
+// from a second clone so the primary's origin/develop is not updated before start runs —
+// otherwise the test would pass without ever fetching.
+//
+// Note: this asserts the fetch ran, NOT that the feature branch is based on NEW. A plain
+// 'git fetch origin' advances origin/develop but does not fast-forward local develop, and
+// executeStart branches from the local start point, so the branch is still based on OLD local
+// develop. That branching behavior is owned by #134 and is out of #98's scope; this mirrors the
+// assertion convention of TestStartFetchesAdvancedStartPoint (config-forced path).
 // Steps:
-// 1. Sets up a test repository with a remote and initializes git-flow
-// 2. Runs 'git flow feature start' with no fetch flag and no fetch config
-// 3. Verifies no "Fetching" line appears
-// 4. Verifies the feature branch is created
-func TestStartWithoutFetch(t *testing.T) {
-	// Setup test repo with remote so absence of fetch reflects the default (not a missing remote)
+// 1. Sets up a test repository with a remote and initializes git-flow (NO fetch config, NO flag)
+// 2. Records OLD = the primary's origin/develop
+// 3. Advances develop from a second clone (commit + push); records NEW = the bare remote develop
+// 4. Asserts the primary's origin/develop is still OLD and the bare develop is NEW (out of sync)
+// 5. Runs 'git flow feature start'
+// 6. Verifies a "Fetching" line, the branch is created, and origin/develop now resolves to NEW
+func TestStartFetchesByDefault(t *testing.T) {
 	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
 	defer testutil.CleanupTestRepo(t, dir)
 	defer testutil.CleanupTestRepo(t, remoteDir)
 
-	// Run git-flow feature start without the fetch flag (default is no fetch)
-	output, err := testutil.RunGitFlow(t, dir, "feature", "start", "no-fetch-test")
+	// Record OLD = the primary's origin/develop before advancing
+	oldRaw, err := testutil.RunGit(t, dir, "rev-parse", "origin/develop")
+	if err != nil {
+		t.Fatalf("Failed to get origin/develop: %v", err)
+	}
+	old := strings.TrimSpace(oldRaw)
+
+	// Advance develop from a second clone
+	secondDir := t.TempDir()
+	if _, err := testutil.RunGit(t, secondDir, "clone", remoteDir, "."); err != nil {
+		t.Fatalf("Failed to clone: %v", err)
+	}
+	testutil.ConfigureGitIdentity(t, secondDir)
+	if _, err := testutil.RunGit(t, secondDir, "checkout", "develop"); err != nil {
+		t.Fatalf("Failed to checkout develop in second repo: %v", err)
+	}
+	testutil.WriteFile(t, secondDir, "advance.txt", "advanced content")
+	if _, err := testutil.RunGit(t, secondDir, "add", "advance.txt"); err != nil {
+		t.Fatalf("Failed to add file in second repo: %v", err)
+	}
+	if _, err := testutil.RunGit(t, secondDir, "commit", "-m", "Advance develop"); err != nil {
+		t.Fatalf("Failed to commit in second repo: %v", err)
+	}
+	if _, err := testutil.RunGit(t, secondDir, "push", "origin", "develop"); err != nil {
+		t.Fatalf("Failed to push from second repo: %v", err)
+	}
+
+	// Record NEW = the bare remote develop
+	newRaw, err := testutil.RunGit(t, remoteDir, "rev-parse", "refs/heads/develop")
+	if err != nil {
+		t.Fatalf("Failed to get bare develop: %v", err)
+	}
+	newSHA := strings.TrimSpace(newRaw)
+
+	// Precondition: primary origin/develop still OLD, bare develop is NEW, and they differ
+	primaryBeforeRaw, err := testutil.RunGit(t, dir, "rev-parse", "origin/develop")
+	if err != nil {
+		t.Fatalf("Failed to get primary origin/develop: %v", err)
+	}
+	if strings.TrimSpace(primaryBeforeRaw) != old {
+		t.Fatalf("Precondition failed: expected primary origin/develop to still be OLD (%s), got %s", old, strings.TrimSpace(primaryBeforeRaw))
+	}
+	if old == newSHA {
+		t.Fatalf("Precondition failed: expected OLD (%s) != NEW (%s)", old, newSHA)
+	}
+
+	// Run start with no fetch config and no flag — the new default should drive the fetch
+	output, err := testutil.RunGitFlow(t, dir, "feature", "start", "advanced-default")
 	if err != nil {
 		t.Fatalf("Failed to run git-flow feature start: %v\nOutput: %s", err, output)
 	}
 
-	// Verify that output does not contain fetching info
-	if strings.Contains(output, "Fetching from") {
-		t.Errorf("Expected no fetch operation, but output indicates fetching: %s", output)
+	// Verify fetch ran by default
+	if !strings.Contains(output, "Fetching from") {
+		t.Errorf("Expected a fetch to run by default. Output: %s", output)
 	}
 
-	// Verify the branch was created
-	if !testutil.BranchExists(t, dir, "feature/no-fetch-test") {
-		t.Error("Expected feature/no-fetch-test branch to exist")
+	// Verify branch created
+	if !testutil.BranchExists(t, dir, "feature/advanced-default") {
+		t.Error("Expected feature/advanced-default branch to exist")
+	}
+
+	// Verify the advance is now visible: primary origin/develop == NEW (proof the default fetch ran)
+	afterRaw, err := testutil.RunGit(t, dir, "rev-parse", "origin/develop")
+	if err != nil {
+		t.Fatalf("Failed to get origin/develop after start: %v", err)
+	}
+	if strings.TrimSpace(afterRaw) != newSHA {
+		t.Errorf("Expected origin/develop to advance to NEW (%s) after default start, got %s", newSHA, strings.TrimSpace(afterRaw))
 	}
 }
 
@@ -781,5 +847,186 @@ func TestStartUnreachableRemoteWarnsAndCreates(t *testing.T) {
 	// Verify branch created
 	if !testutil.BranchExists(t, dir, "feature/unreachable-test") {
 		t.Error("Expected feature/unreachable-test branch to exist")
+	}
+}
+
+// TestStartFetchConfigFalseSkipsFetch tests Scenario 2 (#98): an explicit
+// gitflow.<type>.start.fetch=false opt-out wins over the new fetch-on-by-default.
+// Uses a remote-backed fixture so the absence of "Fetching" reflects the config, not a
+// missing remote.
+// Steps:
+// 1. Sets up a test repository with a remote and initializes git-flow
+// 2. Sets gitflow.feature.start.fetch=false; no flag
+// 3. Runs 'git flow feature start'
+// 4. Verifies no "Fetching from" line appears (config false wins over the default)
+// 5. Verifies the feature branch is created
+func TestStartFetchConfigFalseSkipsFetch(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	// Explicit opt-out via config
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.feature.start.fetch", "false"); err != nil {
+		t.Fatalf("Failed to set config: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "start", "config-false-test")
+	if err != nil {
+		t.Fatalf("Failed to run git-flow feature start: %v\nOutput: %s", err, output)
+	}
+
+	// Verify no fetch (config false overrides the new default)
+	if strings.Contains(output, "Fetching from") {
+		t.Errorf("Expected no fetch due to config false, but output indicates fetching: %s", output)
+	}
+
+	// Verify branch created
+	if !testutil.BranchExists(t, dir, "feature/config-false-test") {
+		t.Error("Expected feature/config-false-test branch to exist")
+	}
+}
+
+// TestStartNoFetchFlagSkipsByDefault tests Scenario 3 (#98): --no-fetch overrides the new
+// fetch-on-by-default when there is no fetch config.
+// Uses a remote-backed fixture so the absence of "Fetching" reflects the flag, not a missing
+// remote.
+// Steps:
+// 1. Sets up a test repository with a remote and initializes git-flow (no fetch config)
+// 2. Runs 'git flow feature start ... --no-fetch'
+// 3. Verifies no "Fetching from" line appears (flag overrides the default)
+// 4. Verifies the feature branch is created
+func TestStartNoFetchFlagSkipsByDefault(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "start", "no-fetch-flag-test", "--no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to run git-flow feature start: %v\nOutput: %s", err, output)
+	}
+
+	// Verify no fetch (--no-fetch overrides the new default)
+	if strings.Contains(output, "Fetching from") {
+		t.Errorf("Expected no fetch due to --no-fetch flag, but output indicates fetching: %s", output)
+	}
+
+	// Verify branch created
+	if !testutil.BranchExists(t, dir, "feature/no-fetch-flag-test") {
+		t.Error("Expected feature/no-fetch-flag-test branch to exist")
+	}
+}
+
+// TestStartFetchFlagOverridesConfigFalse tests Scenario 4 (#98): --fetch beats
+// gitflow.<type>.start.fetch=false, confirming the new default did not disturb precedence.
+// Steps:
+// 1. Sets up a test repository with a remote and initializes git-flow
+// 2. Sets gitflow.feature.start.fetch=false
+// 3. Runs 'git flow feature start ... --fetch'
+// 4. Verifies a "Fetching from" line appears (flag beats config false)
+// 5. Verifies the feature branch is created
+func TestStartFetchFlagOverridesConfigFalse(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.feature.start.fetch", "false"); err != nil {
+		t.Fatalf("Failed to set config: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "start", "flag-over-config-test", "--fetch")
+	if err != nil {
+		t.Fatalf("Failed to run git-flow feature start: %v\nOutput: %s", err, output)
+	}
+
+	// Verify fetch ran (flag beats config false)
+	if !strings.Contains(output, "Fetching from") {
+		t.Errorf("Expected fetch due to --fetch flag overriding config false: %s", output)
+	}
+
+	// Verify branch created
+	if !testutil.BranchExists(t, dir, "feature/flag-over-config-test") {
+		t.Error("Expected feature/flag-over-config-test branch to exist")
+	}
+}
+
+// TestStartDefaultNoRemoteFetchSkipped tests Scenario 5 (#98): with no remote and no fetch
+// config, the new default fetch is skipped silently and the branch is still created. Confirms
+// the new default never turns into a "not a git repository" error in local-only repos.
+// This is the no-config sibling of TestStartFeatureBranchNoRemoteFetchSkipped.
+// Steps:
+// 1. Sets up a test repository WITHOUT a remote and initializes git-flow with defaults
+// 2. Runs 'git flow feature start' (NO fetch config — relies on the new default)
+// 3. Verifies output does NOT contain "Fetching" (fetch skipped silently)
+// 4. Verifies output does NOT contain "does not appear to be a git repository"
+// 5. Verifies the feature branch is created
+func TestStartDefaultNoRemoteFetchSkipped(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+
+	// Start a feature branch relying on the new default (no fetch config)
+	output, err := testutil.RunGitFlow(t, dir, "feature", "start", "no-remote-default-test")
+	if err != nil {
+		t.Fatalf("Failed to start feature branch: %v\nOutput: %s", err, output)
+	}
+
+	// Verify fetch was skipped silently
+	if strings.Contains(output, "Fetching") {
+		t.Error("Expected fetch to be skipped silently, but output contains 'Fetching'")
+	}
+	if strings.Contains(output, "does not appear to be a git repository") {
+		t.Error("Expected no confusing error messages about missing remote")
+	}
+
+	// Verify branch created
+	if !testutil.BranchExists(t, dir, "feature/no-remote-default-test") {
+		t.Error("Expected feature/no-remote-default-test branch to exist")
+	}
+}
+
+// TestStartDefaultUnreachableRemoteWarnsAndCreates tests Scenario 6 (#98): with no fetch config
+// and an unreachable remote, the new default fetch is attempted, its failure is a non-fatal
+// warning, and the branch is still created. Confirms the default fetch is non-fatal for start
+// (no sync gate). This is the no-config sibling of TestStartUnreachableRemoteWarnsAndCreates.
+// RunGitFlow uses CombinedOutput, so both the "Fetching from" attempt and the warning are
+// observable.
+// Steps:
+// 1. Sets up a test repository with a remote and initializes git-flow (NO fetch config)
+// 2. Points origin at a nonexistent path
+// 3. Runs 'git flow feature start' (no flag — relies on the new default)
+// 4. Verifies the command still succeeds (exit 0)
+// 5. Verifies combined output contains "Fetching from origin..." (fetch attempted under default)
+// 6. Verifies combined output contains the fetch-specific warning
+// 7. Verifies the feature branch is created
+func TestStartDefaultUnreachableRemoteWarnsAndCreates(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGit(t, dir, "remote", "set-url", "origin", "./nonexistent-remote-repo.git"); err != nil {
+		t.Fatalf("Failed to break remote: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "start", "unreachable-default-test")
+	if err != nil {
+		t.Fatalf("Expected start to succeed despite fetch failure. Error: %v\nOutput: %s", err, output)
+	}
+
+	// Verify the fetch was attempted under the new default
+	if !strings.Contains(output, "Fetching from origin...") {
+		t.Errorf("Expected a fetch attempt under the new default. Output: %s", output)
+	}
+
+	// Verify the fetch-specific warning (disambiguated from the base-branch-storage warning)
+	if !strings.Contains(output, "Warning: failed to fetch from remote 'origin'") {
+		t.Errorf("Expected a fetch-failure warning. Output: %s", output)
+	}
+
+	// Verify branch created
+	if !testutil.BranchExists(t, dir, "feature/unreachable-default-test") {
+		t.Error("Expected feature/unreachable-default-test branch to exist")
 	}
 }


### PR DESCRIPTION
## Summary

Flips the built-in default for `gitflow.<type>.start.fetch` from `false` to `true`, so `git flow <type> start` fetches before creating a branch out of the box rather than only when opted in. Resolves #98.

Builds on #134 (shared per-command fetch resolver, merged via #141): only the Layer-1 built-in default *value* for `start` moves — the resolver engine and the `default → config → flag` precedence are untouched.

## Behavior

- `git flow feature start x` with no fetch config and no flag now fetches first, so the local repo's remote-tracking refs are current before the branch is created. (The branch is still created from the configured local start point; the fetch refreshes remote-tracking refs but does not fast-forward that start point — updating the branch base is out of scope here, owned by #134.)
- Opt out with `git config gitflow.<type>.start.fetch false` or `--no-fetch`.
- No remote configured → fetch silently skipped (no "not a git repository" noise).
- Fetch stays non-fatal for `start`: an unreachable remote warns and the branch is still created.
- `finish` default (already `true`) is unchanged.

## Changes

- `internal/config/resolver.go` — `ResolveStartShouldFetch` now passes `true` as the built-in default.
- Tests covering the 7 scenarios (default fetch, config opt-out, `--no-fetch`, flag-over-config, no-remote silent skip, unreachable-remote warning, `finish` regression guard).
- Docs: `docs/git-flow-start.1.md`, `docs/gitflow-config.5.md`, `CONFIGURATION.md`, and a `CHANGELOG.md` entry under Unreleased → Changed.

## Testing

- `gofmt -l` / `go vet ./...`: clean
- `go test ./test/cmd/ -run 'Start|Finish.*Fetch'`: pass