### PR TITLE
feat(finish): check parent branch is in sync before merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `finish` now aborts when the parent (merge-target) branch is behind or diverged from its remote, preventing a merge onto a stale base; the parent tolerates being ahead (unlike the topic check), and `--force` skips it
 - `finish` now treats a fetch failure against a reachable-but-failing remote as fatal (was a silent note); the error names the cause and suggests `--no-fetch` / `--force`
 - `finish` now aborts when the topic branch is ahead of its remote (was a silent note that proceeded and merged)
 - `finish` renders a diverged-specific message when the topic branch has diverged (previously reused the "behind" wording)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `finish` now aborts when the parent (merge-target) branch is behind or diverged from its remote, preventing a merge onto a stale base; the parent tolerates being ahead (unlike the topic check), and `--force` skips it
+- `finish` now aborts when the parent (merge-target) branch is behind or diverged from its remote, preventing a merge onto a stale base; being ahead is tolerated, and `--force` skips it
 - `finish` now treats a fetch failure against a reachable-but-failing remote as fatal (was a silent note); the error names the cause and suggests `--no-fetch` / `--force`
 - `finish` now aborts when the topic branch is ahead of its remote (was a silent note that proceeded and merged)
 - `finish` renders a diverged-specific message when the topic branch has diverged (previously reused the "behind" wording)

--- a/cmd/finish.go
+++ b/cmd/finish.go
@@ -238,7 +238,7 @@ func executeFinish(branchType string, name string, continueOp bool, abortOp bool
 	// fetch failure or a behind/diverged topic aborts here, before any merge. Being *ahead* is
 	// tolerated (downgraded to a note): finish merges the unpushed commits into the parent and then
 	// deletes the topic branch, so requiring a push first would preserve nothing.
-	if err := runFetchSyncPreflight(cfg, branchType, cfg.Remote, name, shortName, branchConfig.Parent, resolvedOptions.ShouldFetch, force, preflightOptions{tolerateAhead: true}); err != nil {
+	if err := runFetchSyncPreflight(cfg, branchType, cfg.Remote, name, shortName, branchConfig.Parent, resolvedOptions.ShouldFetch, force, preflightOptions{tolerateAhead: true, parentSyncCheck: true}); err != nil {
 		return err
 	}
 

--- a/cmd/preflight.go
+++ b/cmd/preflight.go
@@ -80,16 +80,17 @@ func runFetchSyncPreflight(cfg *config.Config, branchType, remote, topicBranch, 
 	if shouldFetch && git.RemoteExists(remote) {
 		fmt.Printf("Fetching from remote '%s'...\n", remote)
 
-		// Fetch the parent best-effort. A benign missing remote ref means any local tracking ref is
-		// stale, so the parent sync check is skipped against it (#99); a transport/auth failure is a
-		// non-fatal note here because the same failure is already fatal at the topic fetch below.
-		// Skip entirely when the branch type has no configured parent, so we never issue
+		// Fetch the parent best-effort. When the parent sync check is enabled (finish), a benign
+		// missing remote ref means the local tracking ref is stale, so the check is skipped against
+		// it (#99). Any other failure — and any failure at all when the check is off (delete) — is a
+		// non-fatal note here, because a transport/auth failure is already fatal at the topic fetch
+		// below. Skip entirely when the branch type has no configured parent, so we never issue
 		// `git fetch <remote> ""` or emit a spurious note.
 		if parentBranch != "" {
 			if err := git.FetchBranch(remote, parentBranch); err != nil {
-				if goerrors.Is(err, git.ErrRemoteRefNotFound) {
-					// The remote parent branch is gone; prune the stale tracking ref best-effort and
-					// skip the parent sync check against it.
+				if opts.parentSyncCheck && goerrors.Is(err, git.ErrRemoteRefNotFound) {
+					// The parent sync check is enabled and the remote parent branch is gone; prune the
+					// stale tracking ref best-effort and skip the parent sync check against it.
 					fmt.Printf("Note: Remote branch for base '%s' not found; skipping parent sync check\n", parentBranch)
 					parentRefFound = false
 					if derr := git.DeleteRemoteTrackingRef(remote, parentBranch); derr != nil {

--- a/cmd/preflight.go
+++ b/cmd/preflight.go
@@ -38,6 +38,13 @@ type preflightOptions struct {
 	// into BranchNotInSyncError so a sync abort suggests the right `git flow <type> <op> --force`
 	// command. Empty renders as finish (the zero-value default).
 	operation string
+
+	// parentSyncCheck verifies the parent (merge-target) branch is in sync with its remote before
+	// the caller merges into it (#99). Unlike the topic check, the parent aborts only when it is
+	// *behind* or *diverged* (merging onto a stale base) and proceeds when ahead — being locally
+	// ahead is the normal state right after a previous unpushed finish. finish sets it; delete does
+	// not (delete fast-forwards the parent via ffParent instead, so the two are mutually exclusive).
+	parentSyncCheck bool
 }
 
 // runFetchSyncPreflight guards a topic operation against an out-of-date topic branch. It fetches
@@ -56,22 +63,41 @@ type preflightOptions struct {
 //     fatal unless force too, unless opts.tolerateAhead downgrades it to a note (finish and delete
 //     both set it).
 //
-// The parent is fetched best-effort. It is not sync-checked (see #99), but when opts.ffParent is
-// set and the parent is the current branch, it is fast-forwarded from its remote (#88).
+// The parent is fetched best-effort. When opts.parentSyncCheck is set (finish) it is then
+// sync-checked with a laxer rule than the topic — behind/diverged abort, ahead and equal proceed
+// (#99). When opts.ffParent is set instead (delete) and the parent is the current branch, it is
+// fast-forwarded from its remote (#88). The two are mutually exclusive.
 func runFetchSyncPreflight(cfg *config.Config, branchType, remote, topicBranch, shortName, parentBranch string, shouldFetch, force bool, opts preflightOptions) error {
 	// topicRefFound tracks whether the topic still has a remote ref to compare against. It stays
 	// true when the fetch is skipped (we then rely on existing tracking data).
 	topicRefFound := true
 
+	// parentRefFound mirrors topicRefFound for the parent sync check (#99): a benign missing remote
+	// ref (never pushed / deleted after a remote merge) leaves a stale tracking ref we must not
+	// compare against. It stays true when the fetch is skipped.
+	parentRefFound := true
+
 	if shouldFetch && git.RemoteExists(remote) {
 		fmt.Printf("Fetching from remote '%s'...\n", remote)
 
-		// Fetch the parent best-effort. Any failure (including a missing ref) is a non-fatal note;
-		// the parent is not sync-checked here (see #99). Skip entirely when the branch type has no
-		// configured parent, so we never issue `git fetch <remote> ""` or emit a spurious note.
+		// Fetch the parent best-effort. A benign missing remote ref means any local tracking ref is
+		// stale, so the parent sync check is skipped against it (#99); a transport/auth failure is a
+		// non-fatal note here because the same failure is already fatal at the topic fetch below.
+		// Skip entirely when the branch type has no configured parent, so we never issue
+		// `git fetch <remote> ""` or emit a spurious note.
 		if parentBranch != "" {
 			if err := git.FetchBranch(remote, parentBranch); err != nil {
-				fmt.Printf("Note: Could not fetch base branch '%s': %v\n", parentBranch, err)
+				if goerrors.Is(err, git.ErrRemoteRefNotFound) {
+					// The remote parent branch is gone; prune the stale tracking ref best-effort and
+					// skip the parent sync check against it.
+					fmt.Printf("Note: Remote branch for base '%s' not found; skipping parent sync check\n", parentBranch)
+					parentRefFound = false
+					if derr := git.DeleteRemoteTrackingRef(remote, parentBranch); derr != nil {
+						fmt.Printf("Note: Could not prune stale tracking ref for '%s': %v\n", parentBranch, derr)
+					}
+				} else {
+					fmt.Printf("Note: Could not fetch base branch '%s': %v\n", parentBranch, err)
+				}
 			} else if opts.ffParent {
 				// #88: fast-forward the local parent to its just-fetched remote so that a branch merged
 				// remotely is seen as merged by `git branch -d`. `git merge --ff-only` acts on HEAD, so
@@ -157,6 +183,36 @@ func runFetchSyncPreflight(cfg *config.Config, branchType, remote, topicBranch, 
 		}
 		// SyncStatusEqual: the topic is in sync, proceed normally. (SyncStatusNoTracking always
 		// arrives with a non-nil error, handled fatally above.)
+	}
+
+	// Sync-check the parent (merge-target) branch when the caller asked for it (#99). Gated the same
+	// way as the topic check: only when not forced, the parent still has a remote ref, and it has a
+	// tracking branch. The parent invariant is laxer than the topic's — behind/diverged abort
+	// (merging onto a stale base), but ahead proceeds (normal right after an unpushed finish).
+	if !force && opts.parentSyncCheck && parentBranch != "" && parentRefFound && git.HasTrackingBranch(parentBranch) {
+		status, commitCount, err := git.CompareBranchWithRemote(parentBranch)
+		if err != nil {
+			// As with the topic block, fail closed rather than merge onto an undetermined base.
+			return &errors.GitError{
+				Operation: fmt.Sprintf("determine sync status for branch '%s'", parentBranch),
+				Err:       err,
+			}
+		}
+
+		if status == git.SyncStatusBehind || status == git.SyncStatusDiverged {
+			trackingBranch, terr := git.GetTrackingBranch(parentBranch)
+			if terr != nil {
+				trackingBranch = "remote tracking branch"
+			}
+			return &errors.BaseBranchNotInSyncError{
+				BranchName:   parentBranch,
+				RemoteBranch: trackingBranch,
+				Status:       string(status),
+				CommitCount:  commitCount,
+			}
+		}
+		// SyncStatusAhead and SyncStatusEqual: the parent is safe to merge onto, proceed. Ahead is
+		// left silent (unlike the topic ahead-note) because it is the common, expected state.
 	}
 
 	return nil

--- a/docs/git-flow-finish.1.md
+++ b/docs/git-flow-finish.1.md
@@ -167,7 +167,7 @@ CLI push flags are not persisted across `--continue`. Options are re-resolved on
 
 ## REMOTE SYNC CHECK
 
-Before performing the merge operation, the finish command checks if the local topic branch is in sync with its remote tracking branch. This safety check prevents accidental data loss when the remote has commits that are not present locally (behind or diverged). Being ahead of the remote is tolerated with a note, since finish merges the local commits into the parent and (by default) deletes the topic branch. The parent (merge-target) branch is checked too, but with a laxer rule — see *Parent Branch Sync Check* below.
+Before performing the merge operation, the finish command checks if the local topic branch is in sync with its remote tracking branch. This safety check prevents accidental data loss when the remote has commits that are not present locally (behind or diverged). Being ahead of the remote is tolerated with a note, since finish merges the local commits into the parent and (by default) deletes the topic branch. The parent (merge-target) branch is checked too — see *Parent Branch Sync Check* below.
 
 ### Sync Status Behavior
 
@@ -185,7 +185,7 @@ Before performing the merge operation, the finish command checks if the local to
 
 In addition to the topic branch, finish checks that the parent (merge-target) branch — for example `develop` when finishing a feature, or `main` when finishing a release — is in sync with its remote before merging into it. This prevents finish from writing a merge onto a stale base that would have to be reconciled (or force-pushed) later.
 
-The parent invariant is **laxer than the topic's**: the parent must not be **behind** or **diverged** from its remote, but being **ahead** is accepted. A locally-ahead parent is the normal state right after a previous finish that has not been pushed yet, so it must not block work — this is the key difference from the topic check, which aborts when ahead.
+The parent must not be **behind** or **diverged** from its remote, but being **equal** or **ahead** is accepted. A locally-ahead parent is the normal state right after a previous finish that has not been pushed yet, so it must not block work. Like the topic check in `finish`, an ahead parent is tolerated (behind/diverged remain fatal) — the parent simply proceeds silently rather than printing an ahead note.
 
 **Equal**: Parent matches its remote. Finish proceeds.
 

--- a/docs/git-flow-finish.1.md
+++ b/docs/git-flow-finish.1.md
@@ -167,7 +167,7 @@ CLI push flags are not persisted across `--continue`. Options are re-resolved on
 
 ## REMOTE SYNC CHECK
 
-Before performing the merge operation, the finish command checks if the local topic branch is in sync with its remote tracking branch. This safety check prevents accidental data loss when the remote has commits that are not present locally (behind or diverged). Being ahead of the remote is tolerated with a note, since finish merges the local commits into the parent and (by default) deletes the topic branch. Only the topic branch is sync-checked; the parent branch is fetched best-effort but not compared.
+Before performing the merge operation, the finish command checks if the local topic branch is in sync with its remote tracking branch. This safety check prevents accidental data loss when the remote has commits that are not present locally (behind or diverged). Being ahead of the remote is tolerated with a note, since finish merges the local commits into the parent and (by default) deletes the topic branch. The parent (merge-target) branch is checked too, but with a laxer rule — see *Parent Branch Sync Check* below.
 
 ### Sync Status Behavior
 
@@ -180,6 +180,20 @@ Before performing the merge operation, the finish command checks if the local to
 **Diverged**: Both local and remote have unique commits. Finish **aborts with an error** with a diverged-specific message, since finishing would discard the remote-only commits.
 
 **No Tracking**: Branch has no remote tracking branch configured. Finish proceeds normally (no remote to compare against).
+
+### Parent Branch Sync Check
+
+In addition to the topic branch, finish checks that the parent (merge-target) branch — for example `develop` when finishing a feature, or `main` when finishing a release — is in sync with its remote before merging into it. This prevents finish from writing a merge onto a stale base that would have to be reconciled (or force-pushed) later.
+
+The parent invariant is **laxer than the topic's**: the parent must not be **behind** or **diverged** from its remote, but being **ahead** is accepted. A locally-ahead parent is the normal state right after a previous finish that has not been pushed yet, so it must not block work — this is the key difference from the topic check, which aborts when ahead.
+
+**Equal**: Parent matches its remote. Finish proceeds.
+
+**Ahead**: Parent has local commits not on its remote (e.g. an earlier unpushed finish). Finish **proceeds** silently.
+
+**Behind** / **Diverged**: The parent's remote has commits the local parent lacks. Finish **aborts with an error** naming the parent branch; update the parent (for example `git checkout develop && git pull`) or pass **--force**.
+
+The parent check is gated the same way as the topic check: it is skipped when no remote is configured, when the parent has no remote tracking branch, or when the parent's remote ref is gone (never pushed or deleted after a remote merge). With **--no-fetch** the parent is not fetched but the check still runs against existing tracking data. **--force** bypasses it along with the topic check.
 
 ### Bypassing the Check
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -427,6 +427,41 @@ func (e *FetchFailedError) ExitCode() ExitCode {
 	return ExitCodeGitError
 }
 
+// BaseBranchNotInSyncError indicates the parent (merge-target) branch is behind or diverged from
+// its remote, so finishing would merge onto a stale base. Unlike BranchNotInSyncError (which is
+// about the local *topic* branch and tells the user to push/pull the topic), the remedy here is to
+// update the parent branch itself. Ahead is acceptable for a parent and never reaches this error.
+// Only behind and diverged are represented.
+type BaseBranchNotInSyncError struct {
+	BranchName   string
+	RemoteBranch string
+	Status       string // "behind" or "diverged"
+	CommitCount  int
+}
+
+func (e *BaseBranchNotInSyncError) Error() string {
+	if e.Status == SyncStatusDiverged {
+		return fmt.Sprintf(`branch '%s' has diverged from '%s' by %d commit(s).
+
+The base branch and its remote each have commits the other does not.
+Finishing now would merge onto a stale base.
+
+Reconcile it (e.g. git checkout %s && git pull) or pass --force to finish anyway.`,
+			e.BranchName, e.RemoteBranch, e.CommitCount, e.BranchName)
+	}
+	return fmt.Sprintf(`branch '%s' is %d commit(s) behind '%s'.
+
+The base branch has commits on its remote that are not present locally.
+Finishing now would merge onto a stale base.
+
+Update it (e.g. git checkout %s && git pull) or pass --force to finish anyway.`,
+		e.BranchName, e.CommitCount, e.RemoteBranch, e.BranchName)
+}
+
+func (e *BaseBranchNotInSyncError) ExitCode() ExitCode {
+	return ExitCodeValidationError
+}
+
 // RemoteNotConfiguredError indicates a required remote is not configured
 type RemoteNotConfiguredError struct {
 	Remote    string

--- a/test/cmd/finish_parent_sync_test.go
+++ b/test/cmd/finish_parent_sync_test.go
@@ -1,0 +1,455 @@
+package cmd_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// This file covers issue #99: before finish merges a topic branch into its parent (merge-target)
+// branch, the parent must be in sync with its remote. The parent invariant differs from the topic
+// invariant checked in finish_sync_test.go: the parent must not be *behind* or *diverged* from its
+// remote (merging onto a stale base), but being *ahead* is acceptable (the normal state right after
+// a previous unpushed finish). --force skips the check; the check is gated the same way as the topic
+// check (skipped with no remote / no tracking branch / a benign missing remote ref).
+//
+// The standard fixture parent is develop (git-flow defaults: feature parent = develop), and
+// SetupTestRepoWithRemote pushes develop with upstream tracking.
+
+// advanceRemoteDevelop clones the bare remote into a throwaway working copy, adds a commit on
+// develop, and pushes it — advancing origin/develop without touching the branch under test. It
+// returns the new remote develop SHA.
+func advanceRemoteDevelop(t *testing.T, remoteDir, file, content, msg string) string {
+	t.Helper()
+	second := t.TempDir()
+	if _, err := testutil.RunGit(t, second, "clone", remoteDir, "."); err != nil {
+		t.Fatalf("Failed to clone remote: %v", err)
+	}
+	testutil.ConfigureGitIdentity(t, second)
+	if _, err := testutil.RunGit(t, second, "checkout", "develop"); err != nil {
+		t.Fatalf("Failed to checkout develop in clone: %v", err)
+	}
+	testutil.WriteFile(t, second, file, content)
+	if _, err := testutil.RunGit(t, second, "add", file); err != nil {
+		t.Fatalf("Failed to add %s in clone: %v", file, err)
+	}
+	if _, err := testutil.RunGit(t, second, "commit", "-m", msg); err != nil {
+		t.Fatalf("Failed to commit in clone: %v", err)
+	}
+	if _, err := testutil.RunGit(t, second, "push", "origin", "develop"); err != nil {
+		t.Fatalf("Failed to push develop from clone: %v", err)
+	}
+	sha, err := testutil.RunGit(t, second, "rev-parse", "develop")
+	if err != nil {
+		t.Fatalf("Failed to get develop SHA from clone: %v", err)
+	}
+	return strings.TrimSpace(sha)
+}
+
+// commitOnLocalDevelop adds a local commit to develop and returns to the given branch. It is used to
+// put local develop ahead of (or diverged from) its remote without pushing.
+func commitOnLocalDevelop(t *testing.T, dir, returnBranch, file, content, msg string) {
+	t.Helper()
+	if _, err := testutil.RunGit(t, dir, "checkout", "develop"); err != nil {
+		t.Fatalf("Failed to checkout develop: %v", err)
+	}
+	testutil.WriteFile(t, dir, file, content)
+	if _, err := testutil.RunGit(t, dir, "add", file); err != nil {
+		t.Fatalf("Failed to add %s: %v", file, err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", msg); err != nil {
+		t.Fatalf("Failed to commit on develop: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "checkout", returnBranch); err != nil {
+		t.Fatalf("Failed to checkout %s: %v", returnBranch, err)
+	}
+}
+
+// revParse returns the SHA of a ref, failing the test on error.
+func revParse(t *testing.T, dir, ref string) string {
+	t.Helper()
+	sha, err := testutil.RunGit(t, dir, "rev-parse", ref)
+	if err != nil {
+		t.Fatalf("Failed to rev-parse %s: %v", ref, err)
+	}
+	return strings.TrimSpace(sha)
+}
+
+// assertFeatureMerged asserts finish completed: develop advanced past developBefore and the feature
+// commit is now an ancestor of develop, and the local feature branch was deleted.
+func assertFeatureMerged(t *testing.T, dir, branch, featureSha, developBefore string) {
+	t.Helper()
+	developAfter := revParse(t, dir, "develop")
+	if developAfter == developBefore {
+		t.Errorf("Expected develop to advance after finish; it stayed at %s", developBefore)
+	}
+	if _, err := testutil.RunGit(t, dir, "merge-base", "--is-ancestor", featureSha, "develop"); err != nil {
+		t.Errorf("Expected feature commit %s to be an ancestor of develop after finish", featureSha)
+	}
+	if testutil.BranchExists(t, dir, branch) {
+		t.Errorf("Expected branch %s to be deleted after finish", branch)
+	}
+}
+
+// Scenario 1: Parent in sync — finish proceeds and merges.
+func TestFinishParentInSyncProceeds(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "in-sync"); err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+	featureSha := commitFeatureAndPush(t, dir, "feature.txt", "feature content", "Add feature file", "feature/in-sync")
+	developBefore := revParse(t, dir, "develop")
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "in-sync")
+	if err != nil {
+		t.Fatalf("Expected finish to succeed when parent is in sync. Output: %s, err: %v", output, err)
+	}
+	assertFeatureMerged(t, dir, "feature/in-sync", featureSha, developBefore)
+}
+
+// Scenario 2: Parent behind its remote — abort; merge does not happen.
+func TestFinishParentBehindRemoteAborts(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "parent-behind"); err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+	commitFeatureAndPush(t, dir, "feature.txt", "feature content", "Add feature file", "feature/parent-behind")
+
+	// Advance origin/develop so local develop will be behind after the preflight's parent fetch.
+	advanceRemoteDevelop(t, remoteDir, "remote1.txt", "r1", "Remote develop commit")
+
+	developBefore := revParse(t, dir, "develop")
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "parent-behind")
+	if err == nil {
+		t.Errorf("Expected finish to fail when parent is behind remote. Output: %s", output)
+	}
+	if !strings.Contains(output, "develop") {
+		t.Errorf("Expected error to name the parent branch 'develop'. Output: %s", output)
+	}
+	if !strings.Contains(output, "behind") {
+		t.Errorf("Expected error to mention 'behind'. Output: %s", output)
+	}
+	if !strings.Contains(output, "--force") {
+		t.Errorf("Expected error to suggest '--force'. Output: %s", output)
+	}
+	if after := revParse(t, dir, "develop"); after != developBefore {
+		t.Errorf("Expected develop unchanged after aborted finish. Before: %s After: %s", developBefore, after)
+	}
+	if !testutil.BranchExists(t, dir, "feature/parent-behind") {
+		t.Error("Expected feature branch to still exist after aborted finish")
+	}
+}
+
+// Scenario 3: Parent diverged from its remote — abort; merge does not happen.
+func TestFinishParentDivergedAborts(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "parent-diverged"); err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+	commitFeatureAndPush(t, dir, "feature.txt", "feature content", "Add feature file", "feature/parent-diverged")
+
+	// Remote develop gains one commit; local develop gains a different one → diverged after fetch.
+	advanceRemoteDevelop(t, remoteDir, "remote1.txt", "r1", "Remote develop commit")
+	commitOnLocalDevelop(t, dir, "feature/parent-diverged", "local-dev.txt", "l1", "Local develop commit")
+
+	developBefore := revParse(t, dir, "develop")
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "parent-diverged")
+	if err == nil {
+		t.Errorf("Expected finish to fail when parent is diverged. Output: %s", output)
+	}
+	if !strings.Contains(output, "develop") {
+		t.Errorf("Expected error to name the parent branch 'develop'. Output: %s", output)
+	}
+	if !strings.Contains(output, "diverged") {
+		t.Errorf("Expected error to mention 'diverged'. Output: %s", output)
+	}
+	if after := revParse(t, dir, "develop"); after != developBefore {
+		t.Errorf("Expected develop unchanged after aborted finish. Before: %s After: %s", developBefore, after)
+	}
+	if !testutil.BranchExists(t, dir, "feature/parent-diverged") {
+		t.Error("Expected feature branch to still exist after aborted finish")
+	}
+}
+
+// Scenario 4: Parent ahead of its remote — proceeds (the key divergence from the topic rule).
+func TestFinishParentAheadProceeds(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "parent-ahead"); err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+	featureSha := commitFeatureAndPush(t, dir, "feature.txt", "feature content", "Add feature file", "feature/parent-ahead")
+
+	// Local develop gains a commit that is not pushed → local develop ahead of origin/develop.
+	commitOnLocalDevelop(t, dir, "feature/parent-ahead", "local-dev.txt", "l1", "Local develop commit")
+
+	developBefore := revParse(t, dir, "develop")
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "parent-ahead")
+	if err != nil {
+		t.Fatalf("Expected finish to succeed when parent is ahead of remote. Output: %s, err: %v", output, err)
+	}
+	assertFeatureMerged(t, dir, "feature/parent-ahead", featureSha, developBefore)
+}
+
+// Scenario 5: Topic in sync but parent behind — aborts on the parent check (runs independently of
+// the topic check).
+func TestFinishTopicInSyncParentBehindAborts(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "topic-ok-parent-behind"); err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+	// Topic pushed and equal → topic check passes, so any abort must come from the parent check.
+	commitFeatureAndPush(t, dir, "feature.txt", "feature content", "Add feature file", "feature/topic-ok-parent-behind")
+
+	advanceRemoteDevelop(t, remoteDir, "remote1.txt", "r1", "Remote develop commit")
+
+	developBefore := revParse(t, dir, "develop")
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "topic-ok-parent-behind")
+	if err == nil {
+		t.Errorf("Expected finish to fail on the parent check even though the topic is in sync. Output: %s", output)
+	}
+	if !strings.Contains(output, "develop") {
+		t.Errorf("Expected the abort to name the parent branch 'develop', not the topic. Output: %s", output)
+	}
+	if !strings.Contains(output, "behind") {
+		t.Errorf("Expected error to mention 'behind'. Output: %s", output)
+	}
+	if after := revParse(t, dir, "develop"); after != developBefore {
+		t.Errorf("Expected develop unchanged after aborted finish. Before: %s After: %s", developBefore, after)
+	}
+	if !testutil.BranchExists(t, dir, "feature/topic-ok-parent-behind") {
+		t.Error("Expected feature branch to still exist after aborted finish")
+	}
+}
+
+// Scenario 6: Parent behind, --force — the parent check is skipped; finish completes.
+func TestFinishParentBehindForceSkipsCheck(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "parent-behind-force"); err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+	featureSha := commitFeatureAndPush(t, dir, "feature.txt", "feature content", "Add feature file", "feature/parent-behind-force")
+
+	advanceRemoteDevelop(t, remoteDir, "remote1.txt", "r1", "Remote develop commit")
+
+	developBefore := revParse(t, dir, "develop")
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "--force", "parent-behind-force")
+	if err != nil {
+		t.Fatalf("Expected finish --force to bypass the parent check. Output: %s, err: %v", output, err)
+	}
+	assertFeatureMerged(t, dir, "feature/parent-behind-force", featureSha, developBefore)
+}
+
+// Scenario 7: Parent has no tracking branch — the check is skipped; finish completes. origin/develop
+// still exists locally, but develop's upstream is unset so HasTrackingBranch(develop) is false. This
+// isolates the no-tracking gate from the benign missing-ref path (Scenario 9).
+func TestFinishParentNoTrackingBranchSkips(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	// Unset develop's upstream so it has no tracking branch, while origin/develop stays present.
+	if _, err := testutil.RunGit(t, dir, "branch", "--unset-upstream", "develop"); err != nil {
+		t.Fatalf("Failed to unset develop upstream: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "rev-parse", "--verify", "develop@{upstream}"); err == nil {
+		t.Fatal("Precondition failed: expected develop to have no upstream after unset")
+	}
+
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "parent-no-tracking"); err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+	featureSha := commitFeatureAndPush(t, dir, "feature.txt", "feature content", "Add feature file", "feature/parent-no-tracking")
+	developBefore := revParse(t, dir, "develop")
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "parent-no-tracking")
+	if err != nil {
+		t.Fatalf("Expected finish to succeed when parent has no tracking branch. Output: %s, err: %v", output, err)
+	}
+	if strings.Contains(output, "behind") || strings.Contains(output, "diverged") {
+		t.Errorf("Expected no parent sync abort when parent has no tracking branch. Output: %s", output)
+	}
+	assertFeatureMerged(t, dir, "feature/parent-no-tracking", featureSha, developBefore)
+}
+
+// Scenario 8: No remote configured — no fetch and no parent check; finish completes.
+func TestFinishNoRemoteParentCheckSkipped(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	if _, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to init git-flow: %v", err)
+	}
+
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "no-remote"); err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+	testutil.WriteFile(t, dir, "feature.txt", "feature content")
+	if _, err := testutil.RunGit(t, dir, "add", "feature.txt"); err != nil {
+		t.Fatalf("Failed to add file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Add feature file"); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+	featureSha := revParse(t, dir, "feature/no-remote")
+	developBefore := revParse(t, dir, "develop")
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "no-remote")
+	if err != nil {
+		t.Fatalf("Expected finish to succeed with no remote. Output: %s, err: %v", output, err)
+	}
+	if strings.Contains(output, "Fetching") {
+		t.Errorf("Expected no fetch with no remote configured. Output: %s", output)
+	}
+	if strings.Contains(output, "behind") || strings.Contains(output, "diverged") {
+		t.Errorf("Expected no parent sync abort with no remote. Output: %s", output)
+	}
+	assertFeatureMerged(t, dir, "feature/no-remote", featureSha, developBefore)
+}
+
+// Scenario 9: Stale origin/develop after the remote branch was deleted — the parent fetch reports a
+// benign missing ref, the parent check is skipped against the stale ref, and finish completes
+// without --force. The stale ref deliberately points at a *different* commit than local develop, so
+// a broken implementation that compared it would abort.
+func TestFinishParentStaleTrackingRefProceeds(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "parent-stale"); err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+	featureSha := commitFeatureAndPush(t, dir, "feature.txt", "feature content", "Add feature file", "feature/parent-stale")
+
+	// Advance origin/develop, then fetch so local origin/develop points at the advanced commit while
+	// local develop stays behind — the stale ref now differs from local develop.
+	advanceRemoteDevelop(t, remoteDir, "remote1.txt", "r1", "Remote develop commit")
+	if _, err := testutil.RunGit(t, dir, "fetch", "origin", "develop"); err != nil {
+		t.Fatalf("Failed to fetch develop: %v", err)
+	}
+	if revParse(t, dir, "refs/remotes/origin/develop") == revParse(t, dir, "develop") {
+		t.Fatal("Precondition failed: expected stale origin/develop to differ from local develop")
+	}
+
+	// Delete develop on the remote from a throwaway clone, leaving the original's stale tracking ref.
+	second := t.TempDir()
+	if _, err := testutil.RunGit(t, second, "clone", remoteDir, "."); err != nil {
+		t.Fatalf("Failed to clone remote: %v", err)
+	}
+	if _, err := testutil.RunGit(t, second, "push", "origin", "--delete", "develop"); err != nil {
+		t.Fatalf("Failed to delete remote develop: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "rev-parse", "--verify", "refs/remotes/origin/develop"); err != nil {
+		t.Fatalf("Precondition failed: expected the original clone to keep its stale origin/develop: %v", err)
+	}
+
+	developBefore := revParse(t, dir, "develop")
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "parent-stale")
+	if err != nil {
+		t.Fatalf("Expected finish to succeed against a stale parent tracking ref. Output: %s, err: %v", output, err)
+	}
+	if strings.Contains(output, "behind") || strings.Contains(output, "diverged") {
+		t.Errorf("Expected no parent sync abort against a stale (missing-remote) ref. Output: %s", output)
+	}
+	assertFeatureMerged(t, dir, "feature/parent-stale", featureSha, developBefore)
+}
+
+// Scenario 10: Parent behind in the cached tracking ref, run with --no-fetch — the fetch is skipped
+// but the parent check still runs against cached data and aborts (mirrors the topic --no-fetch rule).
+func TestFinishParentBehindNoFetchStillChecks(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "parent-behind-nofetch"); err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+	commitFeatureAndPush(t, dir, "feature.txt", "feature content", "Add feature file", "feature/parent-behind-nofetch")
+
+	// Advance origin/develop and fetch once so the cached tracking ref shows develop behind.
+	advanceRemoteDevelop(t, remoteDir, "remote1.txt", "r1", "Remote develop commit")
+	if _, err := testutil.RunGit(t, dir, "fetch", "origin", "develop"); err != nil {
+		t.Fatalf("Failed to fetch develop: %v", err)
+	}
+
+	developBefore := revParse(t, dir, "develop")
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "--no-fetch", "parent-behind-nofetch")
+	if err == nil {
+		t.Errorf("Expected finish --no-fetch to still abort on the cached behind parent. Output: %s", output)
+	}
+	if strings.Contains(output, "Fetching") {
+		t.Errorf("Expected no fetch with --no-fetch. Output: %s", output)
+	}
+	if !strings.Contains(output, "develop") || !strings.Contains(output, "behind") {
+		t.Errorf("Expected a 'develop behind' abort against cached data. Output: %s", output)
+	}
+	if after := revParse(t, dir, "develop"); after != developBefore {
+		t.Errorf("Expected develop unchanged after aborted finish. Before: %s After: %s", developBefore, after)
+	}
+	if !testutil.BranchExists(t, dir, "feature/parent-behind-nofetch") {
+		t.Error("Expected feature branch to still exist after aborted finish")
+	}
+}
+
+// Scenario 11: Parent compare-failure — the parent block fails closed. The loose origin/develop ref
+// is corrupted so develop@{upstream} still resolves (HasTrackingBranch stays true) but the sync
+// comparison cannot walk it. --no-fetch prevents a fetch from repairing the ref first.
+func TestFinishParentCompareErrorAborts(t *testing.T) {
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "parent-compare-error"); err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+	// Topic pushed and equal so the topic check passes and we reach the parent block.
+	commitFeatureAndPush(t, dir, "feature.txt", "feature content", "Add feature file", "feature/parent-compare-error")
+
+	// Corrupt the loose parent tracking ref: point it at a nonexistent object.
+	if _, err := testutil.RunGit(t, dir, "rev-parse", "--verify", "origin/develop"); err != nil {
+		t.Fatalf("Precondition failed: expected a loose origin/develop ref: %v", err)
+	}
+	if err := testutil.WriteFile(t, dir, ".git/refs/remotes/origin/develop", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n"); err != nil {
+		t.Fatalf("Failed to corrupt parent tracking ref: %v", err)
+	}
+
+	developBefore := revParse(t, dir, "develop")
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "--no-fetch", "parent-compare-error")
+	if err == nil {
+		t.Errorf("Expected finish to fail when the parent sync status cannot be determined. Output: %s", output)
+	}
+	if !strings.Contains(output, "determine sync status") || !strings.Contains(output, "develop") {
+		t.Errorf("Expected the error to name the sync-status determination for 'develop'. Output: %s", output)
+	}
+	if after := revParse(t, dir, "develop"); after != developBefore {
+		t.Errorf("Expected develop unchanged after aborted finish. Before: %s After: %s", developBefore, after)
+	}
+	if !testutil.BranchExists(t, dir, "feature/parent-compare-error") {
+		t.Error("Expected feature branch to still exist after aborted finish")
+	}
+}


### PR DESCRIPTION
## Summary

Adds the parent (merge-target) branch sync check that #134 left as a placeholder in `runFetchSyncPreflight`. Before `finish` merges a topic branch into its parent (`develop`/`main`), it verifies the parent is in sync with its remote, so a finish cannot write a merge onto a stale base that the user then has to reconcile — or force-push — when publishing. Brings `finish` to git-flow-avh parity for remote-aware workflows. Resolves #99.

Builds on #134 (shared fetch/sync preflight, merged via #141): finish now enables the parent sync-check #134 prepared, reusing the established branch-comparison semantics. No new user-visible config.

## Behavior

The parent must not be **behind** or **diverged** from its remote; **equal** or **ahead** is accepted.

- **Equal / Ahead** — proceed. A locally-ahead parent is the normal state right after a previous unpushed finish, so it must not block. This matches how `finish`'s topic check treats ahead (tolerated) — the parent just proceeds silently rather than printing an ahead note.
- **Behind / Diverged** — abort with an error naming the parent; update the parent (e.g. `git checkout develop && git pull`) or pass `--force`.
- Skipped when no remote is configured, the parent has no remote-tracking branch, or its remote ref is gone (benign never-pushed / deleted-after-merge). Runs against cached tracking data under `--no-fetch`. `--force` bypasses it. Fails closed on an undetermined sync status.

Example — parent behind its remote:

```
$ git flow feature finish my-feature
Fetching from remote 'origin'...
branch 'develop' is 3 commit(s) behind 'origin/develop'.
...
Update it (e.g. git checkout develop && git pull) or pass --force to finish anyway.
```

## Changes

- `cmd/preflight.go` — new `preflightOptions.parentSyncCheck` (finish opts in; delete keeps `ffParent`, the two are mutually exclusive) + a `parentRefFound`-gated parent sync-check block.
- `internal/errors/errors.go` — `BaseBranchNotInSyncError`. Unlike the topic's `BranchNotInSyncError` (which tells you to push/pull the *topic*), its remedy is to update the parent branch.
- `cmd/finish.go` — finish enables the check.
- Docs — `docs/git-flow-finish.1.md` (parent check + gating) and a `CHANGELOG.md` entry.

## Testing

11 scenarios in `test/cmd/finish_parent_sync_test.go` covering all 10 spec scenarios plus a parent compare-failure fail-closed case (in sync / behind / diverged / ahead / topic-ok-parent-behind / `--force` / no-tracking / no-remote / stale-ref / `--no-fetch` cached / compare-error). Full suite green with the CI 20-minute timeout; `gofmt`/`go vet` clean. The test plan was Codex-gated before implementation (test-first).