### PR TITLE
refactor(git): Decouple internal packages from the process working directory

### DIFF
--- a/TESTING_GUIDELINES.md
+++ b/TESTING_GUIDELINES.md
@@ -386,60 +386,50 @@ func TestExample(t *testing.T) {
 }
 ```
 
-### ❌ AVOID: Using `os.Chdir()` with Internal Functions
+### ❌ NEVER: Use `os.Chdir()` in tests
 
-Some tests use `os.Chdir()` to change the working directory, then call internal git functions that don't accept directory parameters. This pattern is fragile:
+`os.Chdir()` mutates process-global state, so it is banned in the test suite
+(there are zero occurrences). In-process tests that exercise `internal/git`,
+`internal/config`, `internal/mergestate`, or `internal/hooks` must open an
+explicit repository handle instead.
+
+### ✅ CORRECT: Open a `git.Repo` handle for the target repository
+
+Every repo-bound operation is a method on `*git.Repo`, and the config,
+merge-state, and hooks packages take the handle (or its absolute git dir). Open
+the handle for the test repository and call methods on it — no working-directory
+change is involved, and the process CWD (the test package directory) is
+irrelevant:
 
 ```go
-// PROBLEMATIC: Relies on global state
 func TestExample(t *testing.T) {
+    t.Parallel() // safe: no shared process state
     dir := testutil.SetupTestRepo(t)
     defer testutil.CleanupTestRepo(t, dir)
 
-    originalDir, _ := os.Getwd()
-    defer os.Chdir(originalDir)  // Must restore!
+    repo, err := git.Open(dir)
+    if err != nil {
+        t.Fatalf("git.Open failed: %v", err)
+    }
 
-    if err := os.Chdir(dir); err != nil {
+    if err := repo.Checkout("develop"); err != nil { // bound to `dir`
         t.Fatal(err)
     }
 
-    // These internal functions have no dir parameter
-    // They rely on os.Chdir() having been called
-    if err := git.Checkout("develop"); err != nil {  // ⚠️ Uses current dir
-        t.Fatal(err)
+    cfg, err := config.Load(repo)                     // reads `dir`'s config
+    // ...
+
+    if err := mergestate.SaveMergeState(repo, state); err != nil { // writes under dir/.git
+        // ...
     }
 }
 ```
 
-**Why this is problematic:**
-- If `os.Chdir()` fails or defer doesn't run, subsequent tests break
-- Test parallelization becomes impossible (shared global state)
-- Harder to understand which directory commands execute in
-
-### When `os.Chdir()` Is Acceptable
-
-In some cases, `os.Chdir()` is necessary because internal functions (`internal/git/repo.go`, `internal/git/config.go`) don't accept directory parameters. If you must use this pattern:
-
-1. **Always save and restore** the original directory with defer
-2. **Place defer immediately** after the `os.Chdir()` call
-3. **Document why** the pattern is necessary
-4. **Consider adding `*InDir` variants** to internal functions if this pattern repeats
-
-```go
-// If os.Chdir() is unavoidable, do it safely:
-originalDir, err := os.Getwd()
-if err != nil {
-    t.Fatalf("Failed to get working directory: %v", err)
-}
-if err := os.Chdir(dir); err != nil {
-    t.Fatalf("Failed to change to test directory: %v", err)
-}
-defer func() {
-    if err := os.Chdir(originalDir); err != nil {
-        t.Errorf("Failed to restore working directory: %v", err)
-    }
-}()
-```
+`git.Open` resolves the work tree, git dir, and common git dir to absolute
+paths, so accessors like `repo.GitDir()` are always absolute (never the bare
+`.git`). Feed `repo.GitDir()` to the hooks/filters helpers
+(`hooks.RunPreHook(repo.GitDir(), …)`). Because nothing depends on the process
+working directory, these tests are safe to run with `t.Parallel()`.
 
 ### Known Areas Using `os.Chdir()`
 

--- a/TESTING_GUIDELINES.md
+++ b/TESTING_GUIDELINES.md
@@ -431,16 +431,15 @@ paths, so accessors like `repo.GitDir()` are always absolute (never the bare
 (`hooks.RunPreHook(repo.GitDir(), …)`). Because nothing depends on the process
 working directory, these tests are safe to run with `t.Parallel()`.
 
-### Known Areas Using `os.Chdir()`
+### Migration Note: `os.Chdir()` Eliminated
 
-The following test files currently use `os.Chdir()` because they call internal functions without directory parameters:
-
-- `test/cmd/config_test.go` - Calls `config.LoadConfig()`, etc.
-- `test/cmd/init_test.go` - Some edge case tests
-
-**Note**: Functions in `internal/git/repo.go` and `internal/git/config.go` don't accept directory parameters. If you need to call these in tests, you must use `os.Chdir()`. Consider whether a testutil helper or `*InDir` variant would be better.
-
-**Refactored**: `test/cmd/update_test.go` was refactored to use only testutil functions, eliminating the need for `os.Chdir()` and internal package imports.
+The suite no longer contains any `os.Chdir()` calls. Every function in
+`internal/git`, `internal/config`, `internal/mergestate`, and `internal/hooks`
+now targets an explicit `git.Repo` handle (or a directory derived from one)
+rather than the process working directory, so tests open a handle for the test
+repository and call methods on it — see the CORRECT pattern above. The former
+`config.LoadConfig()` is gone; use `config.Load(repo)`. There is no need for a
+`*InDir` variant, and `os.Chdir()` must not be reintroduced.
 
 ## Test Implementation Anti-Patterns
 

--- a/cmd/checkout.go
+++ b/cmd/checkout.go
@@ -12,11 +12,7 @@ import (
 
 // CheckoutCommand handles checking out a topic branch
 func CheckoutCommand(branchType string, nameOrPrefix string, showCommands bool) {
-	repo, err := openRepo()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-	}
+	repo := mustOpenRepo()
 	if err := executeCheckout(repo, branchType, nameOrPrefix, showCommands); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {

--- a/cmd/checkout.go
+++ b/cmd/checkout.go
@@ -12,7 +12,12 @@ import (
 
 // CheckoutCommand handles checking out a topic branch
 func CheckoutCommand(branchType string, nameOrPrefix string, showCommands bool) {
-	if err := executeCheckout(branchType, nameOrPrefix, showCommands); err != nil {
+	repo, err := openRepo()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+	}
+	if err := executeCheckout(repo, branchType, nameOrPrefix, showCommands); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -25,9 +30,9 @@ func CheckoutCommand(branchType string, nameOrPrefix string, showCommands bool) 
 }
 
 // executeCheckout performs the actual branch checkout logic and returns any errors
-func executeCheckout(branchType string, nameOrPrefix string, showCommands bool) error {
+func executeCheckout(repo *git.Repo, branchType string, nameOrPrefix string, showCommands bool) error {
 	// Load configuration
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
@@ -40,7 +45,7 @@ func executeCheckout(branchType string, nameOrPrefix string, showCommands bool) 
 
 	// If no name/prefix provided, list available branches and return
 	if nameOrPrefix == "" {
-		branches, err := git.ListBranches()
+		branches, err := repo.ListBranches()
 		if err != nil {
 			return &errors.GitError{Operation: "list branches", Err: err}
 		}
@@ -67,10 +72,10 @@ func executeCheckout(branchType string, nameOrPrefix string, showCommands bool) 
 	}
 
 	// Check if branch exists
-	err = git.BranchExists(fullBranchName)
+	err = repo.BranchExists(fullBranchName)
 	if err != nil {
 		// If exact match not found, try prefix match
-		branches, err := git.ListBranches()
+		branches, err := repo.ListBranches()
 		if err != nil {
 			return &errors.GitError{Operation: "list branches", Err: err}
 		}
@@ -99,7 +104,7 @@ func executeCheckout(branchType string, nameOrPrefix string, showCommands bool) 
 	}
 
 	// Checkout the branch
-	err = git.Checkout(fullBranchName)
+	err = repo.Checkout(fullBranchName)
 	if err != nil {
 		return &errors.GitError{Operation: fmt.Sprintf("checkout branch '%s'", fullBranchName), Err: err}
 	}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -245,11 +245,7 @@ Example:
 
 // ConfigAddBaseCommand adds a base branch configuration
 func ConfigAddBaseCommand(name, parent, upstreamStrategy, downstreamStrategy string, autoUpdate bool) {
-	repo, err := openRepo()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-	}
+	repo := mustOpenRepo()
 	if err := executeConfigAddBase(repo, name, parent, upstreamStrategy, downstreamStrategy, autoUpdate); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
@@ -264,11 +260,7 @@ func ConfigAddBaseCommand(name, parent, upstreamStrategy, downstreamStrategy str
 
 // ConfigAddTopicCommand adds a topic branch type configuration
 func ConfigAddTopicCommand(name, parent, prefix, startingPoint, upstreamStrategy, downstreamStrategy string, tag bool) {
-	repo, err := openRepo()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-	}
+	repo := mustOpenRepo()
 	if err := executeConfigAddTopic(repo, name, parent, prefix, startingPoint, upstreamStrategy, downstreamStrategy, tag); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
@@ -283,11 +275,7 @@ func ConfigAddTopicCommand(name, parent, prefix, startingPoint, upstreamStrategy
 
 // ConfigEditBaseCommand edits a base branch configuration
 func ConfigEditBaseCommand(name, upstreamStrategy, downstreamStrategy string, autoUpdate bool) {
-	repo, err := openRepo()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-	}
+	repo := mustOpenRepo()
 	if err := executeConfigEditBase(repo, name, upstreamStrategy, downstreamStrategy, autoUpdate); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
@@ -302,11 +290,7 @@ func ConfigEditBaseCommand(name, upstreamStrategy, downstreamStrategy string, au
 
 // ConfigEditTopicCommand edits a topic branch type configuration
 func ConfigEditTopicCommand(name, prefix, startingPoint, upstreamStrategy, downstreamStrategy string, tag bool) {
-	repo, err := openRepo()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-	}
+	repo := mustOpenRepo()
 	if err := executeConfigEditTopic(repo, name, prefix, startingPoint, upstreamStrategy, downstreamStrategy, tag); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
@@ -321,11 +305,7 @@ func ConfigEditTopicCommand(name, prefix, startingPoint, upstreamStrategy, downs
 
 // ConfigRenameBaseCommand renames a base branch
 func ConfigRenameBaseCommand(oldName, newName string) {
-	repo, err := openRepo()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-	}
+	repo := mustOpenRepo()
 	if err := executeConfigRenameBase(repo, oldName, newName); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
@@ -340,11 +320,7 @@ func ConfigRenameBaseCommand(oldName, newName string) {
 
 // ConfigRenameTopicCommand renames a topic branch type
 func ConfigRenameTopicCommand(oldName, newName string) {
-	repo, err := openRepo()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-	}
+	repo := mustOpenRepo()
 	if err := executeConfigRenameTopic(repo, oldName, newName); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
@@ -359,11 +335,7 @@ func ConfigRenameTopicCommand(oldName, newName string) {
 
 // ConfigDeleteBaseCommand deletes a base branch configuration
 func ConfigDeleteBaseCommand(name string) {
-	repo, err := openRepo()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-	}
+	repo := mustOpenRepo()
 	if err := executeConfigDeleteBase(repo, name); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
@@ -378,11 +350,7 @@ func ConfigDeleteBaseCommand(name string) {
 
 // ConfigDeleteTopicCommand deletes a topic branch type configuration
 func ConfigDeleteTopicCommand(name string) {
-	repo, err := openRepo()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-	}
+	repo := mustOpenRepo()
 	if err := executeConfigDeleteTopic(repo, name); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
@@ -397,11 +365,7 @@ func ConfigDeleteTopicCommand(name string) {
 
 // ConfigListCommand lists the current configuration
 func ConfigListCommand() {
-	repo, err := openRepo()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-	}
+	repo := mustOpenRepo()
 	if err := executeConfigList(repo); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -246,11 +246,11 @@ Example:
 // ConfigAddBaseCommand adds a base branch configuration
 func ConfigAddBaseCommand(name, parent, upstreamStrategy, downstreamStrategy string, autoUpdate bool) {
 	repo, err := openRepo()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-			os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-		}
-		if err := executeConfigAddBase(repo, name, parent, upstreamStrategy, downstreamStrategy, autoUpdate); err != nil {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+	}
+	if err := executeConfigAddBase(repo, name, parent, upstreamStrategy, downstreamStrategy, autoUpdate); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -265,11 +265,11 @@ func ConfigAddBaseCommand(name, parent, upstreamStrategy, downstreamStrategy str
 // ConfigAddTopicCommand adds a topic branch type configuration
 func ConfigAddTopicCommand(name, parent, prefix, startingPoint, upstreamStrategy, downstreamStrategy string, tag bool) {
 	repo, err := openRepo()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-			os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-		}
-		if err := executeConfigAddTopic(repo, name, parent, prefix, startingPoint, upstreamStrategy, downstreamStrategy, tag); err != nil {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+	}
+	if err := executeConfigAddTopic(repo, name, parent, prefix, startingPoint, upstreamStrategy, downstreamStrategy, tag); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -284,11 +284,11 @@ func ConfigAddTopicCommand(name, parent, prefix, startingPoint, upstreamStrategy
 // ConfigEditBaseCommand edits a base branch configuration
 func ConfigEditBaseCommand(name, upstreamStrategy, downstreamStrategy string, autoUpdate bool) {
 	repo, err := openRepo()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-			os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-		}
-		if err := executeConfigEditBase(repo, name, upstreamStrategy, downstreamStrategy, autoUpdate); err != nil {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+	}
+	if err := executeConfigEditBase(repo, name, upstreamStrategy, downstreamStrategy, autoUpdate); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -303,11 +303,11 @@ func ConfigEditBaseCommand(name, upstreamStrategy, downstreamStrategy string, au
 // ConfigEditTopicCommand edits a topic branch type configuration
 func ConfigEditTopicCommand(name, prefix, startingPoint, upstreamStrategy, downstreamStrategy string, tag bool) {
 	repo, err := openRepo()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-			os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-		}
-		if err := executeConfigEditTopic(repo, name, prefix, startingPoint, upstreamStrategy, downstreamStrategy, tag); err != nil {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+	}
+	if err := executeConfigEditTopic(repo, name, prefix, startingPoint, upstreamStrategy, downstreamStrategy, tag); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -322,11 +322,11 @@ func ConfigEditTopicCommand(name, prefix, startingPoint, upstreamStrategy, downs
 // ConfigRenameBaseCommand renames a base branch
 func ConfigRenameBaseCommand(oldName, newName string) {
 	repo, err := openRepo()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-			os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-		}
-		if err := executeConfigRenameBase(repo, oldName, newName); err != nil {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+	}
+	if err := executeConfigRenameBase(repo, oldName, newName); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -341,11 +341,11 @@ func ConfigRenameBaseCommand(oldName, newName string) {
 // ConfigRenameTopicCommand renames a topic branch type
 func ConfigRenameTopicCommand(oldName, newName string) {
 	repo, err := openRepo()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-			os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-		}
-		if err := executeConfigRenameTopic(repo, oldName, newName); err != nil {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+	}
+	if err := executeConfigRenameTopic(repo, oldName, newName); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -360,11 +360,11 @@ func ConfigRenameTopicCommand(oldName, newName string) {
 // ConfigDeleteBaseCommand deletes a base branch configuration
 func ConfigDeleteBaseCommand(name string) {
 	repo, err := openRepo()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-			os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-		}
-		if err := executeConfigDeleteBase(repo, name); err != nil {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+	}
+	if err := executeConfigDeleteBase(repo, name); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -379,11 +379,11 @@ func ConfigDeleteBaseCommand(name string) {
 // ConfigDeleteTopicCommand deletes a topic branch type configuration
 func ConfigDeleteTopicCommand(name string) {
 	repo, err := openRepo()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-			os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-		}
-		if err := executeConfigDeleteTopic(repo, name); err != nil {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+	}
+	if err := executeConfigDeleteTopic(repo, name); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -398,11 +398,11 @@ func ConfigDeleteTopicCommand(name string) {
 // ConfigListCommand lists the current configuration
 func ConfigListCommand() {
 	repo, err := openRepo()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-			os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-		}
-		if err := executeConfigList(repo); err != nil {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+	}
+	if err := executeConfigList(repo); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -245,7 +245,12 @@ Example:
 
 // ConfigAddBaseCommand adds a base branch configuration
 func ConfigAddBaseCommand(name, parent, upstreamStrategy, downstreamStrategy string, autoUpdate bool) {
-	if err := executeConfigAddBase(name, parent, upstreamStrategy, downstreamStrategy, autoUpdate); err != nil {
+	repo, err := openRepo()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+			os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+		}
+		if err := executeConfigAddBase(repo, name, parent, upstreamStrategy, downstreamStrategy, autoUpdate); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -259,7 +264,12 @@ func ConfigAddBaseCommand(name, parent, upstreamStrategy, downstreamStrategy str
 
 // ConfigAddTopicCommand adds a topic branch type configuration
 func ConfigAddTopicCommand(name, parent, prefix, startingPoint, upstreamStrategy, downstreamStrategy string, tag bool) {
-	if err := executeConfigAddTopic(name, parent, prefix, startingPoint, upstreamStrategy, downstreamStrategy, tag); err != nil {
+	repo, err := openRepo()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+			os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+		}
+		if err := executeConfigAddTopic(repo, name, parent, prefix, startingPoint, upstreamStrategy, downstreamStrategy, tag); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -273,7 +283,12 @@ func ConfigAddTopicCommand(name, parent, prefix, startingPoint, upstreamStrategy
 
 // ConfigEditBaseCommand edits a base branch configuration
 func ConfigEditBaseCommand(name, upstreamStrategy, downstreamStrategy string, autoUpdate bool) {
-	if err := executeConfigEditBase(name, upstreamStrategy, downstreamStrategy, autoUpdate); err != nil {
+	repo, err := openRepo()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+			os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+		}
+		if err := executeConfigEditBase(repo, name, upstreamStrategy, downstreamStrategy, autoUpdate); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -287,7 +302,12 @@ func ConfigEditBaseCommand(name, upstreamStrategy, downstreamStrategy string, au
 
 // ConfigEditTopicCommand edits a topic branch type configuration
 func ConfigEditTopicCommand(name, prefix, startingPoint, upstreamStrategy, downstreamStrategy string, tag bool) {
-	if err := executeConfigEditTopic(name, prefix, startingPoint, upstreamStrategy, downstreamStrategy, tag); err != nil {
+	repo, err := openRepo()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+			os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+		}
+		if err := executeConfigEditTopic(repo, name, prefix, startingPoint, upstreamStrategy, downstreamStrategy, tag); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -301,7 +321,12 @@ func ConfigEditTopicCommand(name, prefix, startingPoint, upstreamStrategy, downs
 
 // ConfigRenameBaseCommand renames a base branch
 func ConfigRenameBaseCommand(oldName, newName string) {
-	if err := executeConfigRenameBase(oldName, newName); err != nil {
+	repo, err := openRepo()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+			os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+		}
+		if err := executeConfigRenameBase(repo, oldName, newName); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -315,7 +340,12 @@ func ConfigRenameBaseCommand(oldName, newName string) {
 
 // ConfigRenameTopicCommand renames a topic branch type
 func ConfigRenameTopicCommand(oldName, newName string) {
-	if err := executeConfigRenameTopic(oldName, newName); err != nil {
+	repo, err := openRepo()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+			os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+		}
+		if err := executeConfigRenameTopic(repo, oldName, newName); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -329,7 +359,12 @@ func ConfigRenameTopicCommand(oldName, newName string) {
 
 // ConfigDeleteBaseCommand deletes a base branch configuration
 func ConfigDeleteBaseCommand(name string) {
-	if err := executeConfigDeleteBase(name); err != nil {
+	repo, err := openRepo()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+			os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+		}
+		if err := executeConfigDeleteBase(repo, name); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -343,7 +378,12 @@ func ConfigDeleteBaseCommand(name string) {
 
 // ConfigDeleteTopicCommand deletes a topic branch type configuration
 func ConfigDeleteTopicCommand(name string) {
-	if err := executeConfigDeleteTopic(name); err != nil {
+	repo, err := openRepo()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+			os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+		}
+		if err := executeConfigDeleteTopic(repo, name); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -357,7 +397,12 @@ func ConfigDeleteTopicCommand(name string) {
 
 // ConfigListCommand lists the current configuration
 func ConfigListCommand() {
-	if err := executeConfigList(); err != nil {
+	repo, err := openRepo()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+			os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+		}
+		if err := executeConfigList(repo); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -369,9 +414,9 @@ func ConfigListCommand() {
 	}
 }
 
-func executeConfigAddBase(name, parent, upstreamStrategy, downstreamStrategy string, autoUpdate bool) error {
+func executeConfigAddBase(repo *git.Repo, name, parent, upstreamStrategy, downstreamStrategy string, autoUpdate bool) error {
 	// Validate that git-flow is initialized
-	initialized, err := config.IsInitialized()
+	initialized, err := config.IsInitialized(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
 	}
@@ -385,7 +430,7 @@ func executeConfigAddBase(name, parent, upstreamStrategy, downstreamStrategy str
 	}
 
 	// Load current configuration
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
@@ -445,9 +490,9 @@ func executeConfigAddBase(name, parent, upstreamStrategy, downstreamStrategy str
 	}
 
 	// Create Git branch if it doesn't exist
-	if err := git.BranchExists(name); err != nil {
+	if err := repo.BranchExists(name); err != nil {
 		// Branch doesn't exist, create it
-		if err := git.CreateBranch(name, parent); err != nil {
+		if err := repo.CreateBranch(name, parent); err != nil {
 			return &errors.GitError{Operation: fmt.Sprintf("create branch '%s'", name), Err: err}
 		}
 		fmt.Printf("✓ Created branch '%s'\n", name)
@@ -457,9 +502,9 @@ func executeConfigAddBase(name, parent, upstreamStrategy, downstreamStrategy str
 	return nil
 }
 
-func executeConfigAddTopic(name, parent, prefix, startingPoint, upstreamStrategy, downstreamStrategy string, tag bool) error {
+func executeConfigAddTopic(repo *git.Repo, name, parent, prefix, startingPoint, upstreamStrategy, downstreamStrategy string, tag bool) error {
 	// Validate that git-flow is initialized
-	initialized, err := config.IsInitialized()
+	initialized, err := config.IsInitialized(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
 	}
@@ -473,7 +518,7 @@ func executeConfigAddTopic(name, parent, prefix, startingPoint, upstreamStrategy
 	}
 
 	// Load current configuration
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
@@ -542,9 +587,9 @@ func executeConfigAddTopic(name, parent, prefix, startingPoint, upstreamStrategy
 	return nil
 }
 
-func executeConfigEditBase(name, upstreamStrategy, downstreamStrategy string, autoUpdate bool) error {
+func executeConfigEditBase(repo *git.Repo, name, upstreamStrategy, downstreamStrategy string, autoUpdate bool) error {
 	// Validate that git-flow is initialized
-	initialized, err := config.IsInitialized()
+	initialized, err := config.IsInitialized(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
 	}
@@ -553,7 +598,7 @@ func executeConfigEditBase(name, upstreamStrategy, downstreamStrategy string, au
 	}
 
 	// Load current configuration
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
@@ -601,9 +646,9 @@ func executeConfigEditBase(name, upstreamStrategy, downstreamStrategy string, au
 	return nil
 }
 
-func executeConfigEditTopic(name, prefix, startingPoint, upstreamStrategy, downstreamStrategy string, tag bool) error {
+func executeConfigEditTopic(repo *git.Repo, name, prefix, startingPoint, upstreamStrategy, downstreamStrategy string, tag bool) error {
 	// Validate that git-flow is initialized
-	initialized, err := config.IsInitialized()
+	initialized, err := config.IsInitialized(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
 	}
@@ -612,7 +657,7 @@ func executeConfigEditTopic(name, prefix, startingPoint, upstreamStrategy, downs
 	}
 
 	// Load current configuration
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
@@ -671,9 +716,9 @@ func executeConfigEditTopic(name, prefix, startingPoint, upstreamStrategy, downs
 	return nil
 }
 
-func executeConfigRenameBase(oldName, newName string) error {
+func executeConfigRenameBase(repo *git.Repo, oldName, newName string) error {
 	// Validate that git-flow is initialized
-	initialized, err := config.IsInitialized()
+	initialized, err := config.IsInitialized(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
 	}
@@ -687,7 +732,7 @@ func executeConfigRenameBase(oldName, newName string) error {
 	}
 
 	// Load current configuration
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
@@ -717,11 +762,11 @@ func executeConfigRenameBase(oldName, newName string) error {
 	// case-insensitive filesystems, where the destination folds to the same
 	// existing ref; it is safe here because we already confirmed newName does
 	// not collide with a *different* branch.
-	if err := git.BranchExists(oldName); err == nil {
+	if err := repo.BranchExists(oldName); err == nil {
 		caseOnlyRename := oldName != newName && strings.EqualFold(oldName, newName)
-		renameErr := git.RenameBranch(oldName, newName)
+		renameErr := repo.RenameBranch(oldName, newName)
 		if renameErr != nil && caseOnlyRename {
-			renameErr = git.RenameBranchForce(oldName, newName)
+			renameErr = repo.RenameBranchForce(oldName, newName)
 		}
 		if renameErr != nil {
 			return &errors.GitError{Operation: fmt.Sprintf("rename branch '%s' to '%s'", oldName, newName), Err: renameErr}
@@ -730,7 +775,7 @@ func executeConfigRenameBase(oldName, newName string) error {
 	}
 
 	// Remove old branch config from git config
-	if err := git.UnsetConfigSection(fmt.Sprintf("gitflow.branch.%s", oldName)); err != nil {
+	if err := repo.UnsetConfigSection(fmt.Sprintf("gitflow.branch.%s", oldName)); err != nil {
 		return &errors.GitError{Operation: fmt.Sprintf("remove old branch config for '%s'", oldName), Err: err}
 	}
 
@@ -759,9 +804,9 @@ func executeConfigRenameBase(oldName, newName string) error {
 	return nil
 }
 
-func executeConfigRenameTopic(oldName, newName string) error {
+func executeConfigRenameTopic(repo *git.Repo, oldName, newName string) error {
 	// Validate that git-flow is initialized
-	initialized, err := config.IsInitialized()
+	initialized, err := config.IsInitialized(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
 	}
@@ -775,7 +820,7 @@ func executeConfigRenameTopic(oldName, newName string) error {
 	}
 
 	// Load current configuration
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
@@ -803,7 +848,7 @@ func executeConfigRenameTopic(oldName, newName string) error {
 	// Remove the old branch config section from git config (topic renames
 	// only touch config, not refs), so the old canonical subsection does not
 	// linger after the save writes the new one.
-	if err := git.UnsetConfigSection(fmt.Sprintf("gitflow.branch.%s", oldName)); err != nil {
+	if err := repo.UnsetConfigSection(fmt.Sprintf("gitflow.branch.%s", oldName)); err != nil {
 		return &errors.GitError{Operation: fmt.Sprintf("remove old branch config for '%s'", oldName), Err: err}
 	}
 
@@ -820,9 +865,9 @@ func executeConfigRenameTopic(oldName, newName string) error {
 	return nil
 }
 
-func executeConfigDeleteBase(name string) error {
+func executeConfigDeleteBase(repo *git.Repo, name string) error {
 	// Validate that git-flow is initialized
-	initialized, err := config.IsInitialized()
+	initialized, err := config.IsInitialized(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
 	}
@@ -831,7 +876,7 @@ func executeConfigDeleteBase(name string) error {
 	}
 
 	// Load current configuration
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
@@ -860,7 +905,7 @@ func executeConfigDeleteBase(name string) error {
 	}
 
 	// Remove branch config from git config
-	if err := git.UnsetConfigSection(fmt.Sprintf("gitflow.branch.%s", name)); err != nil {
+	if err := repo.UnsetConfigSection(fmt.Sprintf("gitflow.branch.%s", name)); err != nil {
 		return &errors.GitError{Operation: fmt.Sprintf("remove branch config for '%s'", name), Err: err}
 	}
 
@@ -877,9 +922,9 @@ func executeConfigDeleteBase(name string) error {
 	return nil
 }
 
-func executeConfigDeleteTopic(name string) error {
+func executeConfigDeleteTopic(repo *git.Repo, name string) error {
 	// Validate that git-flow is initialized
-	initialized, err := config.IsInitialized()
+	initialized, err := config.IsInitialized(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
 	}
@@ -888,7 +933,7 @@ func executeConfigDeleteTopic(name string) error {
 	}
 
 	// Load current configuration
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
@@ -907,7 +952,7 @@ func executeConfigDeleteTopic(name string) error {
 	}
 
 	// Remove branch config from git config
-	if err := git.UnsetConfigSection(fmt.Sprintf("gitflow.branch.%s", name)); err != nil {
+	if err := repo.UnsetConfigSection(fmt.Sprintf("gitflow.branch.%s", name)); err != nil {
 		return &errors.GitError{Operation: fmt.Sprintf("remove branch config for '%s'", name), Err: err}
 	}
 
@@ -923,9 +968,9 @@ func executeConfigDeleteTopic(name string) error {
 	return nil
 }
 
-func executeConfigList() error {
+func executeConfigList(repo *git.Repo) error {
 	// Validate that git-flow is initialized
-	initialized, err := config.IsInitialized()
+	initialized, err := config.IsInitialized(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
 	}
@@ -936,7 +981,7 @@ func executeConfigList() error {
 	}
 
 	// Load current configuration
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}

--- a/cmd/continue_abort.go
+++ b/cmd/continue_abort.go
@@ -22,10 +22,10 @@ import (
 // write from a crash mid-save): if git is genuinely mid-operation the file must
 // not be destroyed, so it is refused rather than left to IsMergeInProgress, which
 // would delete it while the git marker is still present.
-func refuseIfForeignOperation(cfg *config.Config, currentCommand string) error {
-	rawState, loadErr := mergestate.LoadMergeState()
+func refuseIfForeignOperation(repo *git.Repo, cfg *config.Config, currentCommand string) error {
+	rawState, loadErr := mergestate.LoadMergeState(repo)
 
-	gitInProgress := git.IsGitMergeInProgress() || git.IsGitRebaseInProgress() || git.IsGitSquashMergeInProgress()
+	gitInProgress := repo.IsGitMergeInProgress() || repo.IsGitRebaseInProgress() || repo.IsGitSquashMergeInProgress()
 
 	if loadErr != nil {
 		// The state file exists but could not be parsed. If a real git operation

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -12,7 +12,12 @@ import (
 
 // DeleteCommand handles the deletion of a topic branch
 func DeleteCommand(branchType string, name string, force *bool, remote *bool, fetch *bool) {
-	if err := executeDelete(branchType, name, force, remote, fetch); err != nil {
+	repo, err := openRepo()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+	}
+	if err := executeDelete(repo, branchType, name, force, remote, fetch); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -25,11 +30,11 @@ func DeleteCommand(branchType string, name string, force *bool, remote *bool, fe
 }
 
 // executeDelete performs the actual branch deletion logic and returns any errors
-func executeDelete(branchType string, name string, force *bool, remote *bool, fetch *bool) error {
+func executeDelete(repo *git.Repo, branchType string, name string, force *bool, remote *bool, fetch *bool) error {
 	// Validate that git-flow is initialized before resolving branch types.
 	// LoadConfig falls back to DefaultConfig when uninitialized, so this gate
 	// must run first or the default branch types mask the uninitialized state.
-	initialized, err := config.IsInitialized()
+	initialized, err := config.IsInitialized(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
 	}
@@ -38,7 +43,7 @@ func executeDelete(branchType string, name string, force *bool, remote *bool, fe
 	}
 
 	// Load configuration
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
@@ -56,16 +61,13 @@ func executeDelete(branchType string, name string, force *bool, remote *bool, fe
 	}
 
 	// Check if branch exists
-	err = git.BranchExists(fullBranchName)
+	err = repo.BranchExists(fullBranchName)
 	if err != nil {
 		return &errors.BranchNotFoundError{BranchName: fullBranchName}
 	}
 
 	// Get git directory for hooks
-	gitDir, err := git.GetGitDir()
-	if err != nil {
-		return &errors.GitError{Operation: "get git directory", Err: err}
-	}
+	gitDir := repo.GitDir()
 
 	// Get remote name from config
 	remoteName := cfg.Remote
@@ -84,19 +86,19 @@ func executeDelete(branchType string, name string, force *bool, remote *bool, fe
 
 	// Run delete operation wrapped with hooks
 	return hooks.WithHooks(gitDir, branchType, hooks.HookActionDelete, hookCtx, func() error {
-		return performDelete(branchType, name, fullBranchName, branchConfig, force, remote, fetch, cfg)
+		return performDelete(repo, branchType, name, fullBranchName, branchConfig, force, remote, fetch, cfg)
 	})
 }
 
 // performDelete performs the actual delete operation (called within hooks wrapper)
-func performDelete(branchType, name, fullBranchName string, branchConfig config.BranchConfig, force *bool, remote *bool, fetch *bool, cfg *config.Config) error {
+func performDelete(repo *git.Repo, branchType, name, fullBranchName string, branchConfig config.BranchConfig, force *bool, remote *bool, fetch *bool, cfg *config.Config) error {
 	// Determine if we should fetch before deleting (flag > config, default false).
 	shouldFetch := false
 	if fetch != nil {
 		shouldFetch = *fetch
 	} else {
 		configKey := fmt.Sprintf("gitflow.%s.delete.fetch", branchType)
-		fetchConfig, err := git.GetConfig(configKey)
+		fetchConfig, err := repo.GetConfig(configKey)
 		if err == nil && fetchConfig == "true" {
 			shouldFetch = true
 		}
@@ -110,7 +112,7 @@ func performDelete(branchType, name, fullBranchName string, branchConfig config.
 	} else {
 		// Check config if not specified
 		configKey := fmt.Sprintf("gitflow.%s.delete.force", branchType)
-		forceConfig, err := git.GetConfig(configKey)
+		forceConfig, err := repo.GetConfig(configKey)
 		if err == nil && forceConfig == "true" {
 			forceDelete = true
 		}
@@ -124,7 +126,7 @@ func performDelete(branchType, name, fullBranchName string, branchConfig config.
 	} else {
 		// Check config if not specified
 		configKey := fmt.Sprintf("gitflow.branch.%s.deleteRemote", branchType)
-		remoteConfig, err := git.GetConfig(configKey)
+		remoteConfig, err := repo.GetConfig(configKey)
 		if err == nil && remoteConfig == "true" {
 			deleteRemote = true
 		}
@@ -132,21 +134,21 @@ func performDelete(branchType, name, fullBranchName string, branchConfig config.
 
 	// Validate remote exists if remote deletion is requested
 	// This must happen before any state-changing operations (checkout, branch deletion)
-	if deleteRemote && !git.RemoteExists(cfg.Remote) {
+	if deleteRemote && !repo.RemoteExists(cfg.Remote) {
 		return &errors.RemoteNotConfiguredError{Remote: cfg.Remote, Operation: "delete remote branch"}
 	}
 
 	// If we're on the branch to be deleted, switch to its parent first. This happens before the
 	// fetch/sync preflight so that fast-forwarding the parent (see below) operates on HEAD, which
 	// is what `git branch -d` checks a topic against when it has no upstream.
-	currentBranch, err := git.GetCurrentBranch()
+	currentBranch, err := repo.GetCurrentBranch()
 	if err != nil {
 		return &errors.GitError{Operation: "get current branch", Err: err}
 	}
 	if currentBranch == fullBranchName {
 		parentBranch := branchConfig.Parent
 		if parentBranch != "" {
-			if err := git.Checkout(parentBranch); err != nil {
+			if err := repo.Checkout(parentBranch); err != nil {
 				return &errors.GitError{Operation: fmt.Sprintf("checkout parent branch '%s'", parentBranch), Err: err}
 			}
 		} else {
@@ -159,7 +161,7 @@ func performDelete(branchType, name, fullBranchName string, branchConfig config.
 	// the topic. Delete uses the relaxed preflight variant: a fetch failure is a non-fatal note and
 	// a topic that is merely ahead of its remote is tolerated (a non-force `git branch -d` still
 	// guards genuinely unmerged work). A topic that is behind/diverged aborts unless forced.
-	if err := runFetchSyncPreflight(cfg, branchType, cfg.Remote, fullBranchName, name, branchConfig.Parent, shouldFetch, forceDelete, preflightOptions{
+	if err := runFetchSyncPreflight(repo, cfg, branchType, cfg.Remote, fullBranchName, name, branchConfig.Parent, shouldFetch, forceDelete, preflightOptions{
 		ffParent:             true,
 		tolerateAhead:        true,
 		fetchFailureNonFatal: true,
@@ -169,7 +171,7 @@ func performDelete(branchType, name, fullBranchName string, branchConfig config.
 	}
 
 	// Delete the branch with appropriate flag
-	deleteErr := git.DeleteBranch(fullBranchName, forceDelete)
+	deleteErr := repo.DeleteBranch(fullBranchName, forceDelete)
 	if deleteErr != nil {
 		return &errors.GitError{Operation: fmt.Sprintf("delete branch '%s'", fullBranchName), Err: deleteErr}
 	}
@@ -179,9 +181,9 @@ func performDelete(branchType, name, fullBranchName string, branchConfig config.
 		remoteName := cfg.Remote
 
 		deletedRemote := false
-		if git.RemoteBranchExists(remoteName, fullBranchName) {
+		if repo.RemoteBranchExists(remoteName, fullBranchName) {
 			// Delete remote branch
-			if err := git.DeleteRemoteBranch(remoteName, fullBranchName); err != nil {
+			if err := repo.DeleteRemoteBranch(remoteName, fullBranchName); err != nil {
 				return &errors.GitError{Operation: fmt.Sprintf("delete remote branch '%s'", fullBranchName), Err: err}
 			} else {
 				deletedRemote = true
@@ -198,7 +200,7 @@ func performDelete(branchType, name, fullBranchName string, branchConfig config.
 
 	// Clean up base branch configuration
 	configKey := fmt.Sprintf("gitflow.branch.%s.base", fullBranchName)
-	if err := git.UnsetConfigIfPresent(configKey); err != nil {
+	if err := repo.UnsetConfigIfPresent(configKey); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: Failed to clean up base config: %v\n", err)
 	}
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -12,11 +12,7 @@ import (
 
 // DeleteCommand handles the deletion of a topic branch
 func DeleteCommand(branchType string, name string, force *bool, remote *bool, fetch *bool) {
-	repo, err := openRepo()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-	}
+	repo := mustOpenRepo()
 	if err := executeDelete(repo, branchType, name, force, remote, fetch); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {

--- a/cmd/finish.go
+++ b/cmd/finish.go
@@ -85,7 +85,12 @@ const (
 
 // FinishCommand is the implementation of the finish command for topic branches
 func FinishCommand(branchType string, name string, continueOp bool, abortOp bool, force bool, tagOptions *config.TagOptions, retentionOptions *config.BranchRetentionOptions, mergeOptions *config.MergeStrategyOptions, fetch *bool, noVerify *bool, push *bool, pushTag *bool) {
-	if err := executeFinish(branchType, name, continueOp, abortOp, force, tagOptions, retentionOptions, mergeOptions, fetch, noVerify, push, pushTag); err != nil {
+	repo, err := openRepo()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+	}
+	if err := executeFinish(repo, branchType, name, continueOp, abortOp, force, tagOptions, retentionOptions, mergeOptions, fetch, noVerify, push, pushTag); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -102,7 +107,7 @@ func FinishCommand(branchType string, name string, continueOp bool, abortOp bool
 // =============================================================================
 
 // executeFinish performs the actual branch finishing logic and returns any errors
-func executeFinish(branchType string, name string, continueOp bool, abortOp bool, force bool, tagOptions *config.TagOptions, retentionOptions *config.BranchRetentionOptions, mergeOptions *config.MergeStrategyOptions, fetch *bool, noVerify *bool, push *bool, pushTag *bool) error {
+func executeFinish(repo *git.Repo, branchType string, name string, continueOp bool, abortOp bool, force bool, tagOptions *config.TagOptions, retentionOptions *config.BranchRetentionOptions, mergeOptions *config.MergeStrategyOptions, fetch *bool, noVerify *bool, push *bool, pushTag *bool) error {
 	// Validate that git-flow is initialized before loading config or resolving
 	// branches. This is the shared gate for every finish entry point: both the
 	// topic-branch handler (cmd/topicbranch.go) and the shorthand command
@@ -110,7 +115,7 @@ func executeFinish(branchType string, name string, continueOp bool, abortOp bool
 	// DefaultConfig when uninitialized, so this must run first. The topic-branch
 	// handler additionally gates before its own current-branch name detection,
 	// which runs ahead of this function.
-	initialized, err := config.IsInitialized()
+	initialized, err := config.IsInitialized(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
 	}
@@ -119,7 +124,7 @@ func executeFinish(branchType string, name string, continueOp bool, abortOp bool
 	}
 
 	// Get configuration early
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
@@ -133,13 +138,13 @@ func executeFinish(branchType string, name string, continueOp bool, abortOp bool
 	// Foreign-operation guard (#143): refuse a foreign in-progress update/integrate
 	// (or an unknown-Action state) before any dispatch, so finish never resumes or
 	// aborts an operation it does not own.
-	if err := refuseIfForeignOperation(cfg, "finish"); err != nil {
+	if err := refuseIfForeignOperation(repo, cfg, "finish"); err != nil {
 		return err
 	}
 
 	// Check if there's a merge in progress
-	if mergestate.IsMergeInProgress() {
-		state, err := mergestate.LoadMergeState()
+	if mergestate.IsMergeInProgress(repo) {
+		state, err := mergestate.LoadMergeState(repo)
 		if err != nil {
 			return &errors.GitError{Operation: "load merge state", Err: err}
 		}
@@ -157,13 +162,13 @@ func executeFinish(branchType string, name string, continueOp bool, abortOp bool
 		}
 
 		if abortOp {
-			return handleAbort(state)
+			return handleAbort(repo, state)
 		}
 
 		if continueOp {
 			// Resolve options for continue operation
 			resolvedOptions := config.ResolveFinishOptions(cfg, state.BranchType, state.BranchName, tagOptions, retentionOptions, mergeOptions, fetch, noVerify, push, pushTag)
-			return handleContinue(cfg, state, stateBranchConfig, resolvedOptions, mergeOptions)
+			return handleContinue(repo, cfg, state, stateBranchConfig, resolvedOptions, mergeOptions)
 		}
 
 		return &errors.MergeInProgressError{Action: "finish", BranchName: state.FullBranchName, BranchType: state.BranchType}
@@ -182,7 +187,7 @@ func executeFinish(branchType string, name string, continueOp bool, abortOp bool
 	}
 
 	// Resolve branch name (try with and without prefix)
-	resolvedName, err := resolveBranchName(name, branchConfig)
+	resolvedName, err := resolveBranchName(repo, name, branchConfig)
 	if err != nil {
 		return err
 	}
@@ -238,15 +243,15 @@ func executeFinish(branchType string, name string, continueOp bool, abortOp bool
 	// fetch failure or a behind/diverged topic aborts here, before any merge. Being *ahead* is
 	// tolerated (downgraded to a note): finish merges the unpushed commits into the parent and then
 	// deletes the topic branch, so requiring a push first would preserve nothing.
-	if err := runFetchSyncPreflight(cfg, branchType, cfg.Remote, name, shortName, branchConfig.Parent, resolvedOptions.ShouldFetch, force, preflightOptions{tolerateAhead: true, parentSyncCheck: true}); err != nil {
+	if err := runFetchSyncPreflight(repo, cfg, branchType, cfg.Remote, name, shortName, branchConfig.Parent, resolvedOptions.ShouldFetch, force, preflightOptions{tolerateAhead: true, parentSyncCheck: true}); err != nil {
 		return err
 	}
 
 	// Regular finish command flow
-	return finishBranch(cfg, branchType, name, branchConfig, tagOptions, retentionOptions, mergeOptions, fetch, noVerify, push, pushTag)
+	return finishBranch(repo, cfg, branchType, name, branchConfig, tagOptions, retentionOptions, mergeOptions, fetch, noVerify, push, pushTag)
 }
 
-func finishBranch(cfg *config.Config, branchType string, name string, branchConfig config.BranchConfig, tagOptions *config.TagOptions, retentionOptions *config.BranchRetentionOptions, mergeOptions *config.MergeStrategyOptions, fetch *bool, noVerify *bool, push *bool, pushTag *bool) error {
+func finishBranch(repo *git.Repo, cfg *config.Config, branchType string, name string, branchConfig config.BranchConfig, tagOptions *config.TagOptions, retentionOptions *config.BranchRetentionOptions, mergeOptions *config.MergeStrategyOptions, fetch *bool, noVerify *bool, push *bool, pushTag *bool) error {
 	// Note: the git-flow initialization gate runs earlier in executeFinish (the
 	// only path to finishBranch) and in the topic-branch command handler.
 
@@ -266,7 +271,7 @@ func finishBranch(cfg *config.Config, branchType string, name string, branchConf
 	}
 
 	// Check if branch exists
-	if err := git.BranchExists(name); err != nil {
+	if err := repo.BranchExists(name); err != nil {
 		return &errors.BranchNotFoundError{BranchName: name}
 	}
 
@@ -274,7 +279,7 @@ func finishBranch(cfg *config.Config, branchType string, name string, branchConf
 	targetBranch := branchConfig.Parent
 
 	// Check if target branch exists
-	if err := git.BranchExists(targetBranch); err != nil {
+	if err := repo.BranchExists(targetBranch); err != nil {
 		return &errors.BranchNotFoundError{BranchName: targetBranch}
 	}
 
@@ -294,10 +299,7 @@ func finishBranch(cfg *config.Config, branchType string, name string, branchConf
 	resolvedOptions := config.ResolveFinishOptions(cfg, branchType, shortName, tagOptions, retentionOptions, mergeOptions, fetch, noVerify, push, pushTag)
 
 	// Run pre-hook before starting finish operation
-	gitDir, err := git.GetGitDir()
-	if err != nil {
-		return &errors.GitError{Operation: "get git directory", Err: err}
-	}
+	gitDir := repo.GitDir()
 
 	hookCtx := hooks.HookContext{
 		BranchType: branchType,
@@ -332,11 +334,11 @@ func finishBranch(cfg *config.Config, branchType string, name string, branchConf
 		UpdateMessage:   resolvedOptions.UpdateMessage,
 		NoVerify:        resolvedOptions.NoVerify,
 	}
-	if err := mergestate.SaveMergeState(state); err != nil {
+	if err := mergestate.SaveMergeState(repo, state); err != nil {
 		return &errors.GitError{Operation: "save merge state", Err: err}
 	}
 
-	return executeSteps(cfg, state, branchConfig, resolvedOptions)
+	return executeSteps(repo, cfg, state, branchConfig, resolvedOptions)
 }
 
 // =============================================================================
@@ -344,20 +346,20 @@ func finishBranch(cfg *config.Config, branchType string, name string, branchConf
 // =============================================================================
 
 // executeSteps runs the state machine for the finish operation
-func executeSteps(cfg *config.Config, state *mergestate.MergeState, branchConfig config.BranchConfig, resolvedOptions *config.ResolvedFinishOptions) error {
+func executeSteps(repo *git.Repo, cfg *config.Config, state *mergestate.MergeState, branchConfig config.BranchConfig, resolvedOptions *config.ResolvedFinishOptions) error {
 	for {
 		var err error
 		switch state.CurrentStep {
 		case stepMerge:
-			err = handleMergeStep(cfg, state, branchConfig, resolvedOptions)
+			err = handleMergeStep(repo, cfg, state, branchConfig, resolvedOptions)
 		case stepCreateTag:
-			err = handleCreateTagStep(cfg, state, resolvedOptions)
+			err = handleCreateTagStep(repo, cfg, state, resolvedOptions)
 		case stepUpdateChildren:
-			err = handleUpdateChildrenStep(cfg, state, branchConfig, resolvedOptions)
+			err = handleUpdateChildrenStep(repo, cfg, state, branchConfig, resolvedOptions)
 		case stepDeleteBranch:
-			return handleDeleteBranchStep(cfg, state, resolvedOptions) // Final step
+			return handleDeleteBranchStep(repo, cfg, state, resolvedOptions) // Final step
 		case stepIntegrateDone:
-			return handleIntegrateDoneStep(state) // Final step (integrate)
+			return handleIntegrateDoneStep(repo, state) // Final step (integrate)
 		default:
 			return &errors.GitError{Operation: fmt.Sprintf("unknown step '%s'", state.CurrentStep), Err: nil}
 		}
@@ -368,12 +370,12 @@ func executeSteps(cfg *config.Config, state *mergestate.MergeState, branchConfig
 	}
 }
 
-func handleContinue(cfg *config.Config, state *mergestate.MergeState, branchConfig config.BranchConfig, resolvedOptions *config.ResolvedFinishOptions, mergeOptions *config.MergeStrategyOptions) error {
+func handleContinue(repo *git.Repo, cfg *config.Config, state *mergestate.MergeState, branchConfig config.BranchConfig, resolvedOptions *config.ResolvedFinishOptions, mergeOptions *config.MergeStrategyOptions) error {
 	// Handle continuation based on current step
 	switch state.CurrentStep {
 	case stepMerge:
 		// For merge step continuation, check if conflicts are resolved
-		if git.HasConflicts() {
+		if repo.HasConflicts() {
 			return &errors.UnresolvedConflictsError{}
 		}
 
@@ -382,7 +384,7 @@ func handleContinue(cfg *config.Config, state *mergestate.MergeState, branchConf
 		switch state.MergeStrategy {
 		case strategyRebase:
 			// Continue the rebase operation
-			err = git.RebaseContinue()
+			err = repo.RebaseContinue()
 			if err != nil {
 				// Check if rebase is complete or if there are more commits to rebase
 				if strings.Contains(err.Error(), "No rebase in progress") {
@@ -396,7 +398,7 @@ func handleContinue(cfg *config.Config, state *mergestate.MergeState, branchConf
 			}
 
 			// After successful rebase, checkout target and merge
-			err = git.Checkout(state.ParentBranch)
+			err = repo.Checkout(state.ParentBranch)
 			if err != nil {
 				return &errors.GitError{Operation: "checkout target branch after rebase", Err: err}
 			}
@@ -407,9 +409,9 @@ func handleContinue(cfg *config.Config, state *mergestate.MergeState, branchConf
 			}
 			if mergeMsg != "" {
 				expandedMsg := util.ExpandMessagePlaceholders(mergeMsg, state.FullBranchName, state.ParentBranch)
-				err = git.MergeWithMessage(state.FullBranchName, expandedMsg, resolvedOptions.NoFastForward, state.NoVerify)
+				err = repo.MergeWithMessage(state.FullBranchName, expandedMsg, resolvedOptions.NoFastForward, state.NoVerify)
 			} else {
-				err = git.MergeWithOptions(state.FullBranchName, resolvedOptions.NoFastForward, state.NoVerify)
+				err = repo.MergeWithOptions(state.FullBranchName, resolvedOptions.NoFastForward, state.NoVerify)
 			}
 			if err != nil {
 				return &errors.GitError{Operation: "merge rebased branch", Err: err}
@@ -422,7 +424,7 @@ func handleContinue(cfg *config.Config, state *mergestate.MergeState, branchConf
 			if mergeOptions != nil && mergeOptions.SquashMessage != nil && *mergeOptions.SquashMessage != "" {
 				squashMsg = *mergeOptions.SquashMessage
 			}
-			err = git.Commit(squashMsg, state.NoVerify)
+			err = repo.Commit(squashMsg, state.NoVerify)
 			if err != nil {
 				return &errors.GitError{Operation: "commit squashed changes", Err: err}
 			}
@@ -439,7 +441,7 @@ func handleContinue(cfg *config.Config, state *mergestate.MergeState, branchConf
 			} else {
 				mergeMsg = util.ExpandMessagePlaceholders(mergeMsg, state.FullBranchName, state.ParentBranch)
 			}
-			err = git.Commit(mergeMsg, state.NoVerify)
+			err = repo.Commit(mergeMsg, state.NoVerify)
 			if err != nil {
 				return &errors.GitError{Operation: "commit merge", Err: err}
 			}
@@ -450,13 +452,13 @@ func handleContinue(cfg *config.Config, state *mergestate.MergeState, branchConf
 
 		// Move to next step since merge conflicts are resolved and committed
 		state.CurrentStep = stepCreateTag
-		if err := mergestate.SaveMergeState(state); err != nil {
+		if err := mergestate.SaveMergeState(repo, state); err != nil {
 			return &errors.GitError{Operation: "save merge state", Err: err}
 		}
 
 	case stepUpdateChildren:
 		// For child branch update continuation, check if conflicts are resolved
-		if git.HasConflicts() {
+		if repo.HasConflicts() {
 			return &errors.UnresolvedConflictsError{}
 		}
 
@@ -464,7 +466,7 @@ func handleContinue(cfg *config.Config, state *mergestate.MergeState, branchConf
 		currentChild := state.CurrentChildBranch
 		if currentChild == "" {
 			// Try to determine from current branch
-			currentBranch, err := git.GetCurrentBranch()
+			currentBranch, err := repo.GetCurrentBranch()
 			if err != nil {
 				return &errors.GitError{Operation: "get current branch", Err: err}
 			}
@@ -491,7 +493,7 @@ func handleContinue(cfg *config.Config, state *mergestate.MergeState, branchConf
 		switch strategy {
 		case "rebase":
 			// Continue the rebase operation
-			err = git.RebaseContinue()
+			err = repo.RebaseContinue()
 			if err != nil {
 				if strings.Contains(err.Error(), "No rebase in progress") {
 					// Rebase might be complete, try to proceed
@@ -518,7 +520,7 @@ func handleContinue(cfg *config.Config, state *mergestate.MergeState, branchConf
 				// For child updates, the "branch" is the child and "parent" is the source
 				updateMsg = util.ExpandMessagePlaceholders(updateMsg, currentChild, state.ParentBranch)
 			}
-			err = git.Commit(updateMsg, state.NoVerify)
+			err = repo.Commit(updateMsg, state.NoVerify)
 			if err != nil {
 				return &errors.GitError{Operation: "commit squashed child update", Err: err}
 			}
@@ -537,7 +539,7 @@ func handleContinue(cfg *config.Config, state *mergestate.MergeState, branchConf
 				// For child updates, the "branch" is the child and "parent" is the source
 				updateMsg = util.ExpandMessagePlaceholders(updateMsg, currentChild, state.ParentBranch)
 			}
-			err = git.Commit(updateMsg, state.NoVerify)
+			err = repo.Commit(updateMsg, state.NoVerify)
 			if err != nil {
 				return &errors.GitError{Operation: "commit child branch update", Err: err}
 			}
@@ -550,15 +552,15 @@ func handleContinue(cfg *config.Config, state *mergestate.MergeState, branchConf
 		state.CurrentChildBranch = "" // Clear current child
 
 		// Save state and continue
-		if err := mergestate.SaveMergeState(state); err != nil {
+		if err := mergestate.SaveMergeState(repo, state); err != nil {
 			return &errors.GitError{Operation: "save merge state", Err: err}
 		}
 	}
 
-	return executeSteps(cfg, state, branchConfig, resolvedOptions)
+	return executeSteps(repo, cfg, state, branchConfig, resolvedOptions)
 }
 
-func handleAbort(state *mergestate.MergeState) error {
+func handleAbort(repo *git.Repo, state *mergestate.MergeState) error {
 	// Choose which git operation to abort. During the child-update step the
 	// in-progress operation uses the current child's downstream strategy, which
 	// can differ from the parent merge strategy in state.MergeStrategy. Aborting
@@ -568,7 +570,7 @@ func handleAbort(state *mergestate.MergeState) error {
 	if state.CurrentStep == stepUpdateChildren {
 		currentChild := state.CurrentChildBranch
 		if currentChild == "" {
-			if cur, curErr := git.GetCurrentBranch(); curErr == nil {
+			if cur, curErr := repo.GetCurrentBranch(); curErr == nil {
 				currentChild = cur
 			}
 		}
@@ -583,11 +585,11 @@ func handleAbort(state *mergestate.MergeState) error {
 	var err error
 	switch strategy {
 	case strategyMerge:
-		err = git.MergeAbort()
+		err = repo.MergeAbort()
 	case strategyRebase:
-		err = git.RebaseAbort()
+		err = repo.RebaseAbort()
 	default:
-		err = git.MergeAbort() // Default to merge abort
+		err = repo.MergeAbort() // Default to merge abort
 	}
 
 	if err != nil {
@@ -595,12 +597,12 @@ func handleAbort(state *mergestate.MergeState) error {
 	}
 
 	// Checkout the original branch
-	if err := git.Checkout(state.FullBranchName); err != nil {
+	if err := repo.Checkout(state.FullBranchName); err != nil {
 		return &errors.GitError{Operation: fmt.Sprintf("checkout original branch '%s'", state.FullBranchName), Err: err}
 	}
 
 	// Clear the merge state
-	if err := mergestate.ClearMergeState(); err != nil {
+	if err := mergestate.ClearMergeState(repo); err != nil {
 		return &errors.GitError{Operation: "clear merge state", Err: err}
 	}
 
@@ -612,9 +614,9 @@ func handleAbort(state *mergestate.MergeState) error {
 // =============================================================================
 
 // handleMergeStep handles the merge step of the finish operation
-func handleMergeStep(cfg *config.Config, state *mergestate.MergeState, branchConfig config.BranchConfig, resolvedOptions *config.ResolvedFinishOptions) error {
+func handleMergeStep(repo *git.Repo, cfg *config.Config, state *mergestate.MergeState, branchConfig config.BranchConfig, resolvedOptions *config.ResolvedFinishOptions) error {
 	// Checkout target branch
-	err := git.Checkout(state.ParentBranch)
+	err := repo.Checkout(state.ParentBranch)
 	if err != nil {
 		return &errors.GitError{Operation: fmt.Sprintf("checkout target branch '%s'", state.ParentBranch), Err: err}
 	}
@@ -631,34 +633,34 @@ func handleMergeStep(cfg *config.Config, state *mergestate.MergeState, branchCon
 		fmt.Printf("Rebase strategy selected\n")
 		// For rebase, we need to:
 		// 1. Stay on feature branch
-		err = git.Checkout(state.FullBranchName)
+		err = repo.Checkout(state.FullBranchName)
 		if err != nil {
 			return &errors.GitError{Operation: "checkout feature branch for rebase", Err: err}
 		}
 		// 2. Rebase onto target branch with options
-		mergeErr = git.RebaseWithOptions(state.ParentBranch, resolvedOptions.PreserveMerges)
+		mergeErr = repo.RebaseWithOptions(state.ParentBranch, resolvedOptions.PreserveMerges)
 		if mergeErr == nil {
 			// 3. If rebase succeeds, checkout target and merge
-			err = git.Checkout(state.ParentBranch)
+			err = repo.Checkout(state.ParentBranch)
 			if err != nil {
 				return &errors.GitError{Operation: "checkout target branch after rebase", Err: err}
 			}
 			// Use custom merge message if provided, otherwise use default
 			if resolvedOptions.MergeMessage != "" {
 				expandedMsg := util.ExpandMessagePlaceholders(resolvedOptions.MergeMessage, state.FullBranchName, state.ParentBranch)
-				mergeErr = git.MergeWithMessage(state.FullBranchName, expandedMsg, resolvedOptions.NoFastForward, resolvedOptions.NoVerify)
+				mergeErr = repo.MergeWithMessage(state.FullBranchName, expandedMsg, resolvedOptions.NoFastForward, resolvedOptions.NoVerify)
 			} else {
-				mergeErr = git.MergeWithOptions(state.FullBranchName, resolvedOptions.NoFastForward, resolvedOptions.NoVerify)
+				mergeErr = repo.MergeWithOptions(state.FullBranchName, resolvedOptions.NoFastForward, resolvedOptions.NoVerify)
 			}
 		}
 	case strategySquash:
-		mergeErr = git.MergeSquashWithMessage(state.FullBranchName, resolvedOptions.SquashMessage, resolvedOptions.NoVerify)
+		mergeErr = repo.MergeSquashWithMessage(state.FullBranchName, resolvedOptions.SquashMessage, resolvedOptions.NoVerify)
 	case strategyMerge:
 		if resolvedOptions.MergeMessage != "" {
 			expandedMsg := util.ExpandMessagePlaceholders(resolvedOptions.MergeMessage, state.FullBranchName, state.ParentBranch)
-			mergeErr = git.MergeWithMessage(state.FullBranchName, expandedMsg, resolvedOptions.NoFastForward, resolvedOptions.NoVerify)
+			mergeErr = repo.MergeWithMessage(state.FullBranchName, expandedMsg, resolvedOptions.NoFastForward, resolvedOptions.NoVerify)
 		} else {
-			mergeErr = git.MergeWithOptions(state.FullBranchName, resolvedOptions.NoFastForward, resolvedOptions.NoVerify)
+			mergeErr = repo.MergeWithOptions(state.FullBranchName, resolvedOptions.NoFastForward, resolvedOptions.NoVerify)
 		}
 	default:
 		return &errors.GitError{Operation: fmt.Sprintf("unknown merge strategy: %s", resolvedOptions.MergeStrategy), Err: nil}
@@ -668,7 +670,7 @@ func handleMergeStep(cfg *config.Config, state *mergestate.MergeState, branchCon
 		if strings.Contains(mergeErr.Error(), "conflict") {
 			// Save state before returning conflict error
 			state.CurrentStep = stepMerge
-			if err := mergestate.SaveMergeState(state); err != nil {
+			if err := mergestate.SaveMergeState(repo, state); err != nil {
 				return &errors.GitError{Operation: "save merge state", Err: err}
 			}
 
@@ -682,7 +684,7 @@ func handleMergeStep(cfg *config.Config, state *mergestate.MergeState, branchCon
 
 	// Move to next step (tag creation)
 	state.CurrentStep = stepCreateTag
-	if err := mergestate.SaveMergeState(state); err != nil {
+	if err := mergestate.SaveMergeState(repo, state); err != nil {
 		return &errors.GitError{Operation: "save merge state", Err: err}
 	}
 
@@ -690,14 +692,11 @@ func handleMergeStep(cfg *config.Config, state *mergestate.MergeState, branchCon
 }
 
 // handleCreateTagStep handles the tag creation step
-func handleCreateTagStep(cfg *config.Config, state *mergestate.MergeState, resolvedOptions *config.ResolvedFinishOptions) error {
+func handleCreateTagStep(repo *git.Repo, cfg *config.Config, state *mergestate.MergeState, resolvedOptions *config.ResolvedFinishOptions) error {
 	if resolvedOptions.ShouldTag {
 		// Apply tag message filter for any branch type configured with tagging
 		// The filter script (filter-flow-{branchType}-finish-tag-message) decides what to do
-		gitDir, err := git.GetGitDir()
-		if err != nil {
-			return &errors.GitError{Operation: "get git directory", Err: err}
-		}
+		gitDir := repo.GitDir()
 
 		remote := cfg.Remote
 
@@ -720,21 +719,21 @@ func handleCreateTagStep(cfg *config.Config, state *mergestate.MergeState, resol
 			resolvedOptions.TagMessage = filteredMessage
 		}
 
-		if err := createTagForBranchResolved(state, resolvedOptions); err != nil {
+		if err := createTagForBranchResolved(repo, state, resolvedOptions); err != nil {
 			return err
 		}
 	}
 
 	// Move to next step
 	state.CurrentStep = stepUpdateChildren
-	if err := mergestate.SaveMergeState(state); err != nil {
+	if err := mergestate.SaveMergeState(repo, state); err != nil {
 		return &errors.GitError{Operation: "save merge state", Err: err}
 	}
 	return nil
 }
 
 // handleUpdateChildrenStep handles updating child base branches
-func handleUpdateChildrenStep(cfg *config.Config, state *mergestate.MergeState, branchConfig config.BranchConfig, resolvedOptions *config.ResolvedFinishOptions) error {
+func handleUpdateChildrenStep(repo *git.Repo, cfg *config.Config, state *mergestate.MergeState, branchConfig config.BranchConfig, resolvedOptions *config.ResolvedFinishOptions) error {
 	// Find next child branch to update
 	nextBranch := findNextBranchToUpdate(state)
 
@@ -747,21 +746,21 @@ func handleUpdateChildrenStep(cfg *config.Config, state *mergestate.MergeState, 
 		} else {
 			state.CurrentStep = stepDeleteBranch
 		}
-		if err := mergestate.SaveMergeState(state); err != nil {
+		if err := mergestate.SaveMergeState(repo, state); err != nil {
 			return &errors.GitError{Operation: "save merge state", Err: err}
 		}
 		return nil
 	}
 
 	// Update the next child branch
-	if err := updateChildBranch(cfg, nextBranch, state); err != nil {
+	if err := updateChildBranch(repo, cfg, nextBranch, state); err != nil {
 		return err
 	}
 
 	// Mark this branch as updated and clear current child
 	state.UpdatedBranches = append(state.UpdatedBranches, nextBranch)
 	state.CurrentChildBranch = "" // Clear after successful update
-	if err := mergestate.SaveMergeState(state); err != nil {
+	if err := mergestate.SaveMergeState(repo, state); err != nil {
 		return &errors.GitError{Operation: "save merge state", Err: err}
 	}
 
@@ -770,9 +769,9 @@ func handleUpdateChildrenStep(cfg *config.Config, state *mergestate.MergeState, 
 }
 
 // handleDeleteBranchStep handles branch deletion
-func handleDeleteBranchStep(cfg *config.Config, state *mergestate.MergeState, resolvedOptions *config.ResolvedFinishOptions) error {
+func handleDeleteBranchStep(repo *git.Repo, cfg *config.Config, state *mergestate.MergeState, resolvedOptions *config.ResolvedFinishOptions) error {
 	// Ensure we're on the parent branch before deletion
-	if err := git.Checkout(state.ParentBranch); err != nil {
+	if err := repo.Checkout(state.ParentBranch); err != nil {
 		return &errors.GitError{Operation: fmt.Sprintf("checkout parent branch '%s'", state.ParentBranch), Err: err}
 	}
 
@@ -780,7 +779,7 @@ func handleDeleteBranchStep(cfg *config.Config, state *mergestate.MergeState, re
 	// tags, and child updates are complete — the state is only needed for conflict
 	// recovery which is no longer possible. Clearing early ensures a failed branch
 	// deletion (e.g. remote permission error) doesn't leave stale merge state.
-	if err := mergestate.ClearMergeState(); err != nil {
+	if err := mergestate.ClearMergeState(repo); err != nil {
 		return &errors.GitError{Operation: "clear merge state", Err: err}
 	}
 
@@ -795,14 +794,14 @@ func handleDeleteBranchStep(cfg *config.Config, state *mergestate.MergeState, re
 	// Delete branches based on settings
 	// Use force delete since we've already merged the branch
 	forceDelete := true
-	if err := deleteBranchesIfNeeded(state, cfg.Remote, keepRemote, keepLocal, forceDelete); err != nil {
+	if err := deleteBranchesIfNeeded(repo, state, cfg.Remote, keepRemote, keepLocal, forceDelete); err != nil {
 		return err
 	}
 
 	// Clean up base branch configuration if branch was deleted
 	if !keepLocal {
 		configKey := fmt.Sprintf("gitflow.branch.%s.base", state.FullBranchName)
-		if err := git.UnsetConfigIfPresent(configKey); err != nil {
+		if err := repo.UnsetConfigIfPresent(configKey); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: Failed to clean up base config: %v\n", err)
 		}
 	}
@@ -810,32 +809,30 @@ func handleDeleteBranchStep(cfg *config.Config, state *mergestate.MergeState, re
 	// Push stage: runs after all local work is complete and the merge state is
 	// cleared. A missing remote is a skip (exit 0); a rejected push is a real
 	// error, leaving the completed local finish as-is.
-	if err := pushFinishedBranches(cfg, state, resolvedOptions); err != nil {
+	if err := pushFinishedBranches(repo, cfg, state, resolvedOptions); err != nil {
 		return err
 	}
 
 	fmt.Printf("Successfully finished branch '%s' and updated %d child base branches\n", state.FullBranchName, len(state.UpdatedBranches))
 
 	// Run post-hook after successful completion
-	gitDir, err := git.GetGitDir()
-	if err == nil {
-		hookCtx := hooks.HookContext{
-			BranchType: state.BranchType,
-			BranchName: state.BranchName,
-			FullBranch: state.FullBranchName,
-			BaseBranch: state.ParentBranch,
-			Origin:     cfg.Remote,
-			ExitCode:   0, // Success
-		}
-		// Set version for branches configured with tagging
-		if resolvedOptions.ShouldTag {
-			hookCtx.Version = state.BranchName
-		}
+	gitDir := repo.GitDir()
+	hookCtx := hooks.HookContext{
+		BranchType: state.BranchType,
+		BranchName: state.BranchName,
+		FullBranch: state.FullBranchName,
+		BaseBranch: state.ParentBranch,
+		Origin:     cfg.Remote,
+		ExitCode:   0, // Success
+	}
+	// Set version for branches configured with tagging
+	if resolvedOptions.ShouldTag {
+		hookCtx.Version = state.BranchName
+	}
 
-		result := hooks.RunPostHook(gitDir, state.BranchType, hooks.HookActionFinish, hookCtx)
-		if result.Executed && result.Output != "" {
-			fmt.Print(result.Output)
-		}
+	result := hooks.RunPostHook(gitDir, state.BranchType, hooks.HookActionFinish, hookCtx)
+	if result.Executed && result.Output != "" {
+		fmt.Print(result.Output)
 	}
 
 	return nil
@@ -852,7 +849,7 @@ func handleDeleteBranchStep(cfg *config.Config, state *mergestate.MergeState, re
 //   - A push failure (e.g. non-fast-forward rejection): returns the error
 //     verbatim, which propagates to a non-zero exit. The completed local finish
 //     is left as-is (nothing is rolled back).
-func pushFinishedBranches(cfg *config.Config, state *mergestate.MergeState, resolvedOptions *config.ResolvedFinishOptions) error {
+func pushFinishedBranches(repo *git.Repo, cfg *config.Config, state *mergestate.MergeState, resolvedOptions *config.ResolvedFinishOptions) error {
 	// Only push the tag if one was actually created.
 	tagToPush := resolvedOptions.PushTag && resolvedOptions.ShouldTag
 
@@ -864,7 +861,7 @@ func pushFinishedBranches(cfg *config.Config, state *mergestate.MergeState, reso
 	remote := cfg.Remote
 
 	// A missing remote is a skip-with-note, not an error.
-	if !git.RemoteExists(remote) {
+	if !repo.RemoteExists(remote) {
 		fmt.Printf("Note: Remote '%s' not configured, skipping push\n", remote)
 		return nil
 	}
@@ -882,7 +879,7 @@ func pushFinishedBranches(cfg *config.Config, state *mergestate.MergeState, reso
 		}
 
 		for _, branch := range branches {
-			if err := git.PushRef(remote, branch); err != nil {
+			if err := repo.PushRef(remote, branch); err != nil {
 				return &errors.GitError{Operation: fmt.Sprintf("push branch '%s'", branch), Err: err}
 			}
 			fmt.Printf("  %s -> %s/%s\n", branch, remote, branch)
@@ -890,7 +887,7 @@ func pushFinishedBranches(cfg *config.Config, state *mergestate.MergeState, reso
 	}
 
 	if tagToPush {
-		if err := git.PushTag(remote, resolvedOptions.TagName); err != nil {
+		if err := repo.PushTag(remote, resolvedOptions.TagName); err != nil {
 			return &errors.GitError{Operation: fmt.Sprintf("push tag '%s'", resolvedOptions.TagName), Err: err}
 		}
 		fmt.Printf("  %s (tag) -> %s\n", resolvedOptions.TagName, remote)
@@ -902,14 +899,14 @@ func pushFinishedBranches(cfg *config.Config, state *mergestate.MergeState, reso
 // handleIntegrateDoneStep terminates an integrate operation. Unlike finish, it
 // never deletes the integrated branch (base branches are permanent): it checks
 // out the parent branch and clears the merge state.
-func handleIntegrateDoneStep(state *mergestate.MergeState) error {
+func handleIntegrateDoneStep(repo *git.Repo, state *mergestate.MergeState) error {
 	// Ensure we end up on the parent branch.
-	if err := git.Checkout(state.ParentBranch); err != nil {
+	if err := repo.Checkout(state.ParentBranch); err != nil {
 		return &errors.GitError{Operation: fmt.Sprintf("checkout parent branch '%s'", state.ParentBranch), Err: err}
 	}
 
 	// Clear the merge state: all merges, tags, and child updates are complete.
-	if err := mergestate.ClearMergeState(); err != nil {
+	if err := mergestate.ClearMergeState(repo); err != nil {
 		return &errors.GitError{Operation: "clear merge state", Err: err}
 	}
 
@@ -922,16 +919,16 @@ func handleIntegrateDoneStep(state *mergestate.MergeState) error {
 // =============================================================================
 
 // resolveBranchName tries to find the branch name with and without prefix
-func resolveBranchName(name string, branchConfig config.BranchConfig) (string, error) {
+func resolveBranchName(repo *git.Repo, name string, branchConfig config.BranchConfig) (string, error) {
 	// Try name as-is first
-	if err := git.BranchExists(name); err == nil {
+	if err := repo.BranchExists(name); err == nil {
 		return name, nil
 	}
 
 	// If not found as-is, try with prefix
 	if !strings.HasPrefix(name, branchConfig.Prefix) {
 		fullName := branchConfig.Prefix + name
-		if err := git.BranchExists(fullName); err == nil {
+		if err := repo.BranchExists(fullName); err == nil {
 			return fullName, nil
 		}
 	}
@@ -940,14 +937,21 @@ func resolveBranchName(name string, branchConfig config.BranchConfig) (string, e
 }
 
 // createTagForBranchResolved creates a tag using resolved options
-func createTagForBranchResolved(state *mergestate.MergeState, options *config.ResolvedFinishOptions) error {
+func createTagForBranchResolved(repo *git.Repo, state *mergestate.MergeState, options *config.ResolvedFinishOptions) error {
 	// Determine if we should use message file
 	useMessageFile := options.MessageFile != ""
+
+	// Normalize a relative message-file path against the invocation directory.
+	// The tag is created via `git tag -F` running in the work tree, so without
+	// this a relative path (from --messagefile or gitflow.<type>.finish.messagefile)
+	// would resolve against the work-tree root instead of the directory git-flow
+	// was invoked from — the invocation-directory-relative meaning the user expects.
+	messageFile := normalizeInvocationPath(options.MessageFile)
 
 	// Create the tag using the git module
 	gitTagOptions := &git.TagOptions{
 		Message:     options.TagMessage,
-		MessageFile: options.MessageFile,
+		MessageFile: messageFile,
 		Sign:        options.ShouldSign,
 		SigningKey:  options.SigningKey,
 	}
@@ -959,7 +963,7 @@ func createTagForBranchResolved(state *mergestate.MergeState, options *config.Re
 		gitTagOptions.MessageFile = "" // Clear file since we're using message
 	}
 
-	if err := git.CreateTag(options.TagName, gitTagOptions); err != nil {
+	if err := repo.CreateTag(options.TagName, gitTagOptions); err != nil {
 		return &errors.GitError{Operation: fmt.Sprintf("create tag '%s'", options.TagName), Err: err}
 	}
 	fmt.Printf("Created tag '%s'\n", options.TagName)
@@ -984,12 +988,12 @@ func findNextBranchToUpdate(state *mergestate.MergeState) string {
 }
 
 // updateChildBranch updates a single child branch
-func updateChildBranch(cfg *config.Config, branchName string, state *mergestate.MergeState) error {
+func updateChildBranch(repo *git.Repo, cfg *config.Config, branchName string, state *mergestate.MergeState) error {
 	fmt.Printf("Updating child base branch '%s' from '%s'...\n", branchName, state.ParentBranch)
 
 	// Track which child branch we're updating
 	state.CurrentChildBranch = branchName
-	if err := mergestate.SaveMergeState(state); err != nil {
+	if err := mergestate.SaveMergeState(repo, state); err != nil {
 		return &errors.GitError{Operation: "save merge state", Err: err}
 	}
 
@@ -1016,7 +1020,7 @@ func updateChildBranch(cfg *config.Config, branchName string, state *mergestate.
 	}
 
 	// Use the shared update logic with the determined strategy and custom message if provided
-	err := update.UpdateBranchFromParentWithMessage(branchName, state.ParentBranch, strategy, updateMsg, true, state)
+	err := update.UpdateBranchFromParentWithMessage(repo, branchName, state.ParentBranch, strategy, updateMsg, true, state)
 	if err != nil {
 		if _, ok := err.(*errors.UnresolvedConflictsError); ok {
 			// Get resolved options for the message (might be nil, but generateConflictMessage handles that)
@@ -1038,13 +1042,13 @@ func updateChildBranch(cfg *config.Config, branchName string, state *mergestate.
 }
 
 // deleteBranchesIfNeeded deletes branches based on retention settings
-func deleteBranchesIfNeeded(state *mergestate.MergeState, remote string, keepRemote, keepLocal, forceDelete bool) error {
+func deleteBranchesIfNeeded(repo *git.Repo, state *mergestate.MergeState, remote string, keepRemote, keepLocal, forceDelete bool) error {
 	// Delete remote branch if not keeping it and if remote branch exists
 	if !keepRemote {
 		// Only attempt to delete if the remote branch actually exists
-		if git.RemoteBranchExists(remote, state.FullBranchName) {
+		if repo.RemoteBranchExists(remote, state.FullBranchName) {
 			remoteBranch := fmt.Sprintf("%s/%s", remote, state.FullBranchName)
-			if err := git.DeleteRemoteBranch(remote, state.FullBranchName); err != nil {
+			if err := repo.DeleteRemoteBranch(remote, state.FullBranchName); err != nil {
 				return &errors.GitError{Operation: fmt.Sprintf("delete remote branch '%s'", remoteBranch), Err: err}
 			}
 		}
@@ -1052,7 +1056,7 @@ func deleteBranchesIfNeeded(state *mergestate.MergeState, remote string, keepRem
 
 	// Delete local branch if not keeping it
 	if !keepLocal {
-		if err := git.DeleteBranch(state.FullBranchName, forceDelete); err != nil {
+		if err := repo.DeleteBranch(state.FullBranchName, forceDelete); err != nil {
 			return &errors.GitError{Operation: fmt.Sprintf("delete branch '%s'", state.FullBranchName), Err: err}
 		}
 	}

--- a/cmd/finish.go
+++ b/cmd/finish.go
@@ -85,11 +85,7 @@ const (
 
 // FinishCommand is the implementation of the finish command for topic branches
 func FinishCommand(branchType string, name string, continueOp bool, abortOp bool, force bool, tagOptions *config.TagOptions, retentionOptions *config.BranchRetentionOptions, mergeOptions *config.MergeStrategyOptions, fetch *bool, noVerify *bool, push *bool, pushTag *bool) {
-	repo, err := openRepo()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-	}
+	repo := mustOpenRepo()
 	if err := executeFinish(repo, branchType, name, continueOp, abortOp, force, tagOptions, retentionOptions, mergeOptions, fetch, noVerify, push, pushTag); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -99,7 +99,12 @@ func initFlow(useDefaults, createBranches, force bool, preset string, custom boo
 		scope = git.ConfigScopeSystem
 	case fileScope != "":
 		scope = git.ConfigScopeFile
-		scopeFile = fileScope
+		// Normalize a relative --file path against the invocation directory
+		// BEFORE the parent-directory existence check, so a nested relative path
+		// (e.g. cfgdir/myconfig) resolves against the directory git-flow was run
+		// from, matching where the config is later written (git config --file runs
+		// in the invocation directory), not the work-tree root.
+		scopeFile = normalizeInvocationPath(fileScope)
 		// Validate parent directory exists
 		dir := filepath.Dir(scopeFile)
 		if _, err := os.Stat(dir); os.IsNotExist(err) {
@@ -111,8 +116,10 @@ func initFlow(useDefaults, createBranches, force bool, preset string, custom boo
 		scope = git.ConfigScopeDefault // no flag = merged read, local write
 	}
 
-	// Check if we're in a git repo
-	if !git.IsGitRepo() {
+	// Open a handle for the invocation directory. A failure here means we are not
+	// inside a git work tree — the same condition the old git.IsGitRepo() guarded.
+	repo, err := openRepo()
+	if err != nil {
 		return &errors.GitError{Operation: "check if git repository", Err: fmt.Errorf("not a git repository. Please run 'git init' first")}
 	}
 
@@ -177,10 +184,10 @@ func initFlow(useDefaults, createBranches, force bool, preset string, custom boo
 	hasConfigFlags := mainBranch != "" || developBranch != "" || featurePrefix != "" || bugfixPrefix != "" || releasePrefix != "" || hotfixPrefix != "" || supportPrefix != "" || tagPrefix != ""
 
 	// Check if git-flow-avh config exists and no explicit options are provided
-	if config.CheckGitFlowAVHConfig() && preset == "" && !custom && !useDefaults && !hasConfigFlags {
+	if config.CheckGitFlowAVHConfig(repo) && preset == "" && !custom && !useDefaults && !hasConfigFlags {
 		fmt.Println("Found existing git-flow-avh configuration, importing...")
 		var err error
-		cfg, err = config.ImportGitFlowAVHConfig()
+		cfg, err = config.ImportGitFlowAVHConfig(repo)
 		if err != nil {
 			return &errors.GitError{Operation: "import git-flow-avh configuration", Err: err}
 		}
@@ -233,12 +240,12 @@ func initFlow(useDefaults, createBranches, force bool, preset string, custom boo
 	// configured — otherwise `git commit --allow-empty` fails with exit 128
 	// after config/marker have already been written (see issue #131).
 	if createBranches {
-		hasCommits, err := git.HasCommits()
+		hasCommits, err := repo.HasCommits()
 		if err != nil {
 			return &errors.GitError{Operation: "check repository commits", Err: err}
 		}
 		if !hasCommits {
-			ok, err := git.HasUserIdentity()
+			ok, err := repo.HasUserIdentity()
 			if err != nil {
 				return &errors.GitError{Operation: "check git user identity", Err: err}
 			}
@@ -258,7 +265,7 @@ func initFlow(useDefaults, createBranches, force bool, preset string, custom boo
 
 	// Create branches if requested
 	if createBranches {
-		if err := createGitFlowBranches(cfg); err != nil {
+		if err := createGitFlowBranches(repo, cfg); err != nil {
 			return &errors.GitError{Operation: "create branches", Err: err}
 		}
 	}
@@ -268,9 +275,9 @@ func initFlow(useDefaults, createBranches, force bool, preset string, custom boo
 }
 
 // createGitFlowBranches creates the base branches if they don't exist
-func createGitFlowBranches(cfg *config.Config) error {
+func createGitFlowBranches(repo *git.Repo, cfg *config.Config) error {
 	// Check if we have any commits
-	hasCommits, err := git.HasCommits()
+	hasCommits, err := repo.HasCommits()
 	if err != nil {
 		return fmt.Errorf("failed to check if repository has commits: %w", err)
 	}
@@ -278,7 +285,7 @@ func createGitFlowBranches(cfg *config.Config) error {
 	// Get current branch if we have commits
 	var currentBranch string
 	if hasCommits {
-		currentBranch, err = git.GetCurrentBranch()
+		currentBranch, err = repo.GetCurrentBranch()
 		if err != nil {
 			return fmt.Errorf("failed to get current branch: %w", err)
 		}
@@ -291,7 +298,7 @@ func createGitFlowBranches(cfg *config.Config) error {
 	}
 	var toCreate []branchToCreate
 	for name, branch := range cfg.Branches {
-		if branch.Type == string(config.BranchTypeBase) && git.BranchExists(name) != nil {
+		if branch.Type == string(config.BranchTypeBase) && repo.BranchExists(name) != nil {
 			toCreate = append(toCreate, branchToCreate{name: name, parent: branch.Parent})
 		}
 	}
@@ -306,7 +313,7 @@ func createGitFlowBranches(cfg *config.Config) error {
 				continue
 			}
 			// Add if: no parent, parent already exists in git, or parent already in sorted list
-			parentReady := b.parent == "" || git.BranchExists(b.parent) == nil || added[b.parent]
+			parentReady := b.parent == "" || repo.BranchExists(b.parent) == nil || added[b.parent]
 			if parentReady {
 				sorted = append(sorted, b)
 				added[b.name] = true
@@ -320,7 +327,7 @@ func createGitFlowBranches(cfg *config.Config) error {
 
 	// Create branches in dependency order
 	for _, b := range sorted {
-		err := git.CreateBranch(b.name, b.parent)
+		err := repo.CreateBranch(b.name, b.parent)
 		if err != nil {
 			return &errors.GitError{Operation: fmt.Sprintf("create base branch '%s'", b.name), Err: err}
 		}
@@ -337,7 +344,7 @@ func createGitFlowBranches(cfg *config.Config) error {
 			}
 		}
 		if !branchStillExists {
-			err = git.Checkout(currentBranch)
+			err = repo.Checkout(currentBranch)
 			if err != nil {
 				return fmt.Errorf("failed to checkout original branch '%s': %w", currentBranch, err)
 			}

--- a/cmd/integrate.go
+++ b/cmd/integrate.go
@@ -34,7 +34,12 @@ import (
 // IntegrateCommand is the public entry point for the integrate command. It maps
 // git-flow errors to their exit codes and exits non-zero on failure.
 func IntegrateCommand(name string, continueOp bool, abortOp bool, tagOptions *config.TagOptions, mergeOptions *config.MergeStrategyOptions, fetch *bool) {
-	if err := executeIntegrate(name, continueOp, abortOp, tagOptions, mergeOptions, fetch); err != nil {
+	repo, err := openRepo()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+	}
+	if err := executeIntegrate(repo, name, continueOp, abortOp, tagOptions, mergeOptions, fetch); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -47,9 +52,9 @@ func IntegrateCommand(name string, continueOp bool, abortOp bool, tagOptions *co
 }
 
 // executeIntegrate performs the integrate logic and returns any error.
-func executeIntegrate(name string, continueOp bool, abortOp bool, tagOptions *config.TagOptions, mergeOptions *config.MergeStrategyOptions, fetch *bool) error {
+func executeIntegrate(repo *git.Repo, name string, continueOp bool, abortOp bool, tagOptions *config.TagOptions, mergeOptions *config.MergeStrategyOptions, fetch *bool) error {
 	// Validate that git-flow is initialized.
-	initialized, err := config.IsInitialized()
+	initialized, err := config.IsInitialized(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
 	}
@@ -57,7 +62,7 @@ func executeIntegrate(name string, continueOp bool, abortOp bool, tagOptions *co
 		return &errors.NotInitializedError{}
 	}
 
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
@@ -67,13 +72,13 @@ func executeIntegrate(name string, continueOp bool, abortOp bool, tagOptions *co
 	// any dispatch. The shared guard reads raw state and checks git's real
 	// in-progress markers, since an update persists state IsMergeInProgress might
 	// otherwise treat as stale and clear.
-	if err := refuseIfForeignOperation(cfg, "integrate"); err != nil {
+	if err := refuseIfForeignOperation(repo, cfg, "integrate"); err != nil {
 		return err
 	}
 
 	// Merge-in-progress dispatch for integrate's own state.
-	if mergestate.IsMergeInProgress() {
-		state, err := mergestate.LoadMergeState()
+	if mergestate.IsMergeInProgress(repo) {
+		state, err := mergestate.LoadMergeState(repo)
 		if err != nil {
 			return &errors.GitError{Operation: "load merge state", Err: err}
 		}
@@ -82,7 +87,7 @@ func executeIntegrate(name string, continueOp bool, abortOp bool, tagOptions *co
 			return &errors.MergeInProgressError{Action: state.Action, BranchName: state.FullBranchName, BranchType: topicTypeOrEmpty(cfg, state.BranchType)}
 		}
 		if abortOp {
-			return handleAbort(state)
+			return handleAbort(repo, state)
 		}
 		if continueOp {
 			resolved := config.ResolveIntegrateOptions(cfg, state.BranchName, tagOptions, mergeOptions, fetch)
@@ -95,7 +100,7 @@ func executeIntegrate(name string, continueOp bool, abortOp bool, tagOptions *co
 			resolved.ShouldSign = state.ShouldSign
 			resolved.SigningKey = state.SigningKey
 			branchConfig := cfg.Branches[state.BranchType]
-			return handleContinue(cfg, state, branchConfig, resolved, mergeOptions)
+			return handleContinue(repo, cfg, state, branchConfig, resolved, mergeOptions)
 		}
 		return &errors.MergeInProgressError{Action: "integrate", BranchName: state.FullBranchName}
 	}
@@ -111,7 +116,7 @@ func executeIntegrate(name string, continueOp bool, abortOp bool, tagOptions *co
 
 	// Resolve the source base branch: explicit argument or the current branch.
 	if name == "" {
-		currentBranch, err := git.GetCurrentBranch()
+		currentBranch, err := repo.GetCurrentBranch()
 		if err != nil {
 			return &errors.GitError{Operation: "get current branch", Err: err}
 		}
@@ -122,7 +127,7 @@ func executeIntegrate(name string, continueOp bool, abortOp bool, tagOptions *co
 	if !found {
 		// A real branch that is not a configured base branch is a topic/other
 		// branch; a name that matches no branch at all is simply not found.
-		if git.BranchExists(name) == nil {
+		if repo.BranchExists(name) == nil {
 			return &errors.NotBaseBranchError{BranchName: name}
 		}
 		return &errors.BranchNotFoundError{BranchName: name}
@@ -147,12 +152,12 @@ func executeIntegrate(name string, continueOp bool, abortOp bool, tagOptions *co
 	// The configured base branch must actually exist as a git branch. A
 	// branch that is configured but has been deleted must error here, before
 	// any fetch/state/checkout mutation, mirroring finish's BranchExists gate.
-	if err := git.BranchExists(name); err != nil {
+	if err := repo.BranchExists(name); err != nil {
 		return &errors.BranchNotFoundError{BranchName: name}
 	}
 
 	parent := branchConfig.Parent
-	if err := git.BranchExists(parent); err != nil {
+	if err := repo.BranchExists(parent); err != nil {
 		return &errors.BranchNotFoundError{BranchName: parent}
 	}
 
@@ -171,15 +176,15 @@ func executeIntegrate(name string, continueOp bool, abortOp bool, tagOptions *co
 	// currently checked out. Fetch failures stay non-fatal (matching finish), but
 	// we must not claim "Fetch completed" when the parent fast-forward failed —
 	// that would silently integrate stale history.
-	if resolved.ShouldFetch && git.RemoteExists(cfg.Remote) {
+	if resolved.ShouldFetch && repo.RemoteExists(cfg.Remote) {
 		fmt.Printf("Fetching from remote '%s'...\n", cfg.Remote)
 		parentFetched := true
-		if err := git.FetchBranch(cfg.Remote, fmt.Sprintf("%s:%s", parent, parent)); err != nil {
+		if err := repo.FetchBranch(cfg.Remote, fmt.Sprintf("%s:%s", parent, parent)); err != nil {
 			parentFetched = false
 			fmt.Printf("Warning: could not fetch parent branch '%s': %v\n", parent, err)
 			fmt.Printf("Warning: integrating against the local '%s', which may be behind the remote\n", parent)
 		}
-		if err := git.FetchBranch(cfg.Remote, name); err != nil {
+		if err := repo.FetchBranch(cfg.Remote, name); err != nil {
 			fmt.Printf("Note: could not fetch branch '%s': %v\n", name, err)
 		}
 		if parentFetched {
@@ -225,13 +230,13 @@ func executeIntegrate(name string, continueOp bool, abortOp bool, tagOptions *co
 		ShouldSign:     resolved.ShouldSign,
 		SigningKey:     resolved.SigningKey,
 	}
-	if err := mergestate.SaveMergeState(state); err != nil {
+	if err := mergestate.SaveMergeState(repo, state); err != nil {
 		return &errors.GitError{Operation: "save merge state", Err: err}
 	}
 
 	// Drive the shared state machine: merge -> create_tag -> update_children ->
 	// terminate. No delete step.
-	return executeSteps(cfg, state, branchConfig, resolved)
+	return executeSteps(repo, cfg, state, branchConfig, resolved)
 }
 
 // addIntegrateFlags registers the integrate command's flags. It mirrors

--- a/cmd/integrate.go
+++ b/cmd/integrate.go
@@ -34,11 +34,7 @@ import (
 // IntegrateCommand is the public entry point for the integrate command. It maps
 // git-flow errors to their exit codes and exits non-zero on failure.
 func IntegrateCommand(name string, continueOp bool, abortOp bool, tagOptions *config.TagOptions, mergeOptions *config.MergeStrategyOptions, fetch *bool) {
-	repo, err := openRepo()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-	}
+	repo := mustOpenRepo()
 	if err := executeIntegrate(repo, name, continueOp, abortOp, tagOptions, mergeOptions, fetch); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -12,7 +12,12 @@ import (
 
 // ListCommand is the implementation of the list command for topic branches
 func ListCommand(branchType string) {
-	if err := list(branchType); err != nil {
+	repo, err := openRepo()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+	}
+	if err := list(repo, branchType); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -25,9 +30,9 @@ func ListCommand(branchType string) {
 }
 
 // list performs the actual branch listing logic and returns any errors
-func list(branchType string) error {
+func list(repo *git.Repo, branchType string) error {
 	// Validate that git-flow is initialized
-	initialized, err := config.IsInitialized()
+	initialized, err := config.IsInitialized(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
 	}
@@ -36,7 +41,7 @@ func list(branchType string) error {
 	}
 
 	// Get configuration
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
@@ -51,7 +56,7 @@ func list(branchType string) error {
 	prefix := branchConfig.Prefix
 
 	// Get all branches
-	branches, err := git.ListBranches()
+	branches, err := repo.ListBranches()
 	if err != nil {
 		return &errors.GitError{Operation: "list branches", Err: err}
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -12,11 +12,7 @@ import (
 
 // ListCommand is the implementation of the list command for topic branches
 func ListCommand(branchType string) {
-	repo, err := openRepo()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-	}
+	repo := mustOpenRepo()
 	if err := list(repo, branchType); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {

--- a/cmd/overview.go
+++ b/cmd/overview.go
@@ -25,7 +25,12 @@ This command displays the current git-flow configuration and lists all active to
 
 // OverviewCommand is the implementation of the overview command
 func OverviewCommand() {
-	if err := overview(); err != nil {
+	repo, err := openRepo()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+	}
+	if err := overview(repo); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -38,9 +43,9 @@ func OverviewCommand() {
 }
 
 // overview performs the actual overview logic and returns any errors
-func overview() error {
+func overview(repo *git.Repo) error {
 	// Validate that git-flow is initialized
-	initialized, err := config.IsInitialized()
+	initialized, err := config.IsInitialized(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
 	}
@@ -49,7 +54,7 @@ func overview() error {
 	}
 
 	// Get configuration
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
@@ -128,13 +133,13 @@ func overview() error {
 	}
 
 	// Get all branches for active topic branches section
-	branches, err := git.ListBranches()
+	branches, err := repo.ListBranches()
 	if err != nil {
 		return &errors.GitError{Operation: "list branches", Err: err}
 	}
 
 	// Get current branch
-	currentBranch, err := git.GetCurrentBranch()
+	currentBranch, err := repo.GetCurrentBranch()
 	if err != nil {
 		return &errors.GitError{Operation: "get current branch", Err: err}
 	}

--- a/cmd/overview.go
+++ b/cmd/overview.go
@@ -25,11 +25,7 @@ This command displays the current git-flow configuration and lists all active to
 
 // OverviewCommand is the implementation of the overview command
 func OverviewCommand() {
-	repo, err := openRepo()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-	}
+	repo := mustOpenRepo()
 	if err := overview(repo); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {

--- a/cmd/preflight.go
+++ b/cmd/preflight.go
@@ -67,7 +67,7 @@ type preflightOptions struct {
 // sync-checked with a laxer rule than the topic — behind/diverged abort, ahead and equal proceed
 // (#99). When opts.ffParent is set instead (delete) and the parent is the current branch, it is
 // fast-forwarded from its remote (#88). The two are mutually exclusive.
-func runFetchSyncPreflight(cfg *config.Config, branchType, remote, topicBranch, shortName, parentBranch string, shouldFetch, force bool, opts preflightOptions) error {
+func runFetchSyncPreflight(repo *git.Repo, cfg *config.Config, branchType, remote, topicBranch, shortName, parentBranch string, shouldFetch, force bool, opts preflightOptions) error {
 	// topicRefFound tracks whether the topic still has a remote ref to compare against. It stays
 	// true when the fetch is skipped (we then rely on existing tracking data).
 	topicRefFound := true
@@ -77,7 +77,7 @@ func runFetchSyncPreflight(cfg *config.Config, branchType, remote, topicBranch, 
 	// compare against. It stays true when the fetch is skipped.
 	parentRefFound := true
 
-	if shouldFetch && git.RemoteExists(remote) {
+	if shouldFetch && repo.RemoteExists(remote) {
 		fmt.Printf("Fetching from remote '%s'...\n", remote)
 
 		// Fetch the parent best-effort. When the parent sync check is enabled (finish), a benign
@@ -87,13 +87,13 @@ func runFetchSyncPreflight(cfg *config.Config, branchType, remote, topicBranch, 
 		// below. Skip entirely when the branch type has no configured parent, so we never issue
 		// `git fetch <remote> ""` or emit a spurious note.
 		if parentBranch != "" {
-			if err := git.FetchBranch(remote, parentBranch); err != nil {
+			if err := repo.FetchBranch(remote, parentBranch); err != nil {
 				if opts.parentSyncCheck && goerrors.Is(err, git.ErrRemoteRefNotFound) {
 					// The parent sync check is enabled and the remote parent branch is gone; prune the
 					// stale tracking ref best-effort and skip the parent sync check against it.
 					fmt.Printf("Note: Remote branch for base '%s' not found; skipping parent sync check\n", parentBranch)
 					parentRefFound = false
-					if derr := git.DeleteRemoteTrackingRef(remote, parentBranch); derr != nil {
+					if derr := repo.DeleteRemoteTrackingRef(remote, parentBranch); derr != nil {
 						fmt.Printf("Note: Could not prune stale tracking ref for '%s': %v\n", parentBranch, derr)
 					}
 				} else {
@@ -103,9 +103,9 @@ func runFetchSyncPreflight(cfg *config.Config, branchType, remote, topicBranch, 
 				// #88: fast-forward the local parent to its just-fetched remote so that a branch merged
 				// remotely is seen as merged by `git branch -d`. `git merge --ff-only` acts on HEAD, so
 				// only fast-forward when the parent is checked out; otherwise leave HEAD untouched.
-				if current, cerr := git.GetCurrentBranch(); cerr == nil && current == parentBranch {
+				if current, cerr := repo.GetCurrentBranch(); cerr == nil && current == parentBranch {
 					remoteParent := fmt.Sprintf("%s/%s", remote, parentBranch)
-					if ferr := git.MergeFFOnly(remoteParent); ferr != nil {
+					if ferr := repo.MergeFFOnly(remoteParent); ferr != nil {
 						fmt.Printf("Note: Could not fast-forward '%s': %v\n", parentBranch, ferr)
 					}
 				}
@@ -113,7 +113,7 @@ func runFetchSyncPreflight(cfg *config.Config, branchType, remote, topicBranch, 
 		}
 
 		// Fetch the topic, distinguishing a benign missing ref from a fatal transport failure.
-		if err := git.FetchBranch(remote, topicBranch); err != nil {
+		if err := repo.FetchBranch(remote, topicBranch); err != nil {
 			if goerrors.Is(err, git.ErrRemoteRefNotFound) {
 				// The remote branch is gone (or was never pushed). Prune the stale tracking ref
 				// so later steps do not treat it as an existing remote branch, and skip the
@@ -122,7 +122,7 @@ func runFetchSyncPreflight(cfg *config.Config, branchType, remote, topicBranch, 
 				topicRefFound = false
 				// Best-effort cleanup: the ref may already be absent, so a failure here is a
 				// note, not a reason to abort.
-				if derr := git.DeleteRemoteTrackingRef(remote, topicBranch); derr != nil {
+				if derr := repo.DeleteRemoteTrackingRef(remote, topicBranch); derr != nil {
 					fmt.Printf("Note: Could not prune stale tracking ref for '%s': %v\n", topicBranch, derr)
 				}
 			} else if opts.fetchFailureNonFatal {
@@ -140,8 +140,8 @@ func runFetchSyncPreflight(cfg *config.Config, branchType, remote, topicBranch, 
 	}
 
 	// Sync-check the topic only when it still has a remote ref and a tracking branch.
-	if !force && topicRefFound && git.HasTrackingBranch(topicBranch) {
-		status, commitCount, err := git.CompareBranchWithRemote(topicBranch)
+	if !force && topicRefFound && repo.HasTrackingBranch(topicBranch) {
+		status, commitCount, err := repo.CompareBranchWithRemote(topicBranch)
 		if err != nil {
 			// HasTrackingBranch already confirmed a tracking branch, and when fetching, the topic
 			// fetch succeeded — so a compare failure here is unexpected (e.g. a corrupt/dangling
@@ -168,7 +168,7 @@ func runFetchSyncPreflight(cfg *config.Config, branchType, remote, topicBranch, 
 			}
 		}
 		if abort {
-			trackingBranch, terr := git.GetTrackingBranch(topicBranch)
+			trackingBranch, terr := repo.GetTrackingBranch(topicBranch)
 			if terr != nil {
 				trackingBranch = "remote tracking branch"
 			}
@@ -190,8 +190,8 @@ func runFetchSyncPreflight(cfg *config.Config, branchType, remote, topicBranch, 
 	// way as the topic check: only when not forced, the parent still has a remote ref, and it has a
 	// tracking branch. The parent invariant is laxer than the topic's — behind/diverged abort
 	// (merging onto a stale base), but ahead proceeds (normal right after an unpushed finish).
-	if !force && opts.parentSyncCheck && parentBranch != "" && parentRefFound && git.HasTrackingBranch(parentBranch) {
-		status, commitCount, err := git.CompareBranchWithRemote(parentBranch)
+	if !force && opts.parentSyncCheck && parentBranch != "" && parentRefFound && repo.HasTrackingBranch(parentBranch) {
+		status, commitCount, err := repo.CompareBranchWithRemote(parentBranch)
 		if err != nil {
 			// As with the topic block, fail closed rather than merge onto an undetermined base.
 			return &errors.GitError{
@@ -201,7 +201,7 @@ func runFetchSyncPreflight(cfg *config.Config, branchType, remote, topicBranch, 
 		}
 
 		if status == git.SyncStatusBehind || status == git.SyncStatusDiverged {
-			trackingBranch, terr := git.GetTrackingBranch(parentBranch)
+			trackingBranch, terr := repo.GetTrackingBranch(parentBranch)
 			if terr != nil {
 				trackingBranch = "remote tracking branch"
 			}

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -16,7 +16,12 @@ import (
 // pushOptions are CLI-provided push options to transmit to the server.
 // noPushOption suppresses all push options (both CLI and config defaults).
 func PublishCommand(branchType string, name string, pushOptions []string, noPushOption bool) {
-	if err := publish(branchType, name, pushOptions, noPushOption); err != nil {
+	repo, err := openRepo()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+	}
+	if err := publish(repo, branchType, name, pushOptions, noPushOption); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -29,9 +34,9 @@ func PublishCommand(branchType string, name string, pushOptions []string, noPush
 }
 
 // publish performs the actual publish logic and returns any errors
-func publish(branchType string, name string, cliPushOptions []string, noPushOption bool) error {
+func publish(repo *git.Repo, branchType string, name string, cliPushOptions []string, noPushOption bool) error {
 	// Validate that git-flow is initialized
-	initialized, err := config.IsInitialized()
+	initialized, err := config.IsInitialized(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
 	}
@@ -40,7 +45,7 @@ func publish(branchType string, name string, cliPushOptions []string, noPushOpti
 	}
 
 	// Get configuration
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
@@ -55,7 +60,7 @@ func publish(branchType string, name string, cliPushOptions []string, noPushOpti
 	var fullBranchName string
 	var shortName string
 	if name == "" {
-		currentBranch, err := git.GetCurrentBranch()
+		currentBranch, err := repo.GetCurrentBranch()
 		if err != nil {
 			return &errors.GitError{Operation: "get current branch", Err: err}
 		}
@@ -84,7 +89,7 @@ func publish(branchType string, name string, cliPushOptions []string, noPushOpti
 	}
 
 	// Check if branch exists locally
-	if err := git.BranchExists(fullBranchName); err != nil {
+	if err := repo.BranchExists(fullBranchName); err != nil {
 		return &errors.LocalBranchNotFoundError{BranchName: fullBranchName}
 	}
 
@@ -92,15 +97,12 @@ func publish(branchType string, name string, cliPushOptions []string, noPushOpti
 	remote := cfg.Remote
 
 	// Validate remote exists
-	if !git.RemoteExists(remote) {
+	if !repo.RemoteExists(remote) {
 		return &errors.RemoteNotConfiguredError{Remote: remote, Operation: "publish branch"}
 	}
 
 	// Get git directory for hooks
-	gitDir, err := git.GetGitDir()
-	if err != nil {
-		return &errors.GitError{Operation: "get git directory", Err: err}
-	}
+	gitDir := repo.GitDir()
 
 	// Build hook context
 	hookCtx := hooks.HookContext{
@@ -119,11 +121,11 @@ func publish(branchType string, name string, cliPushOptions []string, noPushOpti
 	// Layer 2: Git config (gitflow.<branchType>.publish.push-option)
 	// Layer 3: CLI flags add to config defaults
 	// --no-push-option suppresses all options
-	pushOptions := resolvePushOptions(cfg, branchType, cliPushOptions, noPushOption)
+	pushOptions := resolvePushOptions(repo, cfg, branchType, cliPushOptions, noPushOption)
 
 	// Run publish operation wrapped with hooks
 	return hooks.WithHooks(gitDir, branchType, hooks.HookActionPublish, hookCtx, func() error {
-		return executePublish(fullBranchName, shortName, branchType, remote, pushOptions)
+		return executePublish(repo, fullBranchName, shortName, branchType, remote, pushOptions)
 	})
 }
 
@@ -132,7 +134,7 @@ func publish(branchType string, name string, cliPushOptions []string, noPushOpti
 // - Layer 2: Git config (gitflow.<branchType>.publish.push-option)
 // - Layer 3: CLI flags add to config defaults
 // If noPushOption is true, all push options are suppressed.
-func resolvePushOptions(cfg *config.Config, branchType string, cliPushOptions []string, noPushOption bool) []string {
+func resolvePushOptions(repo *git.Repo, cfg *config.Config, branchType string, cliPushOptions []string, noPushOption bool) []string {
 	// --no-push-option suppresses all options
 	if noPushOption {
 		return nil
@@ -142,7 +144,7 @@ func resolvePushOptions(cfg *config.Config, branchType string, cliPushOptions []
 
 	// Layer 2: Load from git config (multi-value key)
 	configKey := fmt.Sprintf("gitflow.%s.publish.push-option", branchType)
-	configOptions, err := git.GetConfigAllValues(configKey)
+	configOptions, err := repo.GetConfigAllValues(configKey)
 	if err == nil {
 		resolvedOptions = append(resolvedOptions, configOptions...)
 	}
@@ -154,16 +156,16 @@ func resolvePushOptions(cfg *config.Config, branchType string, cliPushOptions []
 }
 
 // executePublish performs the actual publish operation (called within hooks wrapper)
-func executePublish(fullBranchName, shortName, branchType, remote string, pushOptions []string) error {
+func executePublish(repo *git.Repo, fullBranchName, shortName, branchType, remote string, pushOptions []string) error {
 	// Fetch to get latest remote refs
 	fmt.Printf("Fetching from '%s'...\n", remote)
-	if err := git.Fetch(remote); err != nil {
+	if err := repo.Fetch(remote); err != nil {
 		// Don't fail if fetch fails - remote might not be reachable
 		fmt.Fprintf(os.Stderr, "Warning: Could not fetch from '%s': %v\n", remote, err)
 	}
 
 	// Check if remote branch already exists
-	if git.RemoteBranchExists(remote, fullBranchName) {
+	if repo.RemoteBranchExists(remote, fullBranchName) {
 		return &errors.RemoteBranchExistsError{
 			Remote:     remote,
 			BranchName: fullBranchName,
@@ -172,7 +174,7 @@ func executePublish(fullBranchName, shortName, branchType, remote string, pushOp
 
 	// Push the branch to remote with tracking
 	fmt.Printf("Publishing '%s' to '%s'...\n", fullBranchName, remote)
-	if err := git.PushBranch(remote, fullBranchName, pushOptions); err != nil {
+	if err := repo.PushBranch(remote, fullBranchName, pushOptions); err != nil {
 		return &errors.GitError{
 			Operation: fmt.Sprintf("push branch '%s' to '%s'", fullBranchName, remote),
 			Err:       err,

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -16,11 +16,7 @@ import (
 // pushOptions are CLI-provided push options to transmit to the server.
 // noPushOption suppresses all push options (both CLI and config defaults).
 func PublishCommand(branchType string, name string, pushOptions []string, noPushOption bool) {
-	repo, err := openRepo()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-	}
+	repo := mustOpenRepo()
 	if err := publish(repo, branchType, name, pushOptions, noPushOption); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -11,11 +11,7 @@ import (
 
 // RenameCommand handles renaming a topic branch
 func RenameCommand(branchType string, oldName string, newName string) {
-	repo, err := openRepo()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-	}
+	repo := mustOpenRepo()
 	if err := executeRename(repo, branchType, oldName, newName); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -11,7 +11,12 @@ import (
 
 // RenameCommand handles renaming a topic branch
 func RenameCommand(branchType string, oldName string, newName string) {
-	if err := executeRename(branchType, oldName, newName); err != nil {
+	repo, err := openRepo()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+	}
+	if err := executeRename(repo, branchType, oldName, newName); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -24,11 +29,11 @@ func RenameCommand(branchType string, oldName string, newName string) {
 }
 
 // executeRename performs the actual branch renaming logic and returns any errors
-func executeRename(branchType string, oldName string, newName string) error {
+func executeRename(repo *git.Repo, branchType string, oldName string, newName string) error {
 	// Validate that git-flow is initialized before resolving branch types.
 	// LoadConfig falls back to DefaultConfig when uninitialized, so this gate
 	// must run first or the default branch types mask the uninitialized state.
-	initialized, err := config.IsInitialized()
+	initialized, err := config.IsInitialized(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
 	}
@@ -37,7 +42,7 @@ func executeRename(branchType string, oldName string, newName string) error {
 	}
 
 	// Load configuration
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
@@ -57,29 +62,29 @@ func executeRename(branchType string, oldName string, newName string) error {
 	}
 
 	// Check if old branch exists
-	err = git.BranchExists(oldFullBranchName)
+	err = repo.BranchExists(oldFullBranchName)
 	if err != nil {
 		return &errors.BranchNotFoundError{BranchName: oldFullBranchName}
 	}
 
 	// Check if new branch name already exists
-	err = git.BranchExists(newFullBranchName)
+	err = repo.BranchExists(newFullBranchName)
 	if err == nil {
 		return &errors.GitError{Operation: "rename branch", Err: fmt.Errorf("branch '%s' already exists", newFullBranchName)}
 	}
 
 	// Check if we're currently on the branch to be renamed
-	currentBranch, err := git.GetCurrentBranch()
+	currentBranch, err := repo.GetCurrentBranch()
 	if err != nil {
 		return &errors.GitError{Operation: "get current branch", Err: err}
 	}
 
 	// If we're on the branch to be renamed, we need to rename it while on it
 	if currentBranch == oldFullBranchName {
-		err = git.RenameBranch(oldFullBranchName, newFullBranchName)
+		err = repo.RenameBranch(oldFullBranchName, newFullBranchName)
 	} else {
 		// Otherwise, rename it while staying on the current branch
-		err = git.RenameBranch(oldFullBranchName, newFullBranchName)
+		err = repo.RenameBranch(oldFullBranchName, newFullBranchName)
 	}
 
 	if err != nil {

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/gittower/git-flow-next/internal/git"
+)
+
+var (
+	repoOnce   sync.Once
+	cachedRepo *git.Repo
+	cachedErr  error
+)
+
+// openRepo opens a git.Repo handle for the invocation directory — the process
+// working directory where git-flow was run. All repo-bound operations run
+// against this handle's absolute paths, so command behavior does not depend on
+// any later change of working directory.
+//
+// The result is memoized: git-flow is a single-shot CLI whose invocation
+// directory never changes within a process, so the (potentially several)
+// callers per invocation share one resolution rather than re-running git
+// rev-parse each time.
+func openRepo() (*git.Repo, error) {
+	repoOnce.Do(func() {
+		dir, err := os.Getwd()
+		if err != nil {
+			cachedErr = err
+			return
+		}
+		cachedRepo, cachedErr = git.Open(dir)
+	})
+	return cachedRepo, cachedErr
+}
+
+// normalizeInvocationPath resolves a possibly-relative path against the
+// invocation directory (the process working directory), returning an absolute
+// path. An empty path is returned unchanged. This preserves the historical,
+// invocation-directory-relative meaning of relative path arguments (e.g. the tag
+// message file) even though repo-bound git commands now run with the work tree
+// as their working directory.
+func normalizeInvocationPath(path string) string {
+	if path == "" || filepath.IsAbs(path) {
+		return path
+	}
+	dir, err := os.Getwd()
+	if err != nil {
+		return path
+	}
+	return filepath.Join(dir, path)
+}

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
 
+	"github.com/gittower/git-flow-next/internal/errors"
 	"github.com/gittower/git-flow-next/internal/git"
 )
 
@@ -33,6 +35,23 @@ func openRepo() (*git.Repo, error) {
 		cachedRepo, cachedErr = git.Open(dir)
 	})
 	return cachedRepo, cachedErr
+}
+
+// mustOpenRepo opens the invocation repository or exits the process. A failure
+// here means the invocation directory is not inside a git repository — a git
+// error, not a "git-flow not initialized" condition (which is detected later,
+// against an opened repo). It therefore reports a GitError wrapping the
+// underlying cause and exits with the git error code, rather than the
+// misleading NotInitializedError/exit-1 that would send users to 'git flow
+// init' instead of 'git init'.
+func mustOpenRepo() *git.Repo {
+	repo, err := openRepo()
+	if err != nil {
+		gitErr := &errors.GitError{Operation: "open repository", Err: err}
+		fmt.Fprintf(os.Stderr, "Error: %v\n", gitErr)
+		os.Exit(int(gitErr.ExitCode()))
+	}
+	return repo
 }
 
 // normalizeInvocationPath resolves a possibly-relative path against the

--- a/cmd/shorthand.go
+++ b/cmd/shorthand.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/gittower/git-flow-next/internal/config"
-	"github.com/gittower/git-flow-next/internal/git"
 	"github.com/spf13/cobra"
 )
 
@@ -268,11 +267,15 @@ func runShorthandUpdate(useRebase, continueOp, abortOp bool, args []string) erro
 
 // detectBranchTypeAndName detects type and name from current branch
 func detectBranchTypeAndName() (string, string, error) {
-	cfg, err := config.LoadConfig()
+	repo, err := openRepo()
 	if err != nil {
 		return "", "", err
 	}
-	currentBranch, err := git.GetCurrentBranch()
+	cfg, err := config.Load(repo)
+	if err != nil {
+		return "", "", err
+	}
+	currentBranch, err := repo.GetCurrentBranch()
 	if err != nil {
 		return "", "", err
 	}
@@ -314,7 +317,11 @@ func detectBranchTypeAndName() (string, string, error) {
 
 // detectBranchTypeAndNameFromString detects from a given string (for delete [name])
 func detectBranchTypeAndNameFromString(branch string) (string, string, error) {
-	cfg, err := config.LoadConfig()
+	repo, err := openRepo()
+	if err != nil {
+		return "", "", err
+	}
+	cfg, err := config.Load(repo)
 	if err != nil {
 		return "", "", err
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -14,7 +14,12 @@ import (
 // If shouldFetch is nil, the function will check config for fetch preference
 // If base is empty, the function will use the configured starting point
 func StartCommand(branchType string, name string, base string, shouldFetch *bool) {
-	if err := start(branchType, name, base, shouldFetch); err != nil {
+	repo, err := openRepo()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+	}
+	if err := start(repo, branchType, name, base, shouldFetch); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -27,9 +32,9 @@ func StartCommand(branchType string, name string, base string, shouldFetch *bool
 }
 
 // start performs the actual branch creation logic with optional fetch and returns any errors
-func start(branchType string, name string, base string, shouldFetch *bool) error {
+func start(repo *git.Repo, branchType string, name string, base string, shouldFetch *bool) error {
 	// Validate that git-flow is initialized
-	initialized, err := config.IsInitialized()
+	initialized, err := config.IsInitialized(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
 	}
@@ -38,10 +43,7 @@ func start(branchType string, name string, base string, shouldFetch *bool) error
 	}
 
 	// Get git directory for hooks and filters
-	gitDir, err := git.GetGitDir()
-	if err != nil {
-		return &errors.GitError{Operation: "get git directory", Err: err}
-	}
+	gitDir := repo.GitDir()
 
 	// Apply version filter for any branch type. The filter script
 	// (filter-flow-{branchType}-start-version) decides what to do; when no name
@@ -66,7 +68,7 @@ func start(branchType string, name string, base string, shouldFetch *bool) error
 	}
 
 	// Get configuration
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
@@ -106,44 +108,44 @@ func start(branchType string, name string, base string, shouldFetch *bool) error
 
 	// Run start operation wrapped with hooks
 	return hooks.WithHooks(gitDir, branchType, hooks.HookActionStart, hookCtx, func() error {
-		return executeStart(branchType, name, base, shouldFetch, cfg, branchConfig, fullBranchName, startPoint)
+		return executeStart(repo, branchType, name, base, shouldFetch, cfg, branchConfig, fullBranchName, startPoint)
 	})
 }
 
 // executeStart performs the actual start operation (called within hooks wrapper)
-func executeStart(branchType string, name string, base string, shouldFetch *bool, cfg *config.Config, branchConfig config.BranchConfig, fullBranchName string, startPoint string) error {
+func executeStart(repo *git.Repo, branchType string, name string, base string, shouldFetch *bool, cfg *config.Config, branchConfig config.BranchConfig, fullBranchName string, startPoint string) error {
 	// Determine if we should fetch using the shared resolver (default true for start):
 	// Layer 1 default -> gitflow.<type>.start.fetch config -> CLI flag.
 	remoteName := cfg.Remote
 	if config.ResolveStartShouldFetch(cfg, branchType, shouldFetch) {
 		// Skip silently when no remote is configured (no "Fetching" line, no error).
-		if git.RemoteExists(remoteName) {
+		if repo.RemoteExists(remoteName) {
 			fmt.Printf("Fetching from %s...\n", remoteName)
 			// Non-fatal: a failed fetch is a warning; start has no sync gate.
-			if err := git.Fetch(remoteName); err != nil {
+			if err := repo.Fetch(remoteName); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
 			}
 		}
 	}
 
 	// Check if branch already exists
-	if err := git.BranchExists(fullBranchName); err == nil {
+	if err := repo.BranchExists(fullBranchName); err == nil {
 		return &errors.BranchExistsError{BranchName: fullBranchName}
 	}
 
 	// Check if start point exists (can be branch, tag, or commit)
-	if err := git.BranchOrCommitExists(startPoint); err != nil {
+	if err := repo.BranchOrCommitExists(startPoint); err != nil {
 		return &errors.BranchNotFoundError{BranchName: startPoint}
 	}
 
 	// Create branch
-	err := git.CreateBranch(fullBranchName, startPoint)
+	err := repo.CreateBranch(fullBranchName, startPoint)
 	if err != nil {
 		return &errors.GitError{Operation: "create branch", Err: err}
 	}
 
 	// Store the start point in Git config
-	if err := git.SetBaseBranch(fullBranchName, startPoint); err != nil {
+	if err := repo.SetBaseBranch(fullBranchName, startPoint); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: Failed to store base branch: %v\n", err)
 	}
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -14,11 +14,7 @@ import (
 // If shouldFetch is nil, the function will check config for fetch preference
 // If base is empty, the function will use the configured starting point
 func StartCommand(branchType string, name string, base string, shouldFetch *bool) {
-	repo, err := openRepo()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-	}
+	repo := mustOpenRepo()
 	if err := start(repo, branchType, name, base, shouldFetch); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {

--- a/cmd/topicbranch.go
+++ b/cmd/topicbranch.go
@@ -7,15 +7,23 @@ import (
 
 	"github.com/gittower/git-flow-next/internal/config"
 	"github.com/gittower/git-flow-next/internal/errors"
-	"github.com/gittower/git-flow-next/internal/git"
 	"github.com/spf13/cobra"
 )
 
 // RegisterTopicBranchCommands dynamically creates commands for topic branches
 // based on configuration.
 func RegisterTopicBranchCommands() {
+	// Open a handle for the invocation directory. Registration runs at package
+	// init; outside a git repository (or before init) fall back to the standard
+	// branch types instead of failing.
+	repo, err := openRepo()
+	if err != nil {
+		registerDefaultBranchCommands()
+		return
+	}
+
 	// Load configuration
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(repo)
 	if err != nil {
 		// If we can't load the config, fall back to standard branch types
 		fmt.Println("Warning: Could not load git-flow configuration, using default branch types")
@@ -126,7 +134,13 @@ func registerBranchCommand(branchType string) {
 			// uninitialized, so without this gate the detection below (and the
 			// downstream finish logic) would emit a misleading "branch does not
 			// exist"/"not a branch" error instead of "not initialized".
-			initialized, err := config.IsInitialized()
+			repo, err := openRepo()
+			if err != nil {
+				notInit := &errors.NotInitializedError{}
+				fmt.Fprintf(os.Stderr, "Error: %v\n", notInit)
+				os.Exit(int(notInit.ExitCode()))
+			}
+			initialized, err := config.IsInitialized(repo)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.GitError{Operation: "check if git-flow is initialized", Err: err})
 				os.Exit(int(errors.ExitCodeGitError))
@@ -192,13 +206,13 @@ func registerBranchCommand(branchType string) {
 				name = args[0]
 			} else {
 				// No name provided, try to detect from current branch
-				currentBranch, err := git.GetCurrentBranch()
+				currentBranch, err := repo.GetCurrentBranch()
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 					os.Exit(int(errors.ExitCodeGitError))
 				}
 				// Load config to get prefix
-				cfg, err := config.LoadConfig()
+				cfg, err := config.Load(repo)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 					os.Exit(int(errors.ExitCodeGitError))

--- a/cmd/topicbranch.go
+++ b/cmd/topicbranch.go
@@ -134,12 +134,7 @@ func registerBranchCommand(branchType string) {
 			// uninitialized, so without this gate the detection below (and the
 			// downstream finish logic) would emit a misleading "branch does not
 			// exist"/"not a branch" error instead of "not initialized".
-			repo, err := openRepo()
-			if err != nil {
-				notInit := &errors.NotInitializedError{}
-				fmt.Fprintf(os.Stderr, "Error: %v\n", notInit)
-				os.Exit(int(notInit.ExitCode()))
-			}
+			repo := mustOpenRepo()
 			initialized, err := config.IsInitialized(repo)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.GitError{Operation: "check if git-flow is initialized", Err: err})

--- a/cmd/track.go
+++ b/cmd/track.go
@@ -13,7 +13,12 @@ import (
 
 // TrackCommand is the implementation of the track command for topic branches
 func TrackCommand(branchType string, name string) {
-	if err := track(branchType, name); err != nil {
+	repo, err := openRepo()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+	}
+	if err := track(repo, branchType, name); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -26,9 +31,9 @@ func TrackCommand(branchType string, name string) {
 }
 
 // track performs the actual tracking branch creation logic
-func track(branchType string, name string) error {
+func track(repo *git.Repo, branchType string, name string) error {
 	// Validate that git-flow is initialized
-	initialized, err := config.IsInitialized()
+	initialized, err := config.IsInitialized(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
 	}
@@ -42,7 +47,7 @@ func track(branchType string, name string) error {
 	}
 
 	// Get configuration
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
@@ -63,7 +68,7 @@ func track(branchType string, name string) error {
 	}
 
 	// Check if branch already exists locally
-	if err := git.BranchExists(fullBranchName); err == nil {
+	if err := repo.BranchExists(fullBranchName); err == nil {
 		return &errors.BranchExistsError{BranchName: fullBranchName}
 	}
 
@@ -71,15 +76,12 @@ func track(branchType string, name string) error {
 	remote := cfg.Remote
 
 	// Validate remote exists
-	if !git.RemoteExists(remote) {
+	if !repo.RemoteExists(remote) {
 		return &errors.RemoteNotConfiguredError{Remote: remote, Operation: "track branch"}
 	}
 
 	// Get git directory for hooks
-	gitDir, err := git.GetGitDir()
-	if err != nil {
-		return &errors.GitError{Operation: "get git directory", Err: err}
-	}
+	gitDir := repo.GitDir()
 
 	// Build hook context
 	hookCtx := hooks.HookContext{
@@ -95,15 +97,15 @@ func track(branchType string, name string) error {
 
 	// Run track operation wrapped with hooks
 	return hooks.WithHooks(gitDir, branchType, hooks.HookActionTrack, hookCtx, func() error {
-		return executeTrack(fullBranchName, remote)
+		return executeTrack(repo, fullBranchName, remote)
 	})
 }
 
 // executeTrack performs the actual track operation (called within hooks wrapper)
-func executeTrack(fullBranchName, remote string) error {
+func executeTrack(repo *git.Repo, fullBranchName, remote string) error {
 	// Fetch from remote to ensure we have latest refs
 	fmt.Printf("Fetching from '%s'...\n", remote)
-	if err := git.Fetch(remote); err != nil {
+	if err := repo.Fetch(remote); err != nil {
 		return &errors.GitError{
 			Operation: fmt.Sprintf("fetch from remote '%s'", remote),
 			Err:       err,
@@ -111,7 +113,7 @@ func executeTrack(fullBranchName, remote string) error {
 	}
 
 	// Check if branch exists on remote
-	if !git.RemoteBranchExists(remote, fullBranchName) {
+	if !repo.RemoteBranchExists(remote, fullBranchName) {
 		return &errors.RemoteBranchNotFoundError{
 			Remote:     remote,
 			BranchName: fullBranchName,
@@ -120,7 +122,7 @@ func executeTrack(fullBranchName, remote string) error {
 
 	// Create local tracking branch
 	fmt.Printf("Setting up tracking branch for '%s'...\n", fullBranchName)
-	if err := git.CreateTrackingBranch(fullBranchName, remote, fullBranchName); err != nil {
+	if err := repo.CreateTrackingBranch(fullBranchName, remote, fullBranchName); err != nil {
 		return &errors.GitError{
 			Operation: fmt.Sprintf("create tracking branch '%s'", fullBranchName),
 			Err:       err,

--- a/cmd/track.go
+++ b/cmd/track.go
@@ -13,11 +13,7 @@ import (
 
 // TrackCommand is the implementation of the track command for topic branches
 func TrackCommand(branchType string, name string) {
-	repo, err := openRepo()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-	}
+	repo := mustOpenRepo()
 	if err := track(repo, branchType, name); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -25,11 +25,7 @@ import (
 // forces exit 1) is what makes the top-level surface exit 3 for merge-in-progress,
 // no-merge, and unresolved-conflict conditions, consistent with finish/integrate.
 func UpdateCommand(branchType string, name string, useRebase, continueOp, abortOp bool) {
-	repo, err := openRepo()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
-		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
-	}
+	repo := mustOpenRepo()
 	if err := executeUpdate(repo, branchType, name, useRebase, continueOp, abortOp); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -25,7 +25,12 @@ import (
 // forces exit 1) is what makes the top-level surface exit 3 for merge-in-progress,
 // no-merge, and unresolved-conflict conditions, consistent with finish/integrate.
 func UpdateCommand(branchType string, name string, useRebase, continueOp, abortOp bool) {
-	if err := executeUpdate(branchType, name, useRebase, continueOp, abortOp); err != nil {
+	repo, err := openRepo()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", &errors.NotInitializedError{})
+		os.Exit(int((&errors.NotInitializedError{}).ExitCode()))
+	}
+	if err := executeUpdate(repo, branchType, name, useRebase, continueOp, abortOp); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -40,9 +45,9 @@ func UpdateCommand(branchType string, name string, useRebase, continueOp, abortO
 // executeUpdate updates a branch with changes from its parent branch. It owns the
 // resumable dispatch for update: a foreign-operation guard, its own
 // --continue/--abort handling, and the initial update attempt.
-func executeUpdate(branchType string, name string, useRebase, continueOp, abortOp bool) error {
+func executeUpdate(repo *git.Repo, branchType string, name string, useRebase, continueOp, abortOp bool) error {
 	// Validate that git-flow is initialized
-	initialized, err := config.IsInitialized()
+	initialized, err := config.IsInitialized(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
 	}
@@ -51,7 +56,7 @@ func executeUpdate(branchType string, name string, useRebase, continueOp, abortO
 	}
 
 	// Get configuration
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
@@ -59,13 +64,13 @@ func executeUpdate(branchType string, name string, useRebase, continueOp, abortO
 	// Foreign-operation guard (#143): refuse a foreign in-progress finish/integrate
 	// (or an unknown-Action state) before dispatch, so update never resumes or
 	// aborts an operation it does not own.
-	if err := refuseIfForeignOperation(cfg, "update"); err != nil {
+	if err := refuseIfForeignOperation(repo, cfg, "update"); err != nil {
 		return err
 	}
 
 	// Own-state dispatch: resume/abort an update we own.
-	if mergestate.IsMergeInProgress() {
-		state, err := mergestate.LoadMergeState()
+	if mergestate.IsMergeInProgress(repo) {
+		state, err := mergestate.LoadMergeState(repo)
 		if err != nil {
 			return &errors.GitError{Operation: "load merge state", Err: err}
 		}
@@ -74,10 +79,10 @@ func executeUpdate(branchType string, name string, useRebase, continueOp, abortO
 			return &errors.MergeInProgressError{Action: state.Action, BranchName: state.FullBranchName, BranchType: topicTypeOrEmpty(cfg, state.BranchType)}
 		}
 		if abortOp {
-			return handleAbort(state)
+			return handleAbort(repo, state)
 		}
 		if continueOp {
-			return handleUpdateContinue(state)
+			return handleUpdateContinue(repo, state)
 		}
 		// Plain invocation over our own in-progress update: report it rather than
 		// silently restarting.
@@ -102,7 +107,7 @@ func executeUpdate(branchType string, name string, useRebase, continueOp, abortO
 		// If branch type is specified, construct full branch name
 		if name == "" {
 			// If no name provided, try to get current branch and verify it's of the correct type
-			currentBranch, err := git.GetCurrentBranch()
+			currentBranch, err := repo.GetCurrentBranch()
 			if err != nil {
 				return &errors.GitError{Operation: "get current branch", Err: err}
 			}
@@ -127,7 +132,7 @@ func executeUpdate(branchType string, name string, useRebase, continueOp, abortO
 	} else {
 		// No branch type specified, use provided branch name or current branch
 		if name == "" {
-			currentBranch, err := git.GetCurrentBranch()
+			currentBranch, err := repo.GetCurrentBranch()
 			if err != nil {
 				return &errors.GitError{Operation: "get current branch", Err: err}
 			}
@@ -140,7 +145,7 @@ func executeUpdate(branchType string, name string, useRebase, continueOp, abortO
 	}
 
 	// Check if branch exists
-	if err := git.BranchExists(branchName); err != nil {
+	if err := repo.BranchExists(branchName); err != nil {
 		return &errors.BranchNotFoundError{BranchName: branchName}
 	}
 
@@ -151,7 +156,7 @@ func executeUpdate(branchType string, name string, useRebase, continueOp, abortO
 	}
 
 	// Check if parent branch exists
-	if err := git.BranchExists(parentBranch); err != nil {
+	if err := repo.BranchExists(parentBranch); err != nil {
 		return &errors.BranchNotFoundError{BranchName: parentBranch}
 	}
 
@@ -201,10 +206,7 @@ func executeUpdate(branchType string, name string, useRebase, continueOp, abortO
 	// If we detected a branch type, run with hooks
 	if detectedBranchType != "" {
 		// Get git directory for hooks
-		gitDir, err := git.GetGitDir()
-		if err != nil {
-			return &errors.GitError{Operation: "get git directory", Err: err}
-		}
+		gitDir := repo.GitDir()
 
 		// Get remote name from config
 		remoteName := cfg.Remote
@@ -223,26 +225,26 @@ func executeUpdate(branchType string, name string, useRebase, continueOp, abortO
 
 		// Run update operation wrapped with hooks
 		return hooks.WithHooks(gitDir, detectedBranchType, hooks.HookActionUpdate, hookCtx, func() error {
-			return update.UpdateBranchFromParent(branchName, parentBranch, strategy, true, state)
+			return update.UpdateBranchFromParent(repo, branchName, parentBranch, strategy, true, state)
 		})
 	}
 
 	// No branch type detected, run without hooks
-	return update.UpdateBranchFromParent(branchName, parentBranch, strategy, true, state)
+	return update.UpdateBranchFromParent(repo, branchName, parentBranch, strategy, true, state)
 }
 
 // handleUpdateContinue completes an in-progress update after conflict resolution.
 // Unlike finish, it completes ONLY the merge/rebase — no tag, no child update, no
 // branch deletion — then clears the merge state. A rebase that re-conflicts on a
 // later replayed commit stays resumable (UnresolvedConflictsError, state kept).
-func handleUpdateContinue(state *mergestate.MergeState) error {
-	if git.HasConflicts() {
+func handleUpdateContinue(repo *git.Repo, state *mergestate.MergeState) error {
+	if repo.HasConflicts() {
 		return &errors.UnresolvedConflictsError{}
 	}
 
 	switch state.MergeStrategy {
 	case strategyRebase:
-		err := git.RebaseContinue()
+		err := repo.RebaseContinue()
 		if err != nil {
 			if strings.Contains(err.Error(), "conflict") {
 				// A later replayed commit conflicts: stay resumable.
@@ -261,12 +263,12 @@ func handleUpdateContinue(state *mergestate.MergeState) error {
 
 	default: // merge
 		mergeMsg := fmt.Sprintf("Merge branch '%s' into %s", state.ParentBranch, state.FullBranchName)
-		if err := git.Commit(mergeMsg, state.NoVerify); err != nil {
+		if err := repo.Commit(mergeMsg, state.NoVerify); err != nil {
 			return &errors.GitError{Operation: "commit merge", Err: err}
 		}
 	}
 
-	if err := mergestate.ClearMergeState(); err != nil {
+	if err := mergestate.ClearMergeState(repo); err != nil {
 		return &errors.GitError{Operation: "clear merge state", Err: err}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,8 +3,6 @@ package config
 
 import (
 	"fmt"
-	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -170,16 +168,10 @@ func DefaultConfig() *Config {
 	}
 }
 
-// LoadConfig loads the git-flow configuration from Git config
-func LoadConfig() (*Config, error) {
-	// Get current directory for git operations
-	currentDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get current directory: %w", err)
-	}
-
+// Load loads the git-flow configuration from the given repository's Git config.
+func Load(repo *git.Repo) (*Config, error) {
 	// Check if git-flow is initialized
-	initialized, err := IsInitialized()
+	initialized, err := IsInitialized(repo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check if git-flow is initialized: %w", err)
 	}
@@ -190,11 +182,11 @@ func LoadConfig() (*Config, error) {
 	}
 
 	// Get git-flow version
-	version, err := git.GetConfigInDir(currentDir, "gitflow.version")
+	version, err := repo.GetConfig("gitflow.version")
 	if err != nil {
 		// If no version is set but AVH config exists, import AVH config
-		if CheckGitFlowAVHConfig() {
-			return ImportGitFlowAVHConfig()
+		if CheckGitFlowAVHConfig(repo) {
+			return ImportGitFlowAVHConfig(repo)
 		}
 		// If no version is set, assume it's not initialized properly
 		return DefaultConfig(), nil
@@ -209,7 +201,7 @@ func LoadConfig() (*Config, error) {
 	}
 
 	// Load all gitflow.* command-specific config at once
-	allGitflowConfig, err := loadAllGitflowConfig(currentDir)
+	allGitflowConfig, err := loadAllGitflowConfig(repo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load gitflow config: %w", err)
 	}
@@ -222,10 +214,10 @@ func LoadConfig() (*Config, error) {
 	}
 
 	// Get all gitflow.branch.* config entries
-	// We need to adapt GetAllConfig to work with directory
-	cmd := exec.Command("git", "config", "--get-regexp", "gitflow\\.branch\\.")
-	cmd.Dir = currentDir
-	output, err := cmd.Output()
+	branchLines, err := repo.GetConfigRegexpLines("gitflow\\.branch\\.")
+	if err != nil {
+		return nil, fmt.Errorf("failed to load gitflow branch config: %w", err)
+	}
 
 	// Process branch configurations from command output.
 	//
@@ -244,9 +236,8 @@ func LoadConfig() (*Config, error) {
 	// branch name used as the branchMap key.
 	canonicalNames := make(map[string]string)
 
-	if err == nil {
-		lines := strings.Split(string(output), "\n")
-		for _, line := range lines {
+	{
+		for _, line := range branchLines {
 			if line == "" {
 				continue
 			}
@@ -332,21 +323,15 @@ func LoadConfig() (*Config, error) {
 
 // IsInitialized checks if git-flow is initialized in the repository
 // This includes both git-flow-next and git-flow-avh configurations
-func IsInitialized() (bool, error) {
-	// Get current directory for git operations
-	currentDir, err := os.Getwd()
-	if err != nil {
-		return false, fmt.Errorf("failed to get current directory: %w", err)
-	}
-
+func IsInitialized(repo *git.Repo) (bool, error) {
 	// Check for our own gitflow.version config
-	version, err := git.GetConfigInDir(currentDir, "gitflow.version")
+	version, err := repo.GetConfig("gitflow.version")
 	if err == nil && version != "" {
 		return true, nil
 	}
 
 	// Check for git-flow-avh configuration
-	if CheckGitFlowAVHConfig() {
+	if CheckGitFlowAVHConfig(repo) {
 		return true, nil
 	}
 
@@ -355,15 +340,9 @@ func IsInitialized() (bool, error) {
 
 // IsGitFlowNextInitialized checks if git-flow-next specifically is initialized
 // This only checks for our own configuration, not git-flow-avh
-func IsGitFlowNextInitialized() (bool, error) {
-	// Get current directory for git operations
-	currentDir, err := os.Getwd()
-	if err != nil {
-		return false, fmt.Errorf("failed to get current directory: %w", err)
-	}
-
+func IsGitFlowNextInitialized(repo *git.Repo) (bool, error) {
 	// Check for our own gitflow.version config
-	version, err := git.GetConfigInDir(currentDir, "gitflow.version")
+	version, err := repo.GetConfig("gitflow.version")
 	if err == nil && version != "" {
 		return true, nil
 	}
@@ -402,21 +381,15 @@ func IsGitFlowNextInitializedWithScope(scope git.ConfigScope, filePath string) (
 }
 
 // CheckGitFlowAVHConfig checks if git-flow-avh configuration exists
-func CheckGitFlowAVHConfig() bool {
-	// Get current directory for git operations
-	currentDir, err := os.Getwd()
-	if err != nil {
-		return false
-	}
-
+func CheckGitFlowAVHConfig(repo *git.Repo) bool {
 	// Check for gitflow.branch.master (used in git-flow-avh)
-	master, err := git.GetConfigInDir(currentDir, "gitflow.branch.master")
+	master, err := repo.GetConfig("gitflow.branch.master")
 	if err == nil && master != "" {
 		return true
 	}
 
 	// Check for gitflow.prefix.feature (used in git-flow-avh)
-	featurePrefix, err := git.GetConfigInDir(currentDir, "gitflow.prefix.feature")
+	featurePrefix, err := repo.GetConfig("gitflow.prefix.feature")
 	if err == nil && featurePrefix != "" {
 		return true
 	}
@@ -425,17 +398,11 @@ func CheckGitFlowAVHConfig() bool {
 }
 
 // ImportGitFlowAVHConfig imports git-flow-avh configuration
-func ImportGitFlowAVHConfig() (*Config, error) {
+func ImportGitFlowAVHConfig(repo *git.Repo) (*Config, error) {
 	config := DefaultConfig()
 
-	// Get current directory for git operations
-	currentDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get current directory: %w", err)
-	}
-
 	// Check for custom remote in git-flow-avh config
-	remote, err := git.GetConfigInDir(currentDir, "gitflow.origin")
+	remote, err := repo.GetConfig("gitflow.origin")
 	if err == nil && remote != "" {
 		config.Remote = remote
 	}
@@ -448,7 +415,7 @@ func ImportGitFlowAVHConfig() (*Config, error) {
 
 	// Get branch names from git-flow-avh config
 	for avhName, ourName := range branchMap {
-		branchName, err := git.GetConfigInDir(currentDir, "gitflow.branch."+avhName)
+		branchName, err := repo.GetConfig("gitflow.branch." + avhName)
 		if err == nil && branchName != "" {
 			// Update branch name in our config
 			branchConfig := config.Branches[ourName]
@@ -482,7 +449,7 @@ func ImportGitFlowAVHConfig() (*Config, error) {
 	for avhName, ourName := range prefixMap {
 		if avhName == "versiontag" {
 			// Special handling for version tag prefix
-			prefix, err := git.GetConfigInDir(currentDir, "gitflow.prefix."+avhName)
+			prefix, err := repo.GetConfig("gitflow.prefix." + avhName)
 			if err == nil && prefix != "" {
 				// Set the tag prefix for release and hotfix branches
 				releaseConfig := config.Branches["release"]
@@ -502,7 +469,7 @@ func ImportGitFlowAVHConfig() (*Config, error) {
 			continue
 		}
 
-		prefix, err := git.GetConfigInDir(currentDir, "gitflow.prefix."+avhName)
+		prefix, err := repo.GetConfig("gitflow.prefix." + avhName)
 		if err == nil && prefix != "" {
 			// Update prefix in our config
 			branchConfig := config.Branches[ourName]
@@ -764,17 +731,16 @@ func MarkRepoInitializedWithScope(scope git.ConfigScope, filePath string) error 
 }
 
 // ClearConfig removes all git-flow configuration
-func ClearConfig() error {
+func ClearConfig(repo *git.Repo) error {
 	// Get all gitflow.* config entries
-	configs, err := git.GetAllConfig("gitflow\\.")
+	configs, err := repo.GetAllConfig("gitflow\\.")
 	if err != nil {
 		return fmt.Errorf("failed to get gitflow configurations: %w", err)
 	}
 
 	// Remove each config entry
 	for key := range configs {
-		err = git.UnsetConfig(key)
-		if err != nil {
+		if err := repo.UnsetConfig(key); err != nil {
 			return fmt.Errorf("failed to unset %s: %w", key, err)
 		}
 	}
@@ -880,22 +846,16 @@ func gitlabFlowConfig() *Config {
 }
 
 // loadAllGitflowConfig loads all gitflow.* configuration keys at once
-func loadAllGitflowConfig(currentDir string) (map[string]string, error) {
-	cmd := exec.Command("git", "config", "--get-regexp", "gitflow\\.")
-	cmd.Dir = currentDir
-	output, err := cmd.Output()
-
-	result := make(map[string]string)
-
+func loadAllGitflowConfig(repo *git.Repo) (map[string]string, error) {
+	rawLines, err := repo.GetConfigRegexpLines("gitflow\\.")
 	if err != nil {
-		// If no config values match, don't treat it as an error
-		if strings.Contains(err.Error(), "exit status 1") {
-			return result, nil
-		}
 		return nil, fmt.Errorf("failed to get gitflow config: %w", err)
 	}
 
-	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	result := make(map[string]string)
+
+	// Join and re-trim to mirror the previous strings.TrimSpace(output) behavior.
+	lines := strings.Split(strings.TrimSpace(strings.Join(rawLines, "\n")), "\n")
 	for _, line := range lines {
 		if line == "" {
 			continue

--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -22,10 +22,9 @@ const (
 	ConfigScopeFile ConfigScope = "file"
 )
 
-// GetConfig gets a Git config value
-func GetConfig(key string) (string, error) {
-	cmd := exec.Command("git", "config", "--get", key)
-	output, err := cmd.Output()
+// GetConfig gets a Git config value from the repository's merged config.
+func (r *Repo) GetConfig(key string) (string, error) {
+	output, err := r.gitCmd("config", "--get", key).Output()
 	if err != nil {
 		return "", fmt.Errorf("failed to get git config %s: %w", key, err)
 	}
@@ -37,9 +36,9 @@ func GetConfig(key string) (string, error) {
 // matching what `git commit` would see. It returns false without error when a
 // key is simply unset (git config --get exits with status 1), and propagates
 // any other failure (e.g. not in a repository) to the caller.
-func HasUserIdentity() (bool, error) {
+func (r *Repo) HasUserIdentity() (bool, error) {
 	for _, key := range []string{"user.name", "user.email"} {
-		value, found, err := readConfigValue(key)
+		value, found, err := r.readConfigValue(key)
 		if err != nil {
 			return false, err
 		}
@@ -54,9 +53,8 @@ func HasUserIdentity() (bool, error) {
 // scope. It distinguishes an unset key (git config --get exits with status 1)
 // from an unexpected failure: an unset key returns ("", false, nil), while any
 // other error is returned to the caller.
-func readConfigValue(key string) (value string, found bool, err error) {
-	cmd := exec.Command("git", "config", "--get", key)
-	output, runErr := cmd.Output()
+func (r *Repo) readConfigValue(key string) (value string, found bool, err error) {
+	output, runErr := r.gitCmd("config", "--get", key).Output()
 	if runErr != nil {
 		if exitErr, ok := runErr.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
 			return "", false, nil
@@ -67,17 +65,8 @@ func readConfigValue(key string) (value string, found bool, err error) {
 }
 
 // GetConfigAllValues gets all values for a multi-value Git config key
-func GetConfigAllValues(key string) ([]string, error) {
-	return GetConfigAllValuesInDir("", key)
-}
-
-// GetConfigAllValuesInDir gets all values for a multi-value Git config key in the specified directory
-func GetConfigAllValuesInDir(dir, key string) ([]string, error) {
-	cmd := exec.Command("git", "config", "--get-all", key)
-	if dir != "" {
-		cmd.Dir = dir
-	}
-	output, err := cmd.Output()
+func (r *Repo) GetConfigAllValues(key string) ([]string, error) {
+	output, err := r.gitCmd("config", "--get-all", key).Output()
 	if err != nil {
 		// If no config values match, return empty slice (not an error)
 		if strings.Contains(err.Error(), "exit status 1") {
@@ -96,31 +85,17 @@ func GetConfigAllValuesInDir(dir, key string) ([]string, error) {
 	return values, nil
 }
 
-// GetConfigInDir gets a Git config value in the specified directory
-func GetConfigInDir(dir, key string) (string, error) {
-	cmd := exec.Command("git", "config", "--get", key)
-	cmd.Dir = dir
-	output, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("failed to get git config %s in dir %s: %w", key, dir, err)
-	}
-	return strings.TrimSpace(string(output)), nil
-}
-
-// SetConfig sets a Git config value
-func SetConfig(key string, value string) error {
-	cmd := exec.Command("git", "config", key, value)
-	_, err := cmd.Output()
-	if err != nil {
+// SetConfig sets a Git config value (local scope by git's default write behavior).
+func (r *Repo) SetConfig(key string, value string) error {
+	if _, err := r.gitCmd("config", key, value).Output(); err != nil {
 		return fmt.Errorf("failed to set git config %s: %w", key, err)
 	}
 	return nil
 }
 
 // UnsetConfigSection removes all Git config values matching a pattern
-func UnsetConfigSection(pattern string) error {
-	cmd := exec.Command("git", "config", "--remove-section", pattern)
-	_, err := cmd.Output()
+func (r *Repo) UnsetConfigSection(pattern string) error {
+	_, err := r.gitCmd("config", "--remove-section", pattern).Output()
 	if err != nil {
 		// Don't treat "section not found" as an error
 		if strings.Contains(err.Error(), "exit status 128") {
@@ -131,10 +106,9 @@ func UnsetConfigSection(pattern string) error {
 	return nil
 }
 
-// GetAllConfig gets all Git config values matching a pattern
-func GetAllConfig(pattern string) (map[string]string, error) {
-	cmd := exec.Command("git", "config", "--get-regexp", pattern)
-	output, err := cmd.Output()
+// GetAllConfig gets all Git config values matching a pattern, as a key->value map.
+func (r *Repo) GetAllConfig(pattern string) (map[string]string, error) {
+	output, err := r.gitCmd("config", "--get-regexp", pattern).Output()
 	if err != nil {
 		// If no config values match, don't treat it as an error
 		if strings.Contains(err.Error(), "exit status 1") {
@@ -158,11 +132,24 @@ func GetAllConfig(pattern string) (map[string]string, error) {
 	return config, nil
 }
 
-// UnsetConfig unsets a Git config value
-func UnsetConfig(key string) error {
-	cmd := exec.Command("git", "config", "--unset", key)
-	_, err := cmd.Output()
+// GetConfigRegexpLines returns the raw output lines of `git config --get-regexp
+// <pattern>` for the repository, or an empty slice when nothing matches. It is
+// used by the config package, which needs the raw lines (preserving empty values
+// and dotted subsection names) rather than a pre-parsed map.
+func (r *Repo) GetConfigRegexpLines(pattern string) ([]string, error) {
+	output, err := r.gitCmd("config", "--get-regexp", pattern).Output()
 	if err != nil {
+		if strings.Contains(err.Error(), "exit status 1") {
+			return []string{}, nil
+		}
+		return nil, fmt.Errorf("failed to get git config matching %s: %w", pattern, err)
+	}
+	return strings.Split(string(output), "\n"), nil
+}
+
+// UnsetConfig unsets a Git config value
+func (r *Repo) UnsetConfig(key string) error {
+	if _, err := r.gitCmd("config", "--unset", key).Output(); err != nil {
 		return fmt.Errorf("failed to unset git config %s: %w", key, err)
 	}
 	return nil
@@ -173,25 +160,30 @@ func UnsetConfig(key string) error {
 // config --local --get exits 1) returns nil silently. Any other failure —
 // including a multi-value key that --unset refuses (exit 5) or a genuine
 // read/write error — is surfaced as an error.
-func UnsetConfigIfPresent(key string) error {
+func (r *Repo) UnsetConfigIfPresent(key string) error {
 	// Detect absence precisely and in the scope that gets cleaned: `git config
 	// --local --get` exits 1 when the key is absent from local config. The unset
 	// below is local-scoped too, so probing merged config (local+global+system)
 	// would wrongly treat a global/system-only value as present and fall through
 	// to a local --unset that finds nothing and errors. Do NOT match on --unset
 	// exit 5, which also means "multi-value".
-	err := exec.Command("git", "config", "--local", "--get", key).Run()
+	err := r.gitCmd("config", "--local", "--get", key).Run()
 	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
 		return nil // key not present in local config: nothing to clean up
 	}
 	// Present, multi-value, or read error: attempt the unset in the same local
 	// scope we probed so real failures (multi-value, read-only) still surface.
-	return UnsetConfigWithScope(key, ConfigScopeLocal, "")
+	if _, err := r.gitCmd("config", "--local", "--unset", key).Output(); err != nil {
+		return fmt.Errorf("failed to unset git config %s: %w", key, err)
+	}
+	return nil
 }
 
-// GetConfigWithScope gets a Git config value at a specific scope.
+// GetConfigWithScope gets a Git config value at a specific scope. It is
+// repository-less by design: global/system/file scopes are not bound to a work
+// tree, and a relative --file path resolves against the process working
+// directory (the invocation directory).
 // For ConfigScopeDefault, reads merged config (git's standard behavior).
-// For specific scopes, reads only from that scope.
 func GetConfigWithScope(key string, scope ConfigScope, filePath string) (string, error) {
 	args := []string{"config"}
 	switch scope {
@@ -206,8 +198,7 @@ func GetConfigWithScope(key string, scope ConfigScope, filePath string) (string,
 		// ConfigScopeDefault: no flag = merged config
 	}
 	args = append(args, "--get", key)
-	cmd := exec.Command("git", args...)
-	output, err := cmd.Output()
+	output, err := gitCommand("", args...).Output()
 	if err != nil {
 		return "", fmt.Errorf("failed to get git config %s: %w", key, err)
 	}
@@ -230,9 +221,7 @@ func SetConfigWithScope(key, value string, scope ConfigScope, filePath string) e
 		// ConfigScopeDefault: no flag = local (git's default for writes)
 	}
 	args = append(args, key, value)
-	cmd := exec.Command("git", args...)
-	_, err := cmd.Output()
-	if err != nil {
+	if _, err := gitCommand("", args...).Output(); err != nil {
 		return fmt.Errorf("failed to set git config %s: %w", key, err)
 	}
 	return nil
@@ -253,22 +242,20 @@ func UnsetConfigWithScope(key string, scope ConfigScope, filePath string) error 
 		// ConfigScopeDefault: no flag = local (git's default for writes)
 	}
 	args = append(args, "--unset", key)
-	cmd := exec.Command("git", args...)
-	_, err := cmd.Output()
-	if err != nil {
+	if _, err := gitCommand("", args...).Output(); err != nil {
 		return fmt.Errorf("failed to unset git config %s: %w", key, err)
 	}
 	return nil
 }
 
 // GetBaseBranch returns the stored base branch for a topic branch
-func GetBaseBranch(branchName string) (string, error) {
+func (r *Repo) GetBaseBranch(branchName string) (string, error) {
 	configKey := fmt.Sprintf("gitflow.branch.%s.base", branchName)
-	return GetConfig(configKey)
+	return r.GetConfig(configKey)
 }
 
 // SetBaseBranch stores the base branch for a topic branch
-func SetBaseBranch(branchName, baseBranch string) error {
+func (r *Repo) SetBaseBranch(branchName, baseBranch string) error {
 	configKey := fmt.Sprintf("gitflow.branch.%s.base", branchName)
-	return SetConfig(configKey, baseBranch)
+	return r.SetConfig(configKey, baseBranch)
 }

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -32,29 +32,95 @@ const (
 	SyncStatusNoTracking BranchSyncStatus = "no_tracking"
 )
 
-// IsGitRepo checks if the current directory is a Git repository
-func IsGitRepo() bool {
-	cmd := exec.Command("git", "rev-parse", "--is-inside-work-tree")
-	err := cmd.Run()
-	return err == nil
+// gitCommand is the single command factory for the git package. It is the only
+// place git is invoked, so every repo-bound operation runs with a deterministic
+// working directory instead of the process CWD. Pass dir="" for the rare
+// repository-less invocations (explicit --global/--system/--file config scopes)
+// that must not bind to a work tree.
+func gitCommand(dir string, args ...string) *exec.Cmd {
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	return cmd
 }
 
-// GetGitDir returns the path to the git directory for the current repository.
-// For regular repositories, this returns ".git".
-// For worktrees, this returns the actual git directory path (e.g., "/repo/.git/worktrees/work1").
-func GetGitDir() (string, error) {
-	cmd := exec.Command("git", "rev-parse", "--git-dir")
-	output, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("failed to get git directory: %w", err)
+// Repo is a handle to a specific git repository resolved to absolute paths. All
+// repo-bound operations are methods on *Repo and run with the work tree as their
+// working directory, so they never depend on the process CWD.
+type Repo struct {
+	workTree     string // absolute path to the work-tree root
+	gitDir       string // absolute path to this working tree's git dir
+	commonGitDir string // absolute path to the shared (common) git dir
+}
+
+// WorkTree returns the absolute path to the repository's work-tree root.
+func (r *Repo) WorkTree() string { return r.workTree }
+
+// GitDir returns the absolute path to this working tree's git directory. For a
+// linked worktree this is the per-worktree dir (<common>/worktrees/<name>).
+func (r *Repo) GitDir() string { return r.gitDir }
+
+// CommonGitDir returns the absolute path to the repository's common git
+// directory (the main .git), shared across linked worktrees.
+func (r *Repo) CommonGitDir() string { return r.commonGitDir }
+
+// gitCmd builds a git command bound to this repository's work tree.
+func (r *Repo) gitCmd(args ...string) *exec.Cmd {
+	return gitCommand(r.workTree, args...)
+}
+
+// Open resolves dir to a git repository and returns a handle carrying absolute
+// work-tree, git-dir, and common-git-dir paths. It errors on an empty dir or a
+// directory that is not inside a git work tree; it never falls back to the
+// process working directory.
+func Open(dir string) (*Repo, error) {
+	if strings.TrimSpace(dir) == "" {
+		return nil, fmt.Errorf("git.Open: directory must not be empty")
 	}
-	return strings.TrimSpace(string(output)), nil
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, fmt.Errorf("git.Open: resolve %q: %w", dir, err)
+	}
+	if info, err := os.Stat(abs); err != nil || !info.IsDir() {
+		return nil, fmt.Errorf("git.Open: %q is not an accessible directory", dir)
+	}
+
+	run := func(args ...string) (string, error) {
+		out, err := gitCommand(abs, args...).Output()
+		return strings.TrimSpace(string(out)), err
+	}
+
+	workTree, err := run("rev-parse", "--show-toplevel")
+	if err != nil {
+		return nil, fmt.Errorf("git.Open: %q is not inside a git work tree: %w", dir, err)
+	}
+	gitDir, err := run("rev-parse", "--absolute-git-dir")
+	if err != nil {
+		return nil, fmt.Errorf("git.Open: resolve git dir for %q: %w", dir, err)
+	}
+	commonRaw, err := run("rev-parse", "--git-common-dir")
+	if err != nil {
+		return nil, fmt.Errorf("git.Open: resolve common git dir for %q: %w", dir, err)
+	}
+
+	commonGitDir := commonRaw
+	if !filepath.IsAbs(commonGitDir) {
+		// --git-common-dir may be relative to the directory git ran in (abs).
+		commonGitDir = filepath.Join(abs, commonGitDir)
+	}
+
+	return &Repo{
+		workTree:     filepath.Clean(workTree),
+		gitDir:       filepath.Clean(gitDir),
+		commonGitDir: filepath.Clean(commonGitDir),
+	}, nil
 }
 
 // GetCurrentBranch returns the current Git branch
-func GetCurrentBranch() (string, error) {
+func (r *Repo) GetCurrentBranch() (string, error) {
 	// Check if we have any commits
-	hasCommits, err := HasCommits()
+	hasCommits, err := r.HasCommits()
 	if err != nil {
 		return "", fmt.Errorf("failed to check if repository has commits: %w", err)
 	}
@@ -64,8 +130,7 @@ func GetCurrentBranch() (string, error) {
 		return "", nil
 	}
 
-	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
-	output, err := cmd.Output()
+	output, err := r.gitCmd("rev-parse", "--abbrev-ref", "HEAD").Output()
 	if err != nil {
 		return "", fmt.Errorf("failed to get current branch: %w", err)
 	}
@@ -73,35 +138,32 @@ func GetCurrentBranch() (string, error) {
 }
 
 // BranchExists checks if a branch exists
-func BranchExists(branch string) error {
-	cmd := exec.Command("git", "rev-parse", "--verify", "--quiet", "refs/heads/"+branch)
-	if err := cmd.Run(); err != nil {
+func (r *Repo) BranchExists(branch string) error {
+	if err := r.gitCmd("rev-parse", "--verify", "--quiet", "refs/heads/"+branch).Run(); err != nil {
 		return fmt.Errorf("branch '%s' does not exist", branch)
 	}
 	return nil
 }
 
 // BranchOrCommitExists checks if a branch, tag, or commit exists
-func BranchOrCommitExists(ref string) error {
-	cmd := exec.Command("git", "rev-parse", "--verify", "--quiet", ref)
-	if err := cmd.Run(); err != nil {
+func (r *Repo) BranchOrCommitExists(ref string) error {
+	if err := r.gitCmd("rev-parse", "--verify", "--quiet", ref).Run(); err != nil {
 		return fmt.Errorf("reference '%s' does not exist", ref)
 	}
 	return nil
 }
 
 // CreateBranch creates a new branch
-func CreateBranch(name string, startPoint string) error {
+func (r *Repo) CreateBranch(name string, startPoint string) error {
 	// Check if we have any commits
-	hasCommits, err := HasCommits()
+	hasCommits, err := r.HasCommits()
 	if err != nil {
 		return fmt.Errorf("failed to check if repository has commits: %w", err)
 	}
 
 	if !hasCommits {
 		// If no commits, create an initial commit first
-		err = CreateInitialCommit(name)
-		if err != nil {
+		if err := r.CreateInitialCommit(name); err != nil {
 			return fmt.Errorf("failed to create initial commit: %w", err)
 		}
 		return nil
@@ -109,40 +171,35 @@ func CreateBranch(name string, startPoint string) error {
 
 	// If startPoint is empty, use the current branch
 	if startPoint == "" {
-		currentBranch, err := GetCurrentBranch()
+		currentBranch, err := r.GetCurrentBranch()
 		if err != nil {
 			return fmt.Errorf("failed to get current branch: %w", err)
 		}
 		startPoint = currentBranch
 	}
 
-	cmd := exec.Command("git", "checkout", "-b", name, startPoint)
-	_, err = cmd.Output()
-	if err != nil {
+	if _, err := r.gitCmd("checkout", "-b", name, startPoint).Output(); err != nil {
 		return fmt.Errorf("failed to create branch: %w", err)
 	}
 	return nil
 }
 
 // Checkout checks out a branch
-func Checkout(branch string) error {
-	cmd := exec.Command("git", "checkout", branch)
-	_, err := cmd.Output()
-	if err != nil {
+func (r *Repo) Checkout(branch string) error {
+	if _, err := r.gitCmd("checkout", branch).Output(); err != nil {
 		return fmt.Errorf("failed to checkout branch: %w", err)
 	}
 	return nil
 }
 
 // DeleteBranch deletes a branch
-func DeleteBranch(branch string, force bool) error {
+func (r *Repo) DeleteBranch(branch string, force bool) error {
 	flag := "-d"
 	if force {
 		flag = "-D"
 	}
 
-	cmd := exec.Command("git", "branch", flag, branch)
-	output, err := cmd.CombinedOutput()
+	output, err := r.gitCmd("branch", flag, branch).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to delete branch: %s", string(output))
 	}
@@ -150,10 +207,8 @@ func DeleteBranch(branch string, force bool) error {
 }
 
 // HasCommits checks if the repository has any commits
-func HasCommits() (bool, error) {
-	cmd := exec.Command("git", "rev-parse", "--verify", "HEAD")
-	err := cmd.Run()
-	if err != nil {
+func (r *Repo) HasCommits() (bool, error) {
+	if err := r.gitCmd("rev-parse", "--verify", "HEAD").Run(); err != nil {
 		// If error, there are no commits
 		return false, nil
 	}
@@ -161,18 +216,14 @@ func HasCommits() (bool, error) {
 }
 
 // CreateInitialCommit creates an initial commit and branch
-func CreateInitialCommit(branch string) error {
+func (r *Repo) CreateInitialCommit(branch string) error {
 	// Create an empty initial commit
-	cmd := exec.Command("git", "commit", "--allow-empty", "-m", "Initial commit")
-	_, err := cmd.Output()
-	if err != nil {
+	if _, err := r.gitCmd("commit", "--allow-empty", "-m", "Initial commit").Output(); err != nil {
 		return fmt.Errorf("failed to create initial commit: %w", err)
 	}
 
 	// Rename the default branch to the target name
-	cmd = exec.Command("git", "branch", "-m", branch)
-	_, err = cmd.Output()
-	if err != nil {
+	if _, err := r.gitCmd("branch", "-m", branch).Output(); err != nil {
 		return fmt.Errorf("failed to rename branch to %s: %w", branch, err)
 	}
 
@@ -180,22 +231,20 @@ func CreateInitialCommit(branch string) error {
 }
 
 // Merge merges a branch into the current branch
-func Merge(branch string, noVerify bool) error {
+func (r *Repo) Merge(branch string, noVerify bool) error {
 	args := []string{"merge", "--no-ff"}
 	if noVerify {
 		args = append(args, "--no-verify")
 	}
 	args = append(args, branch)
 
-	cmd := exec.Command("git", args...)
-	output, err := cmd.CombinedOutput()
+	output, err := r.gitCmd(args...).CombinedOutput()
 	outputStr := string(output)
 
 	// Check for merge conflicts - Git returns exit code 1 and specific output patterns
 	if err != nil {
 		// Check if there are unmerged paths (conflicts)
-		conflictCmd := exec.Command("git", "ls-files", "--unmerged")
-		conflictOutput, _ := conflictCmd.Output()
+		conflictOutput, _ := r.gitCmd("ls-files", "--unmerged").Output()
 
 		if len(conflictOutput) > 0 ||
 			strings.Contains(outputStr, "Automatic merge failed") ||
@@ -211,9 +260,8 @@ func Merge(branch string, noVerify bool) error {
 }
 
 // Rebase rebases the current branch onto another branch
-func Rebase(branch string) error {
-	cmd := exec.Command("git", "rebase", branch)
-	output, err := cmd.CombinedOutput()
+func (r *Repo) Rebase(branch string) error {
+	output, err := r.gitCmd("rebase", branch).CombinedOutput()
 	if err != nil {
 		if strings.Contains(string(output), "conflict") {
 			return fmt.Errorf("rebase conflict: %s", string(output))
@@ -224,15 +272,14 @@ func Rebase(branch string) error {
 }
 
 // SquashMerge performs a squash merge of a branch into the current branch
-func SquashMerge(branch string, noVerify bool) error {
+func (r *Repo) SquashMerge(branch string, noVerify bool) error {
 	args := []string{"merge", "--squash"}
 	if noVerify {
 		args = append(args, "--no-verify")
 	}
 	args = append(args, branch)
 
-	cmd := exec.Command("git", args...)
-	output, err := cmd.CombinedOutput()
+	output, err := r.gitCmd(args...).CombinedOutput()
 	if err != nil {
 		if strings.Contains(string(output), "conflict") {
 			return fmt.Errorf("squash merge conflict: %s", string(output))
@@ -245,8 +292,7 @@ func SquashMerge(branch string, noVerify bool) error {
 	if noVerify {
 		commitArgs = append(commitArgs, "--no-verify")
 	}
-	cmd = exec.Command("git", commitArgs...)
-	output, err = cmd.CombinedOutput()
+	output, err = r.gitCmd(commitArgs...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to commit squashed changes: %s", string(output))
 	}
@@ -255,14 +301,12 @@ func SquashMerge(branch string, noVerify bool) error {
 }
 
 // ListBranches returns a list of all branches in the repository
-func ListBranches() ([]string, error) {
-	cmd := exec.Command("git", "branch", "--format=%(refname:short)")
-	output, err := cmd.Output()
+func (r *Repo) ListBranches() ([]string, error) {
+	output, err := r.gitCmd("branch", "--format=%(refname:short)").Output()
 	if err != nil {
 		return nil, fmt.Errorf("failed to list branches: %w", err)
 	}
 
-	// Split the output by newlines and remove empty lines
 	branches := []string{}
 	for _, branch := range strings.Split(string(output), "\n") {
 		if branch != "" {
@@ -274,10 +318,8 @@ func ListBranches() ([]string, error) {
 }
 
 // HasConflicts checks if there are unresolved conflicts
-func HasConflicts() bool {
-	// Check for unmerged paths
-	cmd := exec.Command("git", "diff", "--name-only", "--diff-filter=U")
-	output, err := cmd.Output()
+func (r *Repo) HasConflicts() bool {
+	output, err := r.gitCmd("diff", "--name-only", "--diff-filter=U").Output()
 	if err != nil {
 		return false
 	}
@@ -285,26 +327,18 @@ func HasConflicts() bool {
 }
 
 // IsGitMergeInProgress checks if git is in a merge state by looking for MERGE_HEAD
-func IsGitMergeInProgress() bool {
-	gitDir, err := GetGitDir()
-	if err != nil {
-		return false
-	}
-	_, err = os.Stat(filepath.Join(gitDir, "MERGE_HEAD"))
+func (r *Repo) IsGitMergeInProgress() bool {
+	_, err := os.Stat(filepath.Join(r.gitDir, "MERGE_HEAD"))
 	return err == nil
 }
 
 // IsGitRebaseInProgress checks if git is in a rebase state by looking for
 // rebase-merge/ (merge backend, including interactive) or rebase-apply/ (legacy apply backend)
-func IsGitRebaseInProgress() bool {
-	gitDir, err := GetGitDir()
-	if err != nil {
-		return false
-	}
-	if _, err := os.Stat(filepath.Join(gitDir, "rebase-merge")); err == nil {
+func (r *Repo) IsGitRebaseInProgress() bool {
+	if _, err := os.Stat(filepath.Join(r.gitDir, "rebase-merge")); err == nil {
 		return true
 	}
-	if _, err := os.Stat(filepath.Join(gitDir, "rebase-apply")); err == nil {
+	if _, err := os.Stat(filepath.Join(r.gitDir, "rebase-apply")); err == nil {
 		return true
 	}
 	return false
@@ -313,34 +347,28 @@ func IsGitRebaseInProgress() bool {
 // IsGitSquashMergeInProgress checks if git is in a squash merge state.
 // Squash merges create SQUASH_MSG but not MERGE_HEAD. However, SQUASH_MSG also
 // appears during interactive rebase squash steps, so we exclude that case.
-func IsGitSquashMergeInProgress() bool {
-	gitDir, err := GetGitDir()
-	if err != nil {
-		return false
-	}
-	if _, err := os.Stat(filepath.Join(gitDir, "SQUASH_MSG")); err != nil {
+func (r *Repo) IsGitSquashMergeInProgress() bool {
+	if _, err := os.Stat(filepath.Join(r.gitDir, "SQUASH_MSG")); err != nil {
 		return false
 	}
 	// Exclude interactive rebase squash steps
-	if _, err := os.Stat(filepath.Join(gitDir, "rebase-merge")); err == nil {
+	if _, err := os.Stat(filepath.Join(r.gitDir, "rebase-merge")); err == nil {
 		return false
 	}
 	return true
 }
 
 // MergeAbort aborts the current merge
-func MergeAbort() error {
-	cmd := exec.Command("git", "merge", "--abort")
-	if err := cmd.Run(); err != nil {
+func (r *Repo) MergeAbort() error {
+	if err := r.gitCmd("merge", "--abort").Run(); err != nil {
 		return fmt.Errorf("failed to abort merge: %w", err)
 	}
 	return nil
 }
 
 // RebaseAbort aborts the current rebase
-func RebaseAbort() error {
-	cmd := exec.Command("git", "rebase", "--abort")
-	output, err := cmd.CombinedOutput()
+func (r *Repo) RebaseAbort() error {
+	output, err := r.gitCmd("rebase", "--abort").CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to abort rebase: %s", string(output))
 	}
@@ -349,8 +377,8 @@ func RebaseAbort() error {
 
 // RenameBranch renames a branch. If oldBranch is provided, it renames that branch to newBranch.
 // If oldBranch is not provided, it renames the current branch to newBranch.
-func RenameBranch(oldBranch, newBranch string) error {
-	return renameBranch(oldBranch, newBranch, false)
+func (r *Repo) RenameBranch(oldBranch, newBranch string) error {
+	return r.renameBranch(oldBranch, newBranch, false)
 }
 
 // RenameBranchForce renames a Git branch using the force flag (-M). This is
@@ -358,19 +386,17 @@ func RenameBranch(oldBranch, newBranch string) error {
 // destination name folds to the same existing ref and the non-forcing -m
 // refuses with "a branch named '…' already exists". Callers must confirm the
 // rename does not clobber a genuinely different branch before forcing.
-func RenameBranchForce(oldBranch, newBranch string) error {
-	return renameBranch(oldBranch, newBranch, true)
+func (r *Repo) RenameBranchForce(oldBranch, newBranch string) error {
+	return r.renameBranch(oldBranch, newBranch, true)
 }
 
-func renameBranch(oldBranch, newBranch string, force bool) error {
+func (r *Repo) renameBranch(oldBranch, newBranch string, force bool) error {
 	flag := "-m"
 	if force {
 		flag = "-M"
 	}
-	args := []string{"branch", flag, oldBranch, newBranch}
 
-	cmd := exec.Command("git", args...)
-	output, err := cmd.CombinedOutput()
+	output, err := r.gitCmd("branch", flag, oldBranch, newBranch).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to rename branch: %s", strings.TrimSpace(string(output)))
 	}
@@ -378,9 +404,8 @@ func renameBranch(oldBranch, newBranch string, force bool) error {
 }
 
 // Fetch performs a git fetch from the specified remote
-func Fetch(remote string) error {
-	cmd := exec.Command("git", "fetch", remote)
-	output, err := cmd.CombinedOutput()
+func (r *Repo) Fetch(remote string) error {
+	output, err := r.gitCmd("fetch", remote).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to fetch from remote '%s': %s", remote, string(output))
 	}
@@ -388,9 +413,8 @@ func Fetch(remote string) error {
 }
 
 // DeleteRemoteBranch deletes a branch from a remote repository
-func DeleteRemoteBranch(remote, branch string) error {
-	cmd := exec.Command("git", "push", remote, ":"+branch)
-	output, err := cmd.CombinedOutput()
+func (r *Repo) DeleteRemoteBranch(remote, branch string) error {
+	output, err := r.gitCmd("push", remote, ":"+branch).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to delete remote branch: %s", string(output))
 	}
@@ -399,17 +423,14 @@ func DeleteRemoteBranch(remote, branch string) error {
 
 // RemoteExists checks if a remote is configured in the local git config.
 // This is a local-only check (no network call).
-func RemoteExists(remote string) bool {
-	cmd := exec.Command("git", "remote", "get-url", remote)
-	return cmd.Run() == nil
+func (r *Repo) RemoteExists(remote string) bool {
+	return r.gitCmd("remote", "get-url", remote).Run() == nil
 }
 
 // RemoteBranchExists checks if a remote branch exists
-func RemoteBranchExists(remote, branch string) bool {
-	// Check if the remote tracking branch exists
+func (r *Repo) RemoteBranchExists(remote, branch string) bool {
 	ref := fmt.Sprintf("refs/remotes/%s/%s", remote, branch)
-	cmd := exec.Command("git", "rev-parse", "--verify", "--quiet", ref)
-	return cmd.Run() == nil
+	return r.gitCmd("rev-parse", "--verify", "--quiet", ref).Run() == nil
 }
 
 // TagOptions contains options for tag creation
@@ -421,10 +442,9 @@ type TagOptions struct {
 }
 
 // CreateTag creates a Git tag with the specified options
-func CreateTag(tagName string, options *TagOptions) error {
+func (r *Repo) CreateTag(tagName string, options *TagOptions) error {
 	// Check if tag already exists
-	cmd := exec.Command("git", "show-ref", "--tags", tagName)
-	if err := cmd.Run(); err == nil {
+	if err := r.gitCmd("show-ref", "--tags", tagName).Run(); err == nil {
 		// Tag already exists, skip creation
 		return nil
 	}
@@ -458,9 +478,7 @@ func CreateTag(tagName string, options *TagOptions) error {
 		return fmt.Errorf("tag message is required for annotated tags")
 	}
 
-	// Execute tag command
-	cmd = exec.Command("git", args...)
-	output, err := cmd.CombinedOutput()
+	output, err := r.gitCmd(args...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to create tag '%s': %w (output: %s)", tagName, err, string(output))
 	}
@@ -469,15 +487,14 @@ func CreateTag(tagName string, options *TagOptions) error {
 }
 
 // RebaseWithOptions rebases the current branch onto another branch with optional preserve-merges
-func RebaseWithOptions(targetBranch string, preserveMerges bool) error {
+func (r *Repo) RebaseWithOptions(targetBranch string, preserveMerges bool) error {
 	args := []string{"rebase"}
 	if preserveMerges {
 		args = append(args, "--preserve-merges")
 	}
 	args = append(args, targetBranch)
 
-	cmd := exec.Command("git", args...)
-	output, err := cmd.CombinedOutput()
+	output, err := r.gitCmd(args...).CombinedOutput()
 	if err != nil {
 		if strings.Contains(string(output), "conflict") {
 			return fmt.Errorf("rebase conflict: %s", string(output))
@@ -489,9 +506,8 @@ func RebaseWithOptions(targetBranch string, preserveMerges bool) error {
 
 // MergeFFOnly attempts a fast-forward-only merge of the given branch into the current branch.
 // Returns an error if the merge cannot be fast-forwarded.
-func MergeFFOnly(branch string) error {
-	cmd := exec.Command("git", "merge", "--ff-only", branch)
-	output, err := cmd.CombinedOutput()
+func (r *Repo) MergeFFOnly(branch string) error {
+	output, err := r.gitCmd("merge", "--ff-only", branch).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("fast-forward merge of %q failed: %w: %s", branch, err, strings.TrimSpace(string(output)))
 	}
@@ -499,7 +515,7 @@ func MergeFFOnly(branch string) error {
 }
 
 // MergeWithOptions merges a branch into current branch with optional no-fast-forward
-func MergeWithOptions(branchName string, noFF bool, noVerify bool) error {
+func (r *Repo) MergeWithOptions(branchName string, noFF bool, noVerify bool) error {
 	args := []string{"merge"}
 	if noFF {
 		args = append(args, "--no-ff")
@@ -509,15 +525,11 @@ func MergeWithOptions(branchName string, noFF bool, noVerify bool) error {
 	}
 	args = append(args, branchName)
 
-	cmd := exec.Command("git", args...)
-	output, err := cmd.CombinedOutput()
+	output, err := r.gitCmd(args...).CombinedOutput()
 	outputStr := string(output)
 
-	// Check for merge conflicts - Git returns exit code 1 and specific output patterns
 	if err != nil {
-		// Check if there are unmerged paths (conflicts)
-		conflictCmd := exec.Command("git", "ls-files", "--unmerged")
-		conflictOutput, _ := conflictCmd.Output()
+		conflictOutput, _ := r.gitCmd("ls-files", "--unmerged").Output()
 
 		if len(conflictOutput) > 0 ||
 			strings.Contains(outputStr, "Automatic merge failed") ||
@@ -533,7 +545,7 @@ func MergeWithOptions(branchName string, noFF bool, noVerify bool) error {
 }
 
 // MergeWithMessage merges a branch into current branch with a custom commit message
-func MergeWithMessage(branchName string, message string, noFF bool, noVerify bool) error {
+func (r *Repo) MergeWithMessage(branchName string, message string, noFF bool, noVerify bool) error {
 	args := []string{"merge"}
 	if noFF {
 		args = append(args, "--no-ff")
@@ -543,15 +555,11 @@ func MergeWithMessage(branchName string, message string, noFF bool, noVerify boo
 	}
 	args = append(args, "-m", message, branchName)
 
-	cmd := exec.Command("git", args...)
-	output, err := cmd.CombinedOutput()
+	output, err := r.gitCmd(args...).CombinedOutput()
 	outputStr := string(output)
 
-	// Check for merge conflicts - Git returns exit code 1 and specific output patterns
 	if err != nil {
-		// Check if there are unmerged paths (conflicts)
-		conflictCmd := exec.Command("git", "ls-files", "--unmerged")
-		conflictOutput, _ := conflictCmd.Output()
+		conflictOutput, _ := r.gitCmd("ls-files", "--unmerged").Output()
 
 		if len(conflictOutput) > 0 ||
 			strings.Contains(outputStr, "Automatic merge failed") ||
@@ -567,13 +575,12 @@ func MergeWithMessage(branchName string, message string, noFF bool, noVerify boo
 }
 
 // Commit creates a commit with the given message
-func Commit(message string, noVerify bool) error {
+func (r *Repo) Commit(message string, noVerify bool) error {
 	args := []string{"commit", "-m", message}
 	if noVerify {
 		args = append(args, "--no-verify")
 	}
-	cmd := exec.Command("git", args...)
-	output, err := cmd.CombinedOutput()
+	output, err := r.gitCmd(args...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to commit: %s", string(output))
 	}
@@ -581,9 +588,8 @@ func Commit(message string, noVerify bool) error {
 }
 
 // RebaseContinue continues an ongoing rebase operation after conflicts are resolved
-func RebaseContinue() error {
-	cmd := exec.Command("git", "rebase", "--continue")
-	output, err := cmd.CombinedOutput()
+func (r *Repo) RebaseContinue() error {
+	output, err := r.gitCmd("rebase", "--continue").CombinedOutput()
 	outputStr := string(output)
 	if err != nil {
 		if strings.Contains(outputStr, "No rebase in progress") {
@@ -599,15 +605,14 @@ func RebaseContinue() error {
 }
 
 // MergeSquashWithMessage performs a squash merge with a custom commit message
-func MergeSquashWithMessage(branchName string, message string, noVerify bool) error {
+func (r *Repo) MergeSquashWithMessage(branchName string, message string, noVerify bool) error {
 	args := []string{"merge", "--squash"}
 	if noVerify {
 		args = append(args, "--no-verify")
 	}
 	args = append(args, branchName)
 
-	cmd := exec.Command("git", args...)
-	output, err := cmd.CombinedOutput()
+	output, err := r.gitCmd(args...).CombinedOutput()
 	if err != nil {
 		if strings.Contains(string(output), "conflict") {
 			return fmt.Errorf("squash merge conflict: %s", string(output))
@@ -620,8 +625,7 @@ func MergeSquashWithMessage(branchName string, message string, noVerify bool) er
 	if noVerify {
 		commitArgs = append(commitArgs, "--no-verify")
 	}
-	cmd = exec.Command("git", commitArgs...)
-	output, err = cmd.CombinedOutput()
+	output, err = r.gitCmd(commitArgs...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to commit squashed changes: %s", string(output))
 	}
@@ -630,7 +634,7 @@ func MergeSquashWithMessage(branchName string, message string, noVerify bool) er
 }
 
 // PushBranch pushes a local branch to a remote and sets up tracking
-func PushBranch(remote, branch string, pushOptions []string) error {
+func (r *Repo) PushBranch(remote, branch string, pushOptions []string) error {
 	args := []string{"push", "-u", remote}
 
 	for _, opt := range pushOptions {
@@ -639,8 +643,7 @@ func PushBranch(remote, branch string, pushOptions []string) error {
 
 	args = append(args, branch)
 
-	cmd := exec.Command("git", args...)
-	output, err := cmd.CombinedOutput()
+	output, err := r.gitCmd(args...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to push branch '%s' to '%s': %s", branch, remote, strings.TrimSpace(string(output)))
 	}
@@ -652,9 +655,8 @@ func PushBranch(remote, branch string, pushOptions []string) error {
 // avoids rewriting tracking config. On failure it returns a wrapped error that
 // embeds the underlying error and the trimmed combined output, so a rejected
 // (non-fast-forward) push surfaces to the caller.
-func PushRef(remote, branch string) error {
-	cmd := exec.Command("git", "push", remote, branch)
-	output, err := cmd.CombinedOutput()
+func (r *Repo) PushRef(remote, branch string) error {
+	output, err := r.gitCmd("push", remote, branch).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to push branch '%s' to '%s': %w (output: %s)", branch, remote, err, strings.TrimSpace(string(output)))
 	}
@@ -664,9 +666,8 @@ func PushRef(remote, branch string) error {
 // PushTag pushes a single tag to a remote with `git push <remote> tag <tag>`.
 // On failure it returns a wrapped error that embeds the underlying error and the
 // trimmed combined output.
-func PushTag(remote, tag string) error {
-	cmd := exec.Command("git", "push", remote, "tag", tag)
-	output, err := cmd.CombinedOutput()
+func (r *Repo) PushTag(remote, tag string) error {
+	output, err := r.gitCmd("push", remote, "tag", tag).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to push tag '%s' to '%s': %w (output: %s)", tag, remote, err, strings.TrimSpace(string(output)))
 	}
@@ -674,11 +675,9 @@ func PushTag(remote, tag string) error {
 }
 
 // CreateTrackingBranch creates a local branch that tracks a remote branch
-func CreateTrackingBranch(localBranch, remote, remoteBranch string) error {
-	// git checkout -b <local> --track <remote>/<branch>
-	cmd := exec.Command("git", "checkout", "-b", localBranch, "--track",
-		fmt.Sprintf("%s/%s", remote, remoteBranch))
-	output, err := cmd.CombinedOutput()
+func (r *Repo) CreateTrackingBranch(localBranch, remote, remoteBranch string) error {
+	output, err := r.gitCmd("checkout", "-b", localBranch, "--track",
+		fmt.Sprintf("%s/%s", remote, remoteBranch)).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to create tracking branch: %s", string(output))
 	}
@@ -688,11 +687,9 @@ func CreateTrackingBranch(localBranch, remote, remoteBranch string) error {
 // GetTrackingBranch returns the remote tracking branch for a local branch.
 // Returns the full tracking reference (e.g., "origin/feature/foo") or an error
 // if no tracking branch is configured.
-func GetTrackingBranch(branch string) (string, error) {
-	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", branch+"@{upstream}")
-	output, err := cmd.CombinedOutput()
+func (r *Repo) GetTrackingBranch(branch string) (string, error) {
+	output, err := r.gitCmd("rev-parse", "--abbrev-ref", branch+"@{upstream}").CombinedOutput()
 	if err != nil {
-		// Check if the error is because there's no tracking branch
 		outputStr := string(output)
 		if strings.Contains(outputStr, "no upstream") || strings.Contains(outputStr, "does not track") {
 			return "", fmt.Errorf("branch '%s' has no upstream tracking branch", branch)
@@ -707,22 +704,17 @@ func GetTrackingBranch(branch string) (string, error) {
 // For SyncStatusAhead, the count is commits ahead.
 // For SyncStatusBehind, the count is commits behind.
 // For SyncStatusDiverged, the count is total commits different (ahead + behind).
-func CompareBranchWithRemote(branch string) (BranchSyncStatus, int, error) {
-	// First get the tracking branch
-	trackingBranch, err := GetTrackingBranch(branch)
+func (r *Repo) CompareBranchWithRemote(branch string) (BranchSyncStatus, int, error) {
+	trackingBranch, err := r.GetTrackingBranch(branch)
 	if err != nil {
 		return SyncStatusNoTracking, 0, err
 	}
 
-	// Use git rev-list to count commits ahead and behind
-	// Format: <ahead>\t<behind>
-	cmd := exec.Command("git", "rev-list", "--left-right", "--count", branch+"..."+trackingBranch)
-	output, err := cmd.CombinedOutput()
+	output, err := r.gitCmd("rev-list", "--left-right", "--count", branch+"..."+trackingBranch).CombinedOutput()
 	if err != nil {
 		return "", 0, fmt.Errorf("failed to compare branches: %s", string(output))
 	}
 
-	// Parse the output (format: "ahead\tbehind")
 	parts := strings.Fields(strings.TrimSpace(string(output)))
 	if len(parts) != 2 {
 		return "", 0, fmt.Errorf("unexpected output format from rev-list: %s", string(output))
@@ -738,7 +730,6 @@ func CompareBranchWithRemote(branch string) (BranchSyncStatus, int, error) {
 		return "", 0, fmt.Errorf("failed to parse behind count: %w", err)
 	}
 
-	// Determine status based on ahead/behind counts
 	switch {
 	case ahead == 0 && behind == 0:
 		return SyncStatusEqual, 0, nil
@@ -759,8 +750,8 @@ func CompareBranchWithRemote(branch string) (BranchSyncStatus, int, error) {
 //     sentinel ErrRemoteRefNotFound (check with errors.Is).
 //   - Any other non-zero exit (transport/auth failure) returns a fatal error carrying the
 //     trimmed stderr.
-func FetchBranch(remote, branch string) error {
-	cmd := exec.Command("git", "fetch", remote, branch)
+func (r *Repo) FetchBranch(remote, branch string) error {
+	cmd := r.gitCmd("fetch", remote, branch)
 	// Pin the locale so isRemoteRefNotFound classifies stderr against git's English phrasing,
 	// regardless of the user's LANG/LC_* settings. A localized "missing ref" message would
 	// otherwise be misclassified as a fatal transport failure.
@@ -769,8 +760,6 @@ func FetchBranch(remote, branch string) error {
 	if err != nil {
 		stderr := strings.TrimSpace(string(output))
 		if isRemoteRefNotFound(stderr) {
-			// Join the benign sentinel with the underlying exec error so callers can classify via
-			// errors.Is(ErrRemoteRefNotFound) while the original error stays available for diagnostics.
 			return fmt.Errorf("fetch branch '%s' from '%s': %s: %w", branch, remote, stderr, errors.Join(ErrRemoteRefNotFound, err))
 		}
 		return fmt.Errorf("failed to fetch branch '%s' from '%s': %s: %w", branch, remote, stderr, err)
@@ -790,8 +779,8 @@ func isRemoteRefNotFound(stderr string) bool {
 
 // HasTrackingBranch reports whether the given local branch has a remote tracking branch
 // configured. It is a thin wrapper over GetTrackingBranch that returns false on any error.
-func HasTrackingBranch(branch string) bool {
-	_, err := GetTrackingBranch(branch)
+func (r *Repo) HasTrackingBranch(branch string) bool {
+	_, err := r.GetTrackingBranch(branch)
 	return err == nil
 }
 
@@ -799,12 +788,9 @@ func HasTrackingBranch(branch string) bool {
 // from the local repository. It is used to prune a tracking ref once the corresponding remote
 // branch is found to be gone. Errors are returned so callers may log them, but they are safe to
 // ignore (the ref may already be absent).
-func DeleteRemoteTrackingRef(remote, branch string) error {
+func (r *Repo) DeleteRemoteTrackingRef(remote, branch string) error {
 	ref := fmt.Sprintf("refs/remotes/%s/%s", remote, branch)
-	cmd := exec.Command("git", "update-ref", "-d", ref)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		// Wrap the underlying exec error with %w so the exit status stays available for diagnostics,
-		// mirroring FetchBranch's error wrapping, while still surfacing the trimmed git output.
+	if output, err := r.gitCmd("update-ref", "-d", ref).CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to delete remote tracking ref '%s': %s: %w", ref, strings.TrimSpace(string(output)), err)
 	}
 	return nil

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -375,8 +375,9 @@ func (r *Repo) RebaseAbort() error {
 	return nil
 }
 
-// RenameBranch renames a branch. If oldBranch is provided, it renames that branch to newBranch.
-// If oldBranch is not provided, it renames the current branch to newBranch.
+// RenameBranch renames oldBranch to newBranch. Both names are required; there is
+// no rename-current-branch shorthand — pass the resolved current branch name if
+// that is the intent.
 func (r *Repo) RenameBranch(oldBranch, newBranch string) error {
 	return r.renameBranch(oldBranch, newBranch, false)
 }

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -32,11 +32,13 @@ const (
 	SyncStatusNoTracking BranchSyncStatus = "no_tracking"
 )
 
-// gitCommand is the single command factory for the git package. It is the only
-// place git is invoked, so every repo-bound operation runs with a deterministic
-// working directory instead of the process CWD. Pass dir="" for the rare
-// repository-less invocations (explicit --global/--system/--file config scopes)
-// that must not bind to a work tree.
+// gitCommand is the single command factory for the git package: every
+// repo-bound git operation runs through it, so it pins cmd.Dir to a
+// deterministic working directory instead of inheriting the process CWD.
+// (The repository-less refname check in internal/util calls git directly, as
+// it needs no work tree.) Pass dir="" for the rare repository-less invocations
+// (explicit --global/--system/--file config scopes) that must not bind to a
+// work tree.
 func gitCommand(dir string, args ...string) *exec.Cmd {
 	cmd := exec.Command("git", args...)
 	if dir != "" {
@@ -82,8 +84,12 @@ func Open(dir string) (*Repo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("git.Open: resolve %q: %w", dir, err)
 	}
-	if info, err := os.Stat(abs); err != nil || !info.IsDir() {
-		return nil, fmt.Errorf("git.Open: %q is not an accessible directory", dir)
+	info, err := os.Stat(abs)
+	if err != nil {
+		return nil, fmt.Errorf("git.Open: stat %q: %w", abs, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("git.Open: %q is not a directory", abs)
 	}
 
 	run := func(args ...string) (string, error) {

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -34,8 +34,17 @@ func RunPostHook(gitDir string, branchType string, action HookAction, ctx HookCo
 	return runHook(gitDir, HookPost, branchType, action, ctx)
 }
 
-// configLookup is a package-level function variable for testability.
-var configLookup = git.GetConfigInDir
+// configLookup reads a single git config value for the repository rooted at dir.
+// It is a package-level variable for testability. It opens a git.Repo handle so
+// the lookup is bound to that repository's absolute paths rather than the process
+// working directory.
+var configLookup = func(dir, key string) (string, error) {
+	repo, err := git.Open(dir)
+	if err != nil {
+		return "", err
+	}
+	return repo.GetConfig(key)
+}
 
 // resolveHooksPath resolves a hooks path that may be relative to the repository root.
 func resolveHooksPath(hooksPath, repoRoot string) string {

--- a/internal/mergestate/mergestate.go
+++ b/internal/mergestate/mergestate.go
@@ -14,23 +14,15 @@ const (
 	stateFile    = "merge.json"
 )
 
-// getStateDir returns the path to the state directory, resolving the git directory
-// correctly for both regular repos and worktrees.
-func getStateDir() (string, error) {
-	gitDir, err := git.GetGitDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(gitDir, stateDirName), nil
+// getStateDir returns the path to the state directory under the repository's
+// absolute git directory (worktree-aware).
+func getStateDir(repo *git.Repo) string {
+	return filepath.Join(repo.GitDir(), stateDirName)
 }
 
 // getStatePath returns the full path to the state file.
-func getStatePath() (string, error) {
-	stateDir, err := getStateDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(stateDir, stateFile), nil
+func getStatePath(repo *git.Repo) string {
+	return filepath.Join(getStateDir(repo), stateFile)
 }
 
 // MergeState represents the state of a merge operation
@@ -71,12 +63,9 @@ type MergeState struct {
 }
 
 // SaveMergeState saves the current merge state to a file
-func SaveMergeState(state *MergeState) error {
+func SaveMergeState(repo *git.Repo, state *MergeState) error {
 	// Get the state directory path (handles worktrees correctly)
-	stateDir, err := getStateDir()
-	if err != nil {
-		return fmt.Errorf("failed to determine state directory: %w", err)
-	}
+	stateDir := getStateDir(repo)
 
 	// Create state directory if it doesn't exist
 	if err := os.MkdirAll(stateDir, 0755); err != nil {
@@ -99,11 +88,8 @@ func SaveMergeState(state *MergeState) error {
 }
 
 // LoadMergeState loads the current merge state from file
-func LoadMergeState() (*MergeState, error) {
-	statePath, err := getStatePath()
-	if err != nil {
-		return nil, fmt.Errorf("failed to determine state path: %w", err)
-	}
+func LoadMergeState(repo *git.Repo) (*MergeState, error) {
+	statePath := getStatePath(repo)
 
 	data, err := os.ReadFile(statePath)
 	if err != nil {
@@ -122,13 +108,10 @@ func LoadMergeState() (*MergeState, error) {
 }
 
 // ClearMergeState removes the merge state file
-func ClearMergeState() error {
-	statePath, err := getStatePath()
-	if err != nil {
-		return fmt.Errorf("failed to determine state path: %w", err)
-	}
+func ClearMergeState(repo *git.Repo) error {
+	statePath := getStatePath(repo)
 
-	err = os.Remove(statePath)
+	err := os.Remove(statePath)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to remove state file: %w", err)
 	}
@@ -146,7 +129,7 @@ func ClearMergeState() error {
 // guard (refuseIfForeignOperation) reads the raw state directly and refuses an
 // unknown/empty Action before IsMergeInProgress ever runs, so that case never
 // reaches the auto-clear path.
-func isStateValid(state *MergeState) bool {
+func isStateValid(repo *git.Repo, state *MergeState) bool {
 	// Critical fields must be non-empty
 	if state.BranchType == "" || state.FullBranchName == "" || state.CurrentStep == "" {
 		return false
@@ -155,10 +138,10 @@ func isStateValid(state *MergeState) bool {
 	switch state.CurrentStep {
 	case "merge", "update_children":
 		// Git must actually be in a merge, rebase, or squash merge state
-		return git.IsGitMergeInProgress() || git.IsGitRebaseInProgress() || git.IsGitSquashMergeInProgress()
+		return repo.IsGitMergeInProgress() || repo.IsGitRebaseInProgress() || repo.IsGitSquashMergeInProgress()
 	case "create_tag", "delete_branch":
 		// The topic branch must still exist
-		return git.BranchExists(state.FullBranchName) == nil
+		return repo.BranchExists(state.FullBranchName) == nil
 	default:
 		return false
 	}
@@ -167,11 +150,11 @@ func isStateValid(state *MergeState) bool {
 // IsMergeInProgress checks if there's a valid merge in progress. If a state
 // file exists but is stale (e.g., manual resolution, crash, or missing branch),
 // it is automatically cleared and false is returned.
-func IsMergeInProgress() bool {
-	state, err := LoadMergeState()
+func IsMergeInProgress(repo *git.Repo) bool {
+	state, err := LoadMergeState(repo)
 	if err != nil {
 		// Corrupted or unreadable state file — clear it
-		if clearErr := ClearMergeState(); clearErr != nil {
+		if clearErr := ClearMergeState(repo); clearErr != nil {
 			fmt.Fprintf(os.Stderr, "Warning: Failed to clear stale merge state: %v\n", clearErr)
 		} else {
 			fmt.Fprintf(os.Stderr, "Note: Cleared stale merge state from a previous operation\n")
@@ -181,8 +164,8 @@ func IsMergeInProgress() bool {
 	if state == nil {
 		return false
 	}
-	if !isStateValid(state) {
-		if err := ClearMergeState(); err != nil {
+	if !isStateValid(repo, state) {
+		if err := ClearMergeState(repo); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: Failed to clear stale merge state: %v\n", err)
 		} else {
 			fmt.Fprintf(os.Stderr, "Note: Cleared stale merge state from a previous operation\n")

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -11,19 +11,19 @@ import (
 )
 
 // UpdateBranchFromParent updates a branch with changes from its parent branch using the configured strategy
-func UpdateBranchFromParent(branchName string, parentBranch string, strategy string, saveState bool, state *mergestate.MergeState) error {
-	return UpdateBranchFromParentWithMessage(branchName, parentBranch, strategy, "", saveState, state)
+func UpdateBranchFromParent(repo *git.Repo, branchName string, parentBranch string, strategy string, saveState bool, state *mergestate.MergeState) error {
+	return UpdateBranchFromParentWithMessage(repo, branchName, parentBranch, strategy, "", saveState, state)
 }
 
 // UpdateBranchFromParentWithMessage updates a branch with changes from its parent branch using the configured strategy and optional custom message
-func UpdateBranchFromParentWithMessage(branchName string, parentBranch string, strategy string, customMessage string, saveState bool, state *mergestate.MergeState) error {
+func UpdateBranchFromParentWithMessage(repo *git.Repo, branchName string, parentBranch string, strategy string, customMessage string, saveState bool, state *mergestate.MergeState) error {
 	// Checkout the branch if needed
-	currentBranch, err := git.GetCurrentBranch()
+	currentBranch, err := repo.GetCurrentBranch()
 	if err != nil {
 		return &errors.GitError{Operation: "get current branch", Err: err}
 	}
 	if currentBranch != branchName {
-		if err := git.Checkout(branchName); err != nil {
+		if err := repo.Checkout(branchName); err != nil {
 			return &errors.GitError{Operation: fmt.Sprintf("checkout branch '%s'", branchName), Err: err}
 		}
 	}
@@ -34,20 +34,20 @@ func UpdateBranchFromParentWithMessage(branchName string, parentBranch string, s
 	switch strings.ToLower(strategy) {
 	case "rebase":
 		fmt.Printf("Using rebase strategy for '%s'\n", branchName)
-		mergeErr = git.Rebase(parentBranch)
+		mergeErr = repo.Rebase(parentBranch)
 	case "squash":
 		fmt.Printf("Using squash strategy for '%s'\n", branchName)
 		if customMessage != "" {
-			mergeErr = git.MergeSquashWithMessage(parentBranch, customMessage, false)
+			mergeErr = repo.MergeSquashWithMessage(parentBranch, customMessage, false)
 		} else {
-			mergeErr = git.SquashMerge(parentBranch, false)
+			mergeErr = repo.SquashMerge(parentBranch, false)
 		}
 	default:
 		fmt.Printf("Using merge strategy for '%s'\n", branchName)
 		if customMessage != "" {
-			mergeErr = git.MergeWithMessage(parentBranch, customMessage, true, false)
+			mergeErr = repo.MergeWithMessage(parentBranch, customMessage, true, false)
 		} else {
-			mergeErr = git.Merge(parentBranch, false)
+			mergeErr = repo.Merge(parentBranch, false)
 		}
 	}
 
@@ -55,7 +55,7 @@ func UpdateBranchFromParentWithMessage(branchName string, parentBranch string, s
 		if strings.Contains(mergeErr.Error(), "conflict") {
 			if saveState && state != nil {
 				// Save merge state if requested
-				if err := mergestate.SaveMergeState(state); err != nil {
+				if err := mergestate.SaveMergeState(repo, state); err != nil {
 					return &errors.GitError{Operation: "save merge state", Err: err}
 				}
 			}

--- a/test/cmd/config_test.go
+++ b/test/cmd/config_test.go
@@ -20,7 +20,6 @@ func TestConfigAddBase(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-
 	// Initialize git-flow with defaults
 	var err error
 	_, err = testutil.RunGitFlow(t, tempDir, "init", "--defaults")
@@ -90,7 +89,6 @@ func TestConfigAddTopic(t *testing.T) {
 	// Setup test repository
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
-
 
 	// Initialize git-flow with defaults
 	var err error
@@ -168,7 +166,6 @@ func TestConfigRenameBase(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-
 	// Initialize git-flow with defaults
 	var err error
 	_, err = testutil.RunGitFlow(t, tempDir, "init", "--defaults")
@@ -235,7 +232,6 @@ func TestConfigDeleteBase(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-
 	// Initialize git-flow with defaults and add staging branch
 	var err error
 	_, err = testutil.RunGitFlow(t, tempDir, "init", "--defaults")
@@ -290,7 +286,6 @@ func TestConfigDeleteTopic(t *testing.T) {
 	// Setup test repository
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
-
 
 	// Initialize git-flow with defaults
 	_, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults")
@@ -379,7 +374,6 @@ func TestConfigList(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-
 	// Test list with no configuration
 	t.Run("List uninitialized", func(t *testing.T) {
 		_, err := captureConfigList(t, tempDir)
@@ -466,7 +460,6 @@ func TestCircularDependencyValidation(t *testing.T) {
 	// Setup test repository
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
-
 
 	// Initialize git-flow with defaults
 	var err error
@@ -631,7 +624,6 @@ func TestConfigAddBaseUppercaseName(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
 	}
@@ -659,7 +651,6 @@ func TestConfigAddBaseUppercaseName(t *testing.T) {
 func TestConfigAddBaseExactCaseParent(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
-
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -693,7 +684,6 @@ func TestConfigAddBaseDifferentCaseParentUsesCanonicalRef(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
 	}
@@ -725,7 +715,6 @@ func TestConfigAddBaseMixedCaseParentResolves(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
 	}
@@ -754,7 +743,6 @@ func TestConfigAddBaseMixedCaseParentResolves(t *testing.T) {
 func TestConfigAddTopicStartingPointResolvesCaseInsensitively(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
-
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -786,7 +774,6 @@ func TestConfigAddTopicParentResolvesCaseInsensitively(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
 	}
@@ -816,7 +803,6 @@ func TestConfigAddTopicParentResolvesCaseInsensitively(t *testing.T) {
 func TestConfigAddTopicCaseOnlyReAddRejected(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
-
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -849,7 +835,6 @@ func TestConfigAddTopicCaseOnlyReAddRejected(t *testing.T) {
 func TestConfigAddBaseCaseOnlyVariantRejected(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
-
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -884,7 +869,6 @@ func TestConfigEditBaseResolvesCaseInsensitively(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
 	}
@@ -914,7 +898,6 @@ func TestConfigEditTopicResolvesCaseInsensitively(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
 	}
@@ -942,7 +925,6 @@ func TestConfigEditTopicResolvesCaseInsensitively(t *testing.T) {
 func TestConfigDeleteBaseResolvesCaseInsensitively(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
-
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -973,7 +955,6 @@ func TestConfigDeleteBaseResolvesCaseInsensitively(t *testing.T) {
 func TestConfigRenameBaseResolvesAndUpdatesChildren(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
-
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -1013,7 +994,6 @@ func TestConfigRenameBaseResolvesAndUpdatesChildren(t *testing.T) {
 func TestConfigRenameBaseCaseCollisionRejected(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
-
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -1056,7 +1036,6 @@ func TestConfigRenameBaseCaseOnlySelfRename(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
 	}
@@ -1093,7 +1072,6 @@ func TestConfigAddBaseAbsentParentErrors(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
 	}
@@ -1125,7 +1103,6 @@ func TestConfigAddBaseAbsentParentErrors(t *testing.T) {
 func TestConfigNoDuplicateFromReloadRoundTrip(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
-
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -1159,7 +1136,6 @@ func TestConfigNoDuplicateFromReloadRoundTrip(t *testing.T) {
 func TestConfigListShowsCanonicalCase(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
-
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -1196,7 +1172,6 @@ func TestConfigLowercaseNamesNoRegression(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
 	}
@@ -1229,7 +1204,6 @@ func TestConfigInitDefaultsUnaffected(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
 	}
@@ -1253,7 +1227,6 @@ func TestConfigInitDefaultsUnaffected(t *testing.T) {
 func TestConfigRenameTopicResolvesCaseInsensitively(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
-
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -1284,7 +1257,6 @@ func TestConfigDeleteTopicResolvesCaseInsensitively(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
 	}
@@ -1312,7 +1284,6 @@ func TestConfigDeleteTopicResolvesCaseInsensitively(t *testing.T) {
 func TestConfigEditTopicStartingPointResolvesCaseInsensitively(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
-
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)

--- a/test/cmd/config_test.go
+++ b/test/cmd/config_test.go
@@ -1,11 +1,11 @@
 package cmd_test
 
 import (
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/gittower/git-flow-next/internal/config"
+	"github.com/gittower/git-flow-next/internal/git"
 	"github.com/gittower/git-flow-next/test/testutil"
 )
 
@@ -20,10 +20,6 @@ func TestConfigAddBase(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	// Change to test directory
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	// Initialize git-flow with defaults
 	var err error
@@ -62,7 +58,7 @@ func TestConfigAddBase(t *testing.T) {
 
 			if !tt.expectError {
 				// Verify configuration was saved
-				cfg, err := config.LoadConfig()
+				cfg, err := config.Load(mustOpenRepo(t, tempDir))
 				if err != nil {
 					t.Fatalf("Failed to load config: %v", err)
 				}
@@ -95,10 +91,6 @@ func TestConfigAddTopic(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	// Change to test directory
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	// Initialize git-flow with defaults
 	var err error
@@ -138,7 +130,7 @@ func TestConfigAddTopic(t *testing.T) {
 
 			if !tt.expectError {
 				// Verify configuration was saved
-				cfg, err := config.LoadConfig()
+				cfg, err := config.Load(mustOpenRepo(t, tempDir))
 				if err != nil {
 					t.Fatalf("Failed to load config: %v", err)
 				}
@@ -176,10 +168,6 @@ func TestConfigRenameBase(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	// Change to test directory
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	// Initialize git-flow with defaults
 	var err error
@@ -194,7 +182,7 @@ func TestConfigRenameBase(t *testing.T) {
 		t.Fatalf("Failed to rename base branch: %v", err)
 	}
 	// Verify configuration was updated
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(mustOpenRepo(t, tempDir))
 	if err != nil {
 		t.Fatalf("Failed to load config: %v", err)
 	}
@@ -247,10 +235,6 @@ func TestConfigDeleteBase(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	// Change to test directory
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	// Initialize git-flow with defaults and add staging branch
 	var err error
@@ -276,7 +260,7 @@ func TestConfigDeleteBase(t *testing.T) {
 		}
 
 		// Verify configuration was updated
-		cfg, err := config.LoadConfig()
+		cfg, err := config.Load(mustOpenRepo(t, tempDir))
 		if err != nil {
 			t.Fatalf("Failed to load config: %v", err)
 		}
@@ -307,10 +291,6 @@ func TestConfigDeleteTopic(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	// Change to test directory
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	// Initialize git-flow with defaults
 	_, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults")
@@ -326,7 +306,7 @@ func TestConfigDeleteTopic(t *testing.T) {
 		}
 
 		// Verify it was added
-		cfg, err := config.LoadConfig()
+		cfg, err := config.Load(mustOpenRepo(t, tempDir))
 		if err != nil {
 			t.Fatalf("Failed to load config: %v", err)
 		}
@@ -353,7 +333,7 @@ func TestConfigDeleteTopic(t *testing.T) {
 		}
 
 		// Verify configuration was removed from in-memory config
-		cfg, err := config.LoadConfig()
+		cfg, err := config.Load(mustOpenRepo(t, tempDir))
 		if err != nil {
 			t.Fatalf("Failed to load config: %v", err)
 		}
@@ -399,10 +379,6 @@ func TestConfigList(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	// Change to test directory
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	// Test list with no configuration
 	t.Run("List uninitialized", func(t *testing.T) {
@@ -457,11 +433,6 @@ func TestPresetConfigurations(t *testing.T) {
 			tempDir := testutil.SetupTestRepo(t)
 			defer testutil.CleanupTestRepo(t, tempDir)
 
-			// Change to test directory
-			oldDir, _ := os.Getwd()
-			os.Chdir(tempDir)
-			defer os.Chdir(oldDir)
-
 			// Initialize git-flow with preset
 			var err error
 			_, err = testutil.RunGitFlow(t, tempDir, "init", "--preset="+tt.preset)
@@ -470,7 +441,7 @@ func TestPresetConfigurations(t *testing.T) {
 			}
 
 			// Verify configuration
-			cfg, err := config.LoadConfig()
+			cfg, err := config.Load(mustOpenRepo(t, tempDir))
 			if err != nil {
 				t.Fatalf("Failed to load config: %v", err)
 			}
@@ -496,10 +467,6 @@ func TestCircularDependencyValidation(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	// Change to test directory
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	// Initialize git-flow with defaults
 	var err error
@@ -664,9 +631,6 @@ func TestConfigAddBaseUppercaseName(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -696,9 +660,6 @@ func TestConfigAddBaseExactCaseParent(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -732,9 +693,6 @@ func TestConfigAddBaseDifferentCaseParentUsesCanonicalRef(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -767,9 +725,6 @@ func TestConfigAddBaseMixedCaseParentResolves(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -800,9 +755,6 @@ func TestConfigAddTopicStartingPointResolvesCaseInsensitively(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -834,9 +786,6 @@ func TestConfigAddTopicParentResolvesCaseInsensitively(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -868,9 +817,6 @@ func TestConfigAddTopicCaseOnlyReAddRejected(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -904,9 +850,6 @@ func TestConfigAddBaseCaseOnlyVariantRejected(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -941,9 +884,6 @@ func TestConfigEditBaseResolvesCaseInsensitively(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -974,9 +914,6 @@ func TestConfigEditTopicResolvesCaseInsensitively(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -1006,9 +943,6 @@ func TestConfigDeleteBaseResolvesCaseInsensitively(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -1040,9 +974,6 @@ func TestConfigRenameBaseResolvesAndUpdatesChildren(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -1083,9 +1014,6 @@ func TestConfigRenameBaseCaseCollisionRejected(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -1128,9 +1056,6 @@ func TestConfigRenameBaseCaseOnlySelfRename(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -1168,9 +1093,6 @@ func TestConfigAddBaseAbsentParentErrors(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -1204,9 +1126,6 @@ func TestConfigNoDuplicateFromReloadRoundTrip(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -1241,9 +1160,6 @@ func TestConfigListShowsCanonicalCase(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -1280,9 +1196,6 @@ func TestConfigLowercaseNamesNoRegression(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -1316,9 +1229,6 @@ func TestConfigInitDefaultsUnaffected(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -1344,9 +1254,6 @@ func TestConfigRenameTopicResolvesCaseInsensitively(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -1377,9 +1284,6 @@ func TestConfigDeleteTopicResolvesCaseInsensitively(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -1409,9 +1313,6 @@ func TestConfigEditTopicStartingPointResolvesCaseInsensitively(t *testing.T) {
 	tempDir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, tempDir)
 
-	oldDir, _ := os.Getwd()
-	os.Chdir(tempDir)
-	defer os.Chdir(oldDir)
 
 	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v", err)
@@ -1431,4 +1332,14 @@ func TestConfigEditTopicStartingPointResolvesCaseInsensitively(t *testing.T) {
 	cfg := gitflowBranchConfig(t, tempDir)
 	assertContainsLine(t, cfg, "gitflow.branch.QA_Feature.startpoint V9_Release", "edit topic starting point")
 	assertNoLineContains(t, cfg, "gitflow.branch.v9_release.", "edit topic starting point")
+}
+
+// mustOpenRepo opens a git.Repo handle for dir, failing the test on error.
+func mustOpenRepo(t *testing.T, dir string) *git.Repo {
+	t.Helper()
+	repo, err := git.Open(dir)
+	if err != nil {
+		t.Fatalf("git.Open(%q) failed: %v", dir, err)
+	}
+	return repo
 }

--- a/test/cmd/finish_test.go
+++ b/test/cmd/finish_test.go
@@ -1807,3 +1807,108 @@ func TestFinishReleaseWithoutInitialization(t *testing.T) {
 		t.Errorf("Expected 'not initialized' error, got: %s", output)
 	}
 }
+
+// TestFinishTagMessageFileRelativePathCli verifies that a relative
+// --messagefile argument is resolved against the invocation directory, not the
+// work-tree root, when git-flow finish creates the release tag.
+func TestFinishTagMessageFileRelativePathCli(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to init git-flow: %v", err)
+	}
+
+	subDir := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatalf("Failed to create sub dir: %v", err)
+	}
+	const wantMsg = "Custom tag message from a nested file"
+	if err := os.WriteFile(filepath.Join(subDir, "msg.txt"), []byte(wantMsg+"\n"), 0644); err != nil {
+		t.Fatalf("Failed to write message file: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "msg.txt")); !os.IsNotExist(err) {
+		t.Fatalf("Precondition failed: work-tree-root msg.txt must not exist")
+	}
+
+	if _, err := testutil.RunGitFlow(t, dir, "release", "start", "1.0.0"); err != nil {
+		t.Fatalf("Failed to start release: %v", err)
+	}
+	testutil.WriteFile(t, dir, "release-note.txt", "notes")
+	if _, err := testutil.RunGit(t, dir, "add", "release-note.txt"); err != nil {
+		t.Fatalf("Failed to add file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "release work"); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// Invoke finish from the nested subdir with a relative message-file path.
+	output, err := testutil.RunGitFlow(t, subDir, "release", "finish", "1.0.0", "--messagefile", "msg.txt")
+	if err != nil {
+		t.Fatalf("release finish failed: %v\nOutput: %s", err, output)
+	}
+
+	contents, err := testutil.RunGit(t, dir, "tag", "-l", "--format=%(contents)", "1.0.0")
+	if err != nil {
+		t.Fatalf("Failed to read tag contents: %v", err)
+	}
+	if !strings.Contains(contents, wantMsg) {
+		t.Errorf("Tag message did not come from B/sub/msg.txt.\nGot: %q\nWant substring: %q", contents, wantMsg)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "msg.txt")); !os.IsNotExist(err) {
+		t.Errorf("work-tree-root msg.txt was created/read; message file did not resolve against invocation dir")
+	}
+}
+
+// TestFinishTagMessageFileRelativePathFromConfig verifies the same invocation-dir
+// resolution when the message file comes from Layer-2 config
+// (gitflow.release.finish.messagefile) rather than the CLI flag.
+func TestFinishTagMessageFileRelativePathFromConfig(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to init git-flow: %v", err)
+	}
+
+	subDir := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatalf("Failed to create sub dir: %v", err)
+	}
+	const wantMsg = "Config-provided tag message from a nested file"
+	if err := os.WriteFile(filepath.Join(subDir, "msg.txt"), []byte(wantMsg+"\n"), 0644); err != nil {
+		t.Fatalf("Failed to write message file: %v", err)
+	}
+
+	// Layer-2 config carries the relative path; it keeps invocation-dir meaning.
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.release.finish.messagefile", "msg.txt"); err != nil {
+		t.Fatalf("Failed to set messagefile config: %v", err)
+	}
+
+	if _, err := testutil.RunGitFlow(t, dir, "release", "start", "1.0.0"); err != nil {
+		t.Fatalf("Failed to start release: %v", err)
+	}
+	testutil.WriteFile(t, dir, "release-note.txt", "notes")
+	if _, err := testutil.RunGit(t, dir, "add", "release-note.txt"); err != nil {
+		t.Fatalf("Failed to add file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "release work"); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, subDir, "release", "finish", "1.0.0")
+	if err != nil {
+		t.Fatalf("release finish failed: %v\nOutput: %s", err, output)
+	}
+
+	contents, err := testutil.RunGit(t, dir, "tag", "-l", "--format=%(contents)", "1.0.0")
+	if err != nil {
+		t.Fatalf("Failed to read tag contents: %v", err)
+	}
+	if !strings.Contains(contents, wantMsg) {
+		t.Errorf("Tag message did not come from config-referenced B/sub/msg.txt.\nGot: %q\nWant substring: %q", contents, wantMsg)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "msg.txt")); !os.IsNotExist(err) {
+		t.Errorf("work-tree-root msg.txt was created/read; config message file did not resolve against invocation dir")
+	}
+}

--- a/test/cmd/init_test.go
+++ b/test/cmd/init_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/gittower/git-flow-next/internal/config"
+	"github.com/gittower/git-flow-next/internal/git"
 	"github.com/gittower/git-flow-next/test/testutil"
 )
 
@@ -597,18 +598,12 @@ func TestInitWithDefaultsAndOverrides(t *testing.T) {
 		t.Error("Expected 'custom-dev' branch to exist")
 	}
 
-	// Change to the test directory before loading config
-	oldDir, err := os.Getwd()
+	// Verify configuration through a handle for the test repo (no os.Chdir).
+	repo, err := git.Open(dir)
 	if err != nil {
-		t.Fatalf("Failed to get current directory: %v", err)
+		t.Fatalf("Failed to open repo: %v", err)
 	}
-	defer os.Chdir(oldDir)
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("Failed to change to test directory: %v", err)
-	}
-
-	// Verify configuration
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(repo)
 	if err != nil {
 		t.Fatalf("Failed to load configuration: %v", err)
 	}
@@ -1614,5 +1609,48 @@ func TestInitWithEmptyIdentityValue(t *testing.T) {
 	}
 	if !strings.Contains(output, "git user identity is not configured") {
 		t.Errorf("Expected output to contain 'git user identity is not configured', got: %s", output)
+	}
+}
+
+// TestInitFileRelativePathResolvesAgainstInvocationDir verifies that a relative
+// --file argument is resolved against the invocation directory (the process CWD
+// where git-flow was run), not the work-tree root. The parent-dir existence
+// check must run after that normalization: with a nested relative path
+// (cfgdir/myconfig), cfgdir/ exists under the invocation dir B/sub but not under
+// the work-tree root B/, so only invocation-dir resolution succeeds.
+func TestInitFileRelativePathResolvesAgainstInvocationDir(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// Nested invocation dir B/sub with a cfgdir/ under it; ensure the work-tree
+	// root has NO cfgdir/ so a work-tree-relative resolution would fail.
+	subDir := filepath.Join(dir, "sub")
+	cfgDir := filepath.Join(subDir, "cfgdir")
+	if err := os.MkdirAll(cfgDir, 0755); err != nil {
+		t.Fatalf("Failed to create nested cfgdir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "cfgdir")); !os.IsNotExist(err) {
+		t.Fatalf("Precondition failed: work-tree-root cfgdir must not exist")
+	}
+
+	// Invoke from B/sub with a nested relative --file path.
+	output, err := runGitFlow(t, subDir, "init", "--file", "cfgdir/myconfig", "--defaults")
+	if err != nil {
+		t.Fatalf("init --file failed: %v\nOutput: %s", err, output)
+	}
+
+	// The config file must be written under the invocation dir.
+	written := filepath.Join(subDir, "cfgdir", "myconfig")
+	content, err := os.ReadFile(written)
+	if err != nil {
+		t.Fatalf("Expected config at %s: %v", written, err)
+	}
+	if !strings.Contains(string(content), "version") {
+		t.Errorf("Expected gitflow config content in %s, got:\n%s", written, content)
+	}
+
+	// The work-tree-root cfgdir must never have been created.
+	if _, err := os.Stat(filepath.Join(dir, "cfgdir")); !os.IsNotExist(err) {
+		t.Errorf("work-tree-root cfgdir was created/read; --file did not resolve against invocation dir")
 	}
 }

--- a/test/internal/config/config_test.go
+++ b/test/internal/config/config_test.go
@@ -59,6 +59,13 @@ func openRepo(t *testing.T, dir string) *git.Repo {
 	return repo
 }
 
+// TestLoadConfigCaseInsensitive verifies that branch property keys are matched
+// case-insensitively when loading configuration.
+// Steps:
+// 1. Sets up a test repository
+// 2. Sets startPoint keys with mixed casing (startPoint, StartPoint, STARTPOINT)
+// 3. Loads config through a git.Repo handle for the repository
+// 4. Verifies each branch's start point resolves regardless of key case
 func TestLoadConfigCaseInsensitive(t *testing.T) {
 	t.Parallel()
 	dir := setupTestRepo(t)
@@ -86,6 +93,13 @@ func TestLoadConfigCaseInsensitive(t *testing.T) {
 	}
 }
 
+// TestLoadConfigWithMixedCaseProperties verifies that all branch config
+// properties are parsed regardless of the casing used in their config keys.
+// Steps:
+// 1. Sets up a test repository
+// 2. Sets the full set of feature branch properties with mixed-case keys
+// 3. Loads config through a git.Repo handle for the repository
+// 4. Verifies each parsed feature property matches the expected value
 func TestLoadConfigWithMixedCaseProperties(t *testing.T) {
 	t.Parallel()
 	dir := setupTestRepo(t)
@@ -133,6 +147,12 @@ func TestLoadConfigWithMixedCaseProperties(t *testing.T) {
 	}
 }
 
+// TestApplyOverrides_NoOverrides verifies that applying empty overrides leaves
+// the default branch configuration intact.
+// Steps:
+// 1. Builds a default config
+// 2. Applies an empty ConfigOverrides
+// 3. Verifies all default branches retain their types, parents, and start points
 func TestApplyOverrides_NoOverrides(t *testing.T) {
 	t.Parallel()
 	cfg := config.DefaultConfig()
@@ -175,6 +195,14 @@ func TestApplyOverrides_NoOverrides(t *testing.T) {
 	assert.Equal(t, "main", supportConfig.StartPoint)
 }
 
+// TestApplyOverrides_CustomBranchNames verifies that overriding the main and
+// develop branch names rekeys the branches and updates dependent parents.
+// Steps:
+// 1. Builds a default config
+// 2. Applies overrides setting custom main and develop branch names
+// 3. Verifies the custom-named base branches exist with correct parents
+// 4. Verifies feature/release/hotfix/support parents point at the custom names
+// 5. Verifies the original "main" and "develop" keys no longer exist
 func TestApplyOverrides_CustomBranchNames(t *testing.T) {
 	t.Parallel()
 	cfg := config.DefaultConfig()
@@ -221,6 +249,13 @@ func TestApplyOverrides_CustomBranchNames(t *testing.T) {
 	assert.False(t, exists)
 }
 
+// TestApplyOverrides_CustomPrefixes verifies that custom branch prefix overrides
+// are applied without altering parents or start points.
+// Steps:
+// 1. Builds a default config
+// 2. Applies overrides setting custom feature/release/hotfix/support prefixes
+// 3. Verifies each branch adopts its custom prefix
+// 4. Verifies each branch retains its default parent and start point
 func TestApplyOverrides_CustomPrefixes(t *testing.T) {
 	t.Parallel()
 	cfg := config.DefaultConfig()
@@ -252,6 +287,13 @@ func TestApplyOverrides_CustomPrefixes(t *testing.T) {
 	assert.Equal(t, "main", supportConfig.StartPoint)
 }
 
+// TestApplyOverrides_CustomTagPrefix verifies that a custom tag prefix override
+// is applied to the tagging branches.
+// Steps:
+// 1. Builds a default config
+// 2. Applies an override setting a custom tag prefix
+// 3. Verifies the release and hotfix branches adopt the custom tag prefix
+// 4. Verifies their parents and start points are unchanged
 func TestApplyOverrides_CustomTagPrefix(t *testing.T) {
 	t.Parallel()
 	cfg := config.DefaultConfig()
@@ -270,6 +312,14 @@ func TestApplyOverrides_CustomTagPrefix(t *testing.T) {
 	assert.Equal(t, "main", hotfixConfig.StartPoint)
 }
 
+// TestApplyOverrides_AllOverrides verifies that applying the full set of
+// overrides together produces a consistent, fully customized config.
+// Steps:
+// 1. Builds a default config
+// 2. Applies custom branch names, prefixes, and tag prefix together
+// 3. Verifies the custom-named base branches exist with correct parents
+// 4. Verifies feature/release/hotfix/support prefixes, parents, and start points
+// 5. Verifies the custom tag prefix on release and hotfix branches
 func TestApplyOverrides_AllOverrides(t *testing.T) {
 	t.Parallel()
 	cfg := config.DefaultConfig()
@@ -318,6 +368,12 @@ func TestApplyOverrides_AllOverrides(t *testing.T) {
 	assert.Equal(t, "custom-main", supportConfig.StartPoint)
 }
 
+// TestDefaultRemoteConfiguration verifies that the remote defaults to "origin"
+// when no remote is configured.
+// Steps:
+// 1. Sets up a test repository and marks it git-flow-initialized
+// 2. Loads config through a git.Repo handle for the repository
+// 3. Verifies the loaded remote is "origin"
 func TestDefaultRemoteConfiguration(t *testing.T) {
 	t.Parallel()
 	dir := setupTestRepo(t)
@@ -332,6 +388,12 @@ func TestDefaultRemoteConfiguration(t *testing.T) {
 	assert.Equal(t, "origin", cfg.Remote, "Default remote should be 'origin'")
 }
 
+// TestGitFlowAVHRemoteImport verifies that the remote is imported from the
+// git-flow-avh gitflow.origin key.
+// Steps:
+// 1. Sets up a test repository and sets gitflow.origin to a custom remote
+// 2. Imports git-flow-avh config through a git.Repo handle
+// 3. Verifies the imported config's remote matches the avh value
 func TestGitFlowAVHRemoteImport(t *testing.T) {
 	t.Parallel()
 	dir := setupTestRepo(t)
@@ -346,6 +408,14 @@ func TestGitFlowAVHRemoteImport(t *testing.T) {
 	assert.Equal(t, "avh-remote", cfg.Remote, "git-flow-avh remote should be imported")
 }
 
+// TestLoadConfigPreservesBranchNameCase verifies that the canonical casing of a
+// branch name is preserved and remains case-insensitively resolvable.
+// Steps:
+// 1. Sets up a test repository with a mixed-case branch name (V9_Release)
+// 2. Loads config through a git.Repo handle for the repository
+// 3. Verifies the canonical key 'V9_Release' is preserved and not lowercased
+// 4. Verifies ResolveBranchName resolves a lowercased query to the canonical key
+// 5. Verifies the branch's parsed Type and UpstreamStrategy
 func TestLoadConfigPreservesBranchNameCase(t *testing.T) {
 	t.Parallel()
 	dir := setupTestRepo(t)
@@ -386,6 +456,13 @@ func TestLoadConfigPreservesBranchNameCase(t *testing.T) {
 
 // --- Scenario 6: config read off-CWD ---
 
+// TestLoadConfigReflectsTargetRepoOffCwd verifies config.Load reads from the
+// target repository, not the process working directory.
+// Steps:
+// 1. Sets up a test repository B and initializes git-flow in it
+// 2. Sets a custom feature prefix (feat/) in B
+// 3. Loads config through a git.Repo handle for B
+// 4. Verifies the loaded feature prefix is 'feat/' from B
 func TestLoadConfigReflectsTargetRepoOffCwd(t *testing.T) {
 	t.Parallel()
 	dir := testutil.SetupTestRepo(t)
@@ -407,6 +484,13 @@ func TestLoadConfigReflectsTargetRepoOffCwd(t *testing.T) {
 	}
 }
 
+// TestLoadConfigUninitializedReturnsDefaults verifies config.Load returns
+// defaults for a repository that has not been git-flow-initialized.
+// Steps:
+// 1. Sets up a test repository B without initializing git-flow
+// 2. Loads config through a git.Repo handle for B
+// 3. Verifies no error is returned
+// 4. Verifies the default feature prefix ('feature/') and default remote ('origin')
 func TestLoadConfigUninitializedReturnsDefaults(t *testing.T) {
 	t.Parallel()
 	dir := testutil.SetupTestRepo(t)
@@ -425,6 +509,13 @@ func TestLoadConfigUninitializedReturnsDefaults(t *testing.T) {
 	}
 }
 
+// TestLoadConfigImportsAvhOffCwd verifies config.Load imports git-flow-avh
+// configuration from the target repository when no gitflow.version is present.
+// Steps:
+// 1. Sets up a test repository B with distinctive git-flow-avh keys and no version
+// 2. Loads config through a git.Repo handle for B
+// 3. Verifies the AVH master rename ('production') is imported and 'main' is gone
+// 4. Verifies the imported feature prefix is 'feat/'
 func TestLoadConfigImportsAvhOffCwd(t *testing.T) {
 	t.Parallel()
 	dir := testutil.SetupTestRepo(t)
@@ -453,6 +544,13 @@ func TestLoadConfigImportsAvhOffCwd(t *testing.T) {
 
 // --- Scenario 7: config mutation off-CWD ---
 
+// TestConfigSetIsolatedToTargetRepo verifies that a config write through one
+// repository's handle affects only that repository.
+// Steps:
+// 1. Sets up and initializes two test repositories A and B
+// 2. Sets a custom feature prefix ('xb/') through B's handle
+// 3. Verifies B's loaded config reflects the new prefix
+// 4. Verifies A's loaded config retains the default 'feature/' prefix
 func TestConfigSetIsolatedToTargetRepo(t *testing.T) {
 	t.Parallel()
 	dirA := testutil.SetupTestRepo(t)
@@ -489,6 +587,13 @@ func TestConfigSetIsolatedToTargetRepo(t *testing.T) {
 	}
 }
 
+// TestConfigClearIsolatedToTargetRepo verifies that clearing config through one
+// repository's handle affects only that repository.
+// Steps:
+// 1. Sets up and initializes two test repositories A and B
+// 2. Clears gitflow config through B's handle
+// 3. Verifies B's gitflow.branch.feature.prefix is removed
+// 4. Verifies A's gitflow.branch.feature.prefix remains 'feature/'
 func TestConfigClearIsolatedToTargetRepo(t *testing.T) {
 	t.Parallel()
 	dirA := testutil.SetupTestRepo(t)

--- a/test/internal/config/config_test.go
+++ b/test/internal/config/config_test.go
@@ -7,41 +7,30 @@ import (
 
 	"github.com/gittower/git-flow-next/internal/config"
 	"github.com/gittower/git-flow-next/internal/git"
+	"github.com/gittower/git-flow-next/test/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
+// setupTestRepo creates a temporary git repository and returns its path. Unlike
+// the previous helper, it does not change the process working directory: tests
+// open a git.Repo handle for the returned dir instead.
 func setupTestRepo(t *testing.T) string {
-	// Create a temporary directory
+	t.Helper()
 	dir, err := os.MkdirTemp("", "git-flow-test-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
 
-	// Change to the temporary directory
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("Failed to change to temp dir: %v", err)
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("git %v failed: %v", args, err)
+		}
 	}
-
-	// Initialize git repo
-	cmd := exec.Command("git", "init")
-	cmd.Dir = dir
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("Failed to initialize git repo: %v", err)
-	}
-
-	// Configure git user
-	cmd = exec.Command("git", "config", "user.name", "Test User")
-	cmd.Dir = dir
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("Failed to configure git user name: %v", err)
-	}
-
-	cmd = exec.Command("git", "config", "user.email", "test@example.com")
-	cmd.Dir = dir
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("Failed to configure git user email: %v", err)
-	}
-
+	run("init")
+	run("config", "user.name", "Test User")
+	run("config", "user.email", "test@example.com")
 	return dir
 }
 
@@ -51,49 +40,45 @@ func cleanupTestRepo(t *testing.T, dir string) {
 	}
 }
 
+// setConfig sets a git config value in dir.
+func setConfig(t *testing.T, dir, key, value string) {
+	t.Helper()
+	cmd := exec.Command("git", "config", key, value)
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to set git config %s: %v", key, err)
+	}
+}
+
+func openRepo(t *testing.T, dir string) *git.Repo {
+	t.Helper()
+	repo, err := git.Open(dir)
+	if err != nil {
+		t.Fatalf("git.Open(%q) failed: %v", dir, err)
+	}
+	return repo
+}
+
 func TestLoadConfigCaseInsensitive(t *testing.T) {
-	// Setup
+	t.Parallel()
 	dir := setupTestRepo(t)
 	defer cleanupTestRepo(t, dir)
 
-	// Set config values with different cases
-	testCases := []struct {
-		key   string
-		value string
-	}{
-		{"gitflow.branch.feature.startPoint", "develop"},
-		{"gitflow.branch.release.StartPoint", "develop"},
-		{"gitflow.branch.hotfix.STARTPOINT", "main"},
-	}
+	setConfig(t, dir, "gitflow.branch.feature.startPoint", "develop")
+	setConfig(t, dir, "gitflow.branch.release.StartPoint", "develop")
+	setConfig(t, dir, "gitflow.branch.hotfix.STARTPOINT", "main")
+	setConfig(t, dir, "gitflow.version", "1.0")
 
-	for _, tc := range testCases {
-		cmd := exec.Command("git", "config", tc.key, tc.value)
-		cmd.Dir = dir
-		if err := cmd.Run(); err != nil {
-			t.Fatalf("Failed to set git config %s: %v", tc.key, err)
-		}
-	}
-
-	// Set version to mark as initialized
-	cmd := exec.Command("git", "config", "gitflow.version", "1.0")
-	cmd.Dir = dir
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("Failed to set gitflow version: %v", err)
-	}
-
-	// Load config
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(openRepo(t, dir))
 	if err != nil {
 		t.Fatalf("Failed to load config: %v", err)
 	}
 
-	// Verify all start points are loaded correctly regardless of case
 	expectedStartPoints := map[string]string{
 		"feature": "develop",
 		"release": "develop",
 		"hotfix":  "main",
 	}
-
 	for branch, expected := range expectedStartPoints {
 		if actual := cfg.Branches[branch].StartPoint; actual != expected {
 			t.Errorf("Branch %s: expected start point %s, got %s", branch, expected, actual)
@@ -102,45 +87,23 @@ func TestLoadConfigCaseInsensitive(t *testing.T) {
 }
 
 func TestLoadConfigWithMixedCaseProperties(t *testing.T) {
-	// Setup
+	t.Parallel()
 	dir := setupTestRepo(t)
 	defer cleanupTestRepo(t, dir)
 
-	// Set config values with mixed case for different properties
-	configs := []struct {
-		key   string
-		value string
-	}{
-		{"gitflow.branch.feature.Type", "topic"},
-		{"gitflow.branch.feature.parent", "develop"},
-		{"gitflow.branch.feature.UpstreamStrategy", "rebase"},
-		{"gitflow.branch.feature.downstreamStrategy", "squash"},
-		{"gitflow.branch.feature.PREFIX", "feature/"},
-		{"gitflow.branch.feature.AutoUpdate", "true"},
-	}
+	setConfig(t, dir, "gitflow.branch.feature.Type", "topic")
+	setConfig(t, dir, "gitflow.branch.feature.parent", "develop")
+	setConfig(t, dir, "gitflow.branch.feature.UpstreamStrategy", "rebase")
+	setConfig(t, dir, "gitflow.branch.feature.downstreamStrategy", "squash")
+	setConfig(t, dir, "gitflow.branch.feature.PREFIX", "feature/")
+	setConfig(t, dir, "gitflow.branch.feature.AutoUpdate", "true")
+	setConfig(t, dir, "gitflow.version", "1.0")
 
-	for _, cfg := range configs {
-		cmd := exec.Command("git", "config", cfg.key, cfg.value)
-		cmd.Dir = dir
-		if err := cmd.Run(); err != nil {
-			t.Fatalf("Failed to set git config %s: %v", cfg.key, err)
-		}
-	}
-
-	// Set version to mark as initialized
-	cmd := exec.Command("git", "config", "gitflow.version", "1.0")
-	cmd.Dir = dir
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("Failed to set gitflow version: %v", err)
-	}
-
-	// Load config
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(openRepo(t, dir))
 	if err != nil {
 		t.Fatalf("Failed to load config: %v", err)
 	}
 
-	// Verify all properties are loaded correctly regardless of case
 	feature := cfg.Branches["feature"]
 	expected := config.BranchConfig{
 		Type:               "topic",
@@ -150,7 +113,6 @@ func TestLoadConfigWithMixedCaseProperties(t *testing.T) {
 		Prefix:             "feature/",
 		AutoUpdate:         true,
 	}
-
 	if feature.Type != expected.Type {
 		t.Errorf("Expected Type %s, got %s", expected.Type, feature.Type)
 	}
@@ -172,45 +134,40 @@ func TestLoadConfigWithMixedCaseProperties(t *testing.T) {
 }
 
 func TestApplyOverrides_NoOverrides(t *testing.T) {
+	t.Parallel()
 	cfg := config.DefaultConfig()
 	cfg = config.ApplyOverrides(cfg, config.ConfigOverrides{})
 
-	// Check main branch (base branch)
 	mainConfig, exists := cfg.Branches["main"]
 	assert.True(t, exists)
 	assert.Equal(t, string(config.BranchTypeBase), mainConfig.Type)
 	assert.Equal(t, "", mainConfig.Parent)
 	assert.Equal(t, "", mainConfig.StartPoint)
 
-	// Check develop branch (base branch)
 	developConfig, exists := cfg.Branches["develop"]
 	assert.True(t, exists)
 	assert.Equal(t, string(config.BranchTypeBase), developConfig.Type)
 	assert.Equal(t, "main", developConfig.Parent)
 	assert.Equal(t, "", developConfig.StartPoint)
 
-	// Check feature branch
 	featureConfig, exists := cfg.Branches["feature"]
 	assert.True(t, exists)
 	assert.Equal(t, "feature/", featureConfig.Prefix)
 	assert.Equal(t, "develop", featureConfig.Parent)
 	assert.Equal(t, "develop", featureConfig.StartPoint)
 
-	// Check release branch
 	releaseConfig, exists := cfg.Branches["release"]
 	assert.True(t, exists)
 	assert.Equal(t, "release/", releaseConfig.Prefix)
 	assert.Equal(t, "main", releaseConfig.Parent)
 	assert.Equal(t, "develop", releaseConfig.StartPoint)
 
-	// Check hotfix branch
 	hotfixConfig, exists := cfg.Branches["hotfix"]
 	assert.True(t, exists)
 	assert.Equal(t, "hotfix/", hotfixConfig.Prefix)
 	assert.Equal(t, "main", hotfixConfig.Parent)
 	assert.Equal(t, "main", hotfixConfig.StartPoint)
 
-	// Check support branch
 	supportConfig, exists := cfg.Branches["support"]
 	assert.True(t, exists)
 	assert.Equal(t, "support/", supportConfig.Prefix)
@@ -219,51 +176,45 @@ func TestApplyOverrides_NoOverrides(t *testing.T) {
 }
 
 func TestApplyOverrides_CustomBranchNames(t *testing.T) {
+	t.Parallel()
 	cfg := config.DefaultConfig()
 	cfg = config.ApplyOverrides(cfg, config.ConfigOverrides{
 		MainBranch:    "custom-main",
 		DevelopBranch: "custom-dev",
 	})
 
-	// Check main branch (base branch)
 	mainConfig, exists := cfg.Branches["custom-main"]
 	assert.True(t, exists)
 	assert.Equal(t, string(config.BranchTypeBase), mainConfig.Type)
 	assert.Equal(t, "", mainConfig.Parent)
 	assert.Equal(t, "", mainConfig.StartPoint)
 
-	// Check develop branch (base branch)
 	developConfig, exists := cfg.Branches["custom-dev"]
 	assert.True(t, exists)
 	assert.Equal(t, string(config.BranchTypeBase), developConfig.Type)
 	assert.Equal(t, "custom-main", developConfig.Parent)
 	assert.Equal(t, "", developConfig.StartPoint)
 
-	// Check feature branch parent and start point
 	featureConfig, exists := cfg.Branches["feature"]
 	assert.True(t, exists)
 	assert.Equal(t, "custom-dev", featureConfig.Parent)
 	assert.Equal(t, "custom-dev", featureConfig.StartPoint)
 
-	// Check release branch parent and start point
 	releaseConfig, exists := cfg.Branches["release"]
 	assert.True(t, exists)
 	assert.Equal(t, "custom-main", releaseConfig.Parent)
 	assert.Equal(t, "custom-dev", releaseConfig.StartPoint)
 
-	// Check hotfix branch parent and start point
 	hotfixConfig, exists := cfg.Branches["hotfix"]
 	assert.True(t, exists)
 	assert.Equal(t, "custom-main", hotfixConfig.Parent)
 	assert.Equal(t, "custom-main", hotfixConfig.StartPoint)
 
-	// Check support branch parent and start point
 	supportConfig, exists := cfg.Branches["support"]
 	assert.True(t, exists)
 	assert.Equal(t, "custom-main", supportConfig.Parent)
 	assert.Equal(t, "custom-main", supportConfig.StartPoint)
 
-	// Check old names don't exist
 	_, exists = cfg.Branches["main"]
 	assert.False(t, exists)
 	_, exists = cfg.Branches["develop"]
@@ -271,6 +222,7 @@ func TestApplyOverrides_CustomBranchNames(t *testing.T) {
 }
 
 func TestApplyOverrides_CustomPrefixes(t *testing.T) {
+	t.Parallel()
 	cfg := config.DefaultConfig()
 	cfg = config.ApplyOverrides(cfg, config.ConfigOverrides{
 		FeaturePrefix: "f/",
@@ -279,7 +231,6 @@ func TestApplyOverrides_CustomPrefixes(t *testing.T) {
 		SupportPrefix: "s/",
 	})
 
-	// Check prefixes while verifying parents and start points remain unchanged
 	featureConfig := cfg.Branches["feature"]
 	assert.Equal(t, "f/", featureConfig.Prefix)
 	assert.Equal(t, "develop", featureConfig.Parent)
@@ -302,12 +253,12 @@ func TestApplyOverrides_CustomPrefixes(t *testing.T) {
 }
 
 func TestApplyOverrides_CustomTagPrefix(t *testing.T) {
+	t.Parallel()
 	cfg := config.DefaultConfig()
 	cfg = config.ApplyOverrides(cfg, config.ConfigOverrides{
 		TagPrefix: "v",
 	})
 
-	// Check tag prefixes while verifying parents and start points remain unchanged
 	releaseConfig := cfg.Branches["release"]
 	assert.Equal(t, "v", releaseConfig.TagPrefix)
 	assert.Equal(t, "main", releaseConfig.Parent)
@@ -320,6 +271,7 @@ func TestApplyOverrides_CustomTagPrefix(t *testing.T) {
 }
 
 func TestApplyOverrides_AllOverrides(t *testing.T) {
+	t.Parallel()
 	cfg := config.DefaultConfig()
 	cfg = config.ApplyOverrides(cfg, config.ConfigOverrides{
 		MainBranch:    "custom-main",
@@ -331,182 +283,83 @@ func TestApplyOverrides_AllOverrides(t *testing.T) {
 		TagPrefix:     "v",
 	})
 
-	// Check main branch (base branch)
 	mainConfig, exists := cfg.Branches["custom-main"]
 	assert.True(t, exists)
 	assert.Equal(t, string(config.BranchTypeBase), mainConfig.Type)
 	assert.Equal(t, "", mainConfig.Parent)
 	assert.Equal(t, "", mainConfig.StartPoint)
 
-	// Check develop branch (base branch)
 	developConfig, exists := cfg.Branches["custom-dev"]
 	assert.True(t, exists)
 	assert.Equal(t, string(config.BranchTypeBase), developConfig.Type)
 	assert.Equal(t, "custom-main", developConfig.Parent)
 	assert.Equal(t, "", developConfig.StartPoint)
 
-	// Check feature branch
 	featureConfig := cfg.Branches["feature"]
 	assert.Equal(t, "f/", featureConfig.Prefix)
 	assert.Equal(t, "custom-dev", featureConfig.Parent)
 	assert.Equal(t, "custom-dev", featureConfig.StartPoint)
 
-	// Check release branch
 	releaseConfig := cfg.Branches["release"]
 	assert.Equal(t, "r/", releaseConfig.Prefix)
 	assert.Equal(t, "custom-main", releaseConfig.Parent)
 	assert.Equal(t, "custom-dev", releaseConfig.StartPoint)
 	assert.Equal(t, "v", releaseConfig.TagPrefix)
 
-	// Check hotfix branch
 	hotfixConfig := cfg.Branches["hotfix"]
 	assert.Equal(t, "h/", hotfixConfig.Prefix)
 	assert.Equal(t, "custom-main", hotfixConfig.Parent)
 	assert.Equal(t, "custom-main", hotfixConfig.StartPoint)
 	assert.Equal(t, "v", hotfixConfig.TagPrefix)
 
-	// Check support branch
 	supportConfig := cfg.Branches["support"]
 	assert.Equal(t, "s/", supportConfig.Prefix)
 	assert.Equal(t, "custom-main", supportConfig.Parent)
 	assert.Equal(t, "custom-main", supportConfig.StartPoint)
 }
 
-// TestDefaultRemoteConfiguration tests that "origin" is used as the default remote name
 func TestDefaultRemoteConfiguration(t *testing.T) {
-	// Setup
+	t.Parallel()
 	dir := setupTestRepo(t)
 	defer cleanupTestRepo(t, dir)
 
-	// Initialize git-flow
-	cmd := exec.Command("git", "config", "gitflow.version", "1.0")
-	cmd.Dir = dir
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("Failed to set gitflow version: %v", err)
-	}
+	setConfig(t, dir, "gitflow.version", "1.0")
 
-	// Load config without setting gitflow.origin
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(openRepo(t, dir))
 	if err != nil {
 		t.Fatalf("Failed to load config: %v", err)
 	}
-
-	// Verify default remote is "origin"
 	assert.Equal(t, "origin", cfg.Remote, "Default remote should be 'origin'")
 }
 
-// TestCustomRemoteConfiguration tests that a custom remote name is used when gitflow.origin is set
-func TestCustomRemoteConfiguration(t *testing.T) {
-	// Setup
-	dir := setupTestRepo(t)
-	defer cleanupTestRepo(t, dir)
-
-	// Initialize git-flow
-	cmd := exec.Command("git", "config", "gitflow.version", "1.0")
-	cmd.Dir = dir
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("Failed to set gitflow version: %v", err)
-	}
-
-	// Set custom remote
-	customRemote := "myremote"
-	cmd = exec.Command("git", "config", "gitflow.origin", customRemote)
-	cmd.Dir = dir
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("Failed to set custom remote: %v", err)
-	}
-
-	// Debug: Print git config
-	cmd = exec.Command("git", "config", "--get", "gitflow.origin")
-	cmd.Dir = dir
-	out, err := cmd.Output()
-	if err != nil {
-		t.Logf("Failed to get gitflow.origin config: %v", err)
-	} else {
-		t.Logf("gitflow.origin from git config: %s", string(out))
-	}
-
-	// We need to manually create a config to test with the specific repository
-	cfg := config.DefaultConfig()
-
-	// Override with our custom remote
-	remote, err := git.GetConfigInDir(dir, "gitflow.origin")
-	if err == nil && remote != "" {
-		cfg.Remote = remote
-	}
-
-	// Verify custom remote is used
-	assert.Equal(t, customRemote, cfg.Remote, "Custom remote should be used")
-}
-
-// TestGitFlowAVHRemoteImport tests that git-flow-avh remote configuration is imported correctly
 func TestGitFlowAVHRemoteImport(t *testing.T) {
-	// Setup
+	t.Parallel()
 	dir := setupTestRepo(t)
 	defer cleanupTestRepo(t, dir)
 
-	// Set git-flow-avh config
-	cmd := exec.Command("git", "config", "gitflow.origin", "avh-remote")
-	cmd.Dir = dir
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("Failed to set git-flow-avh remote: %v", err)
-	}
+	setConfig(t, dir, "gitflow.origin", "avh-remote")
 
-	// Import git-flow-avh config
-	cfg, err := config.ImportGitFlowAVHConfig()
+	cfg, err := config.ImportGitFlowAVHConfig(openRepo(t, dir))
 	if err != nil {
 		t.Fatalf("Failed to import git-flow-avh config: %v", err)
 	}
-
-	// Verify git-flow-avh remote is imported
 	assert.Equal(t, "avh-remote", cfg.Remote, "git-flow-avh remote should be imported")
 }
 
-// TestLoadConfigPreservesBranchNameCase verifies LoadConfig keeps the original
-// branch-name case as the canonical key and resolves lookups case-insensitively.
-// Steps:
-//  1. Sets up a test repository
-//  2. Writes gitflow.branch.V9_Release.* config with a mixed-case subsection name
-//  3. Calls config.LoadConfig()
-//  4. Verifies the loaded config keys the branch by its exact case (V9_Release),
-//     not a lowercased variant (v9_release)
-//  5. Verifies ResolveBranchName resolves a lowercase lookup to the canonical key
-//  6. Verifies property-name lowercasing still parses (Type/UpstreamStrategy)
 func TestLoadConfigPreservesBranchNameCase(t *testing.T) {
-	// Setup
+	t.Parallel()
 	dir := setupTestRepo(t)
 	defer cleanupTestRepo(t, dir)
 
-	// Write a mixed-case branch subsection plus a mixed-case property name
-	configs := []struct {
-		key   string
-		value string
-	}{
-		{"gitflow.branch.V9_Release.type", "base"},
-		{"gitflow.branch.V9_Release.upstreamStrategy", "merge"},
-	}
-	for _, c := range configs {
-		cmd := exec.Command("git", "config", c.key, c.value)
-		cmd.Dir = dir
-		if err := cmd.Run(); err != nil {
-			t.Fatalf("Failed to set git config %s: %v", c.key, err)
-		}
-	}
+	setConfig(t, dir, "gitflow.branch.V9_Release.type", "base")
+	setConfig(t, dir, "gitflow.branch.V9_Release.upstreamStrategy", "merge")
+	setConfig(t, dir, "gitflow.version", "1.0")
 
-	// Set version to mark as initialized
-	cmd := exec.Command("git", "config", "gitflow.version", "1.0")
-	cmd.Dir = dir
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("Failed to set gitflow version: %v", err)
-	}
-
-	// Load config
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(openRepo(t, dir))
 	if err != nil {
 		t.Fatalf("Failed to load config: %v", err)
 	}
 
-	// The canonical key must be the exact original case, not lowercased
 	if _, exists := cfg.Branches["V9_Release"]; !exists {
 		t.Errorf("Expected canonical branch key 'V9_Release' to be preserved; branches: %v", keysOf(cfg.Branches))
 	}
@@ -514,7 +367,6 @@ func TestLoadConfigPreservesBranchNameCase(t *testing.T) {
 		t.Errorf("Did not expect a lowercased branch key 'v9_release'; branches: %v", keysOf(cfg.Branches))
 	}
 
-	// A case-insensitive lookup for a lowercase variant must resolve to the canonical key
 	canonical, found := cfg.ResolveBranchName("v9_release")
 	if !found {
 		t.Fatalf("Expected ResolveBranchName(\"v9_release\") to resolve, got not found")
@@ -523,13 +375,152 @@ func TestLoadConfigPreservesBranchNameCase(t *testing.T) {
 		t.Errorf("Expected resolved canonical name 'V9_Release', got '%s'", canonical)
 	}
 
-	// Property-name lowercasing must still parse the values
 	branch := cfg.Branches[canonical]
 	if branch.Type != "base" {
 		t.Errorf("Expected Type 'base', got '%s'", branch.Type)
 	}
 	if branch.UpstreamStrategy != "merge" {
 		t.Errorf("Expected UpstreamStrategy 'merge', got '%s'", branch.UpstreamStrategy)
+	}
+}
+
+// --- Scenario 6: config read off-CWD ---
+
+func TestLoadConfigReflectsTargetRepoOffCwd(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to init git-flow: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.branch.feature.prefix", "feat/"); err != nil {
+		t.Fatalf("Failed to set feature prefix: %v", err)
+	}
+
+	cfg, err := config.Load(openRepo(t, dir))
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+	if got := cfg.Branches["feature"].Prefix; got != "feat/" {
+		t.Errorf("Expected feature prefix 'feat/' from B, got %q", got)
+	}
+}
+
+func TestLoadConfigUninitializedReturnsDefaults(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	cfg, err := config.Load(openRepo(t, dir))
+	if err != nil {
+		t.Fatalf("Expected no error for uninitialized repo, got %v", err)
+	}
+	// Falls back to defaults: default feature prefix, default remote.
+	if got := cfg.Branches["feature"].Prefix; got != "feature/" {
+		t.Errorf("Expected default feature prefix 'feature/', got %q", got)
+	}
+	if cfg.Remote != "origin" {
+		t.Errorf("Expected default remote 'origin', got %q", cfg.Remote)
+	}
+}
+
+func TestLoadConfigImportsAvhOffCwd(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// git-flow-avh keys with distinctive non-default values, no gitflow.version.
+	setConfig(t, dir, "gitflow.branch.master", "production")
+	setConfig(t, dir, "gitflow.prefix.feature", "feat/")
+	setConfig(t, dir, "gitflow.prefix.hotfix", "hf/")
+
+	cfg, err := config.Load(openRepo(t, dir))
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	if _, exists := cfg.Branches["production"]; !exists {
+		t.Errorf("Expected AVH master 'production' imported; branches: %v", keysOf(cfg.Branches))
+	}
+	if _, exists := cfg.Branches["main"]; exists {
+		t.Errorf("Did not expect default 'main' after AVH import renamed it to 'production'")
+	}
+	if got := cfg.Branches["feature"].Prefix; got != "feat/" {
+		t.Errorf("Expected imported feature prefix 'feat/', got %q", got)
+	}
+}
+
+// --- Scenario 7: config mutation off-CWD ---
+
+func TestConfigSetIsolatedToTargetRepo(t *testing.T) {
+	t.Parallel()
+	dirA := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dirA)
+	dirB := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dirB)
+
+	if _, err := testutil.RunGitFlow(t, dirA, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to init A: %v", err)
+	}
+	if _, err := testutil.RunGitFlow(t, dirB, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to init B: %v", err)
+	}
+
+	repoB := openRepo(t, dirB)
+	if err := repoB.SetConfig("gitflow.branch.feature.prefix", "xb/"); err != nil {
+		t.Fatalf("SetConfig on B failed: %v", err)
+	}
+
+	cfgB, err := config.Load(repoB)
+	if err != nil {
+		t.Fatalf("Failed to load B config: %v", err)
+	}
+	if got := cfgB.Branches["feature"].Prefix; got != "xb/" {
+		t.Errorf("Expected B feature prefix 'xb/', got %q", got)
+	}
+
+	cfgA, err := config.Load(openRepo(t, dirA))
+	if err != nil {
+		t.Fatalf("Failed to load A config: %v", err)
+	}
+	if got := cfgA.Branches["feature"].Prefix; got != "feature/" {
+		t.Errorf("Expected A feature prefix to retain default 'feature/', got %q", got)
+	}
+}
+
+func TestConfigClearIsolatedToTargetRepo(t *testing.T) {
+	t.Parallel()
+	dirA := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dirA)
+	dirB := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dirB)
+
+	if _, err := testutil.RunGitFlow(t, dirA, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to init A: %v", err)
+	}
+	if _, err := testutil.RunGitFlow(t, dirB, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to init B: %v", err)
+	}
+
+	repoB := openRepo(t, dirB)
+	if err := config.ClearConfig(repoB); err != nil {
+		t.Fatalf("ClearConfig on B failed: %v", err)
+	}
+
+	// B's gitflow config is gone.
+	if _, err := repoB.GetConfig("gitflow.branch.feature.prefix"); err == nil {
+		t.Error("Expected B's gitflow.branch.feature.prefix to be removed")
+	}
+
+	// A's gitflow config is intact.
+	repoA := openRepo(t, dirA)
+	got, err := repoA.GetConfig("gitflow.branch.feature.prefix")
+	if err != nil {
+		t.Fatalf("Expected A's gitflow.branch.feature.prefix intact, got err: %v", err)
+	}
+	if got != "feature/" {
+		t.Errorf("Expected A feature prefix 'feature/', got %q", got)
 	}
 }
 

--- a/test/internal/config/dotted_names_test.go
+++ b/test/internal/config/dotted_names_test.go
@@ -33,13 +33,14 @@ func setDottedConfig(t *testing.T, dir string, kv map[string]string) {
 func TestLoadConfigDottedBranchName(t *testing.T) {
 	dir := setupTestRepo(t)
 	defer cleanupTestRepo(t, dir)
+	t.Parallel()
 
 	setDottedConfig(t, dir, map[string]string{
 		"gitflow.branch.custom.main.type":             "base",
 		"gitflow.branch.custom.main.upstreamStrategy": "merge",
 	})
 
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(openRepo(t, dir))
 	if err != nil {
 		t.Fatalf("Failed to load config: %v", err)
 	}
@@ -65,6 +66,7 @@ func TestLoadConfigDottedBranchName(t *testing.T) {
 func TestLoadConfigDottedTopicRoundTrip(t *testing.T) {
 	dir := setupTestRepo(t)
 	defer cleanupTestRepo(t, dir)
+	t.Parallel()
 
 	setDottedConfig(t, dir, map[string]string{
 		"gitflow.branch.qa.release.type":               "topic",
@@ -77,7 +79,7 @@ func TestLoadConfigDottedTopicRoundTrip(t *testing.T) {
 		"gitflow.branch.qa.release.tagPrefix":          "qa-",
 	})
 
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(openRepo(t, dir))
 	if err != nil {
 		t.Fatalf("Failed to load config: %v", err)
 	}
@@ -128,6 +130,7 @@ func TestLoadConfigDottedTopicRoundTrip(t *testing.T) {
 func TestLoadConfigDottedBooleanAndPrefix(t *testing.T) {
 	dir := setupTestRepo(t)
 	defer cleanupTestRepo(t, dir)
+	t.Parallel()
 
 	setDottedConfig(t, dir, map[string]string{
 		"gitflow.branch.custom.dev.type":       "base",
@@ -135,7 +138,7 @@ func TestLoadConfigDottedBooleanAndPrefix(t *testing.T) {
 		"gitflow.branch.custom.dev.autoUpdate": "true",
 	})
 
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(openRepo(t, dir))
 	if err != nil {
 		t.Fatalf("Failed to load config: %v", err)
 	}
@@ -158,12 +161,13 @@ func TestLoadConfigDottedBooleanAndPrefix(t *testing.T) {
 func TestLoadConfigMultiDotName(t *testing.T) {
 	dir := setupTestRepo(t)
 	defer cleanupTestRepo(t, dir)
+	t.Parallel()
 
 	setDottedConfig(t, dir, map[string]string{
 		"gitflow.branch.release.2.0.type": "base",
 	})
 
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(openRepo(t, dir))
 	if err != nil {
 		t.Fatalf("Failed to load config: %v", err)
 	}
@@ -187,6 +191,7 @@ func TestLoadConfigMultiDotName(t *testing.T) {
 func TestLoadConfigMixedCaseDottedName(t *testing.T) {
 	dir := setupTestRepo(t)
 	defer cleanupTestRepo(t, dir)
+	t.Parallel()
 
 	// Two keys with the same fold key but different case. Git stores subsections
 	// case-sensitively, so these are two distinct config entries; the reader
@@ -209,7 +214,7 @@ func TestLoadConfigMixedCaseDottedName(t *testing.T) {
 		t.Fatalf("Failed to set gitflow version: %v", err)
 	}
 
-	cfg, err := config.LoadConfig()
+	cfg, err := config.Load(openRepo(t, dir))
 	if err != nil {
 		t.Fatalf("Failed to load config: %v", err)
 	}

--- a/test/internal/config/main_test.go
+++ b/test/internal/config/main_test.go
@@ -1,0 +1,23 @@
+package config_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// TestMain builds the git-flow binary before running the config tests that
+// initialize git-flow via the binary. Set GIT_FLOW_PATH to test a specific
+// prebuilt binary instead.
+func TestMain(m *testing.M) {
+	cleanup, err := testutil.BuildGitFlow()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to build git-flow binary: %v\n", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}

--- a/test/internal/git/open_test.go
+++ b/test/internal/git/open_test.go
@@ -1,0 +1,197 @@
+package git_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gittower/git-flow-next/internal/git"
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// evalSymlinks normalizes a path through filepath.EvalSymlinks so comparisons
+// survive macOS's /var -> /private/var TMPDIR symlink. It falls back to the
+// input on error (e.g. the path does not exist yet).
+func evalSymlinks(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return path
+	}
+	return resolved
+}
+
+// relFromCwd computes a genuinely relative path from the process working
+// directory to target, so tests can exercise git.Open with a relative argument.
+func relFromCwd(t *testing.T, target string) string {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working directory: %v", err)
+	}
+	rel, err := filepath.Rel(cwd, target)
+	if err != nil {
+		t.Fatalf("Failed to compute relative path: %v", err)
+	}
+	if filepath.IsAbs(rel) {
+		t.Fatalf("Expected relative path, got absolute: %s", rel)
+	}
+	return rel
+}
+
+// TestOpenTargetsGivenRepoNotCwd verifies the core CWD-independence property:
+// git.Open(B) operates on repository B even though the process working directory
+// is neither B nor the second repo A, and a mutation on B's handle does not touch A.
+func TestOpenTargetsGivenRepoNotCwd(t *testing.T) {
+	t.Parallel()
+
+	repoA := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, repoA)
+	repoB := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, repoB)
+
+	repo, err := git.Open(repoB)
+	if err != nil {
+		t.Fatalf("git.Open(B) failed: %v", err)
+	}
+
+	if err := repo.CreateBranch("feature/only-in-b", "main"); err != nil {
+		t.Fatalf("CreateBranch on B failed: %v", err)
+	}
+
+	// The branch must exist in B.
+	if _, err := testutil.RunGit(t, repoB, "rev-parse", "--verify", "refs/heads/feature/only-in-b"); err != nil {
+		t.Errorf("Expected feature/only-in-b to exist in B: %v", err)
+	}
+
+	// The branch must NOT exist in A (Open(B) targeted only B).
+	if _, err := testutil.RunGit(t, repoA, "rev-parse", "--verify", "refs/heads/feature/only-in-b"); err == nil {
+		t.Error("feature/only-in-b leaked into repo A; Open(B) affected the wrong repository")
+	}
+}
+
+// TestOpenAccessorsAreAbsoluteFromNestedSubdir verifies that opening a repo via a
+// genuinely relative path to a nested subdirectory yields absolute accessors that
+// resolve to the target repository's root and git dir.
+func TestOpenAccessorsAreAbsoluteFromNestedSubdir(t *testing.T) {
+	t.Parallel()
+
+	repoB := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, repoB)
+
+	nested := filepath.Join(repoB, "sub", "dir")
+	if err := os.MkdirAll(nested, 0755); err != nil {
+		t.Fatalf("Failed to create nested subdir: %v", err)
+	}
+
+	relNested := relFromCwd(t, nested)
+
+	repo, err := git.Open(relNested)
+	if err != nil {
+		t.Fatalf("git.Open(relative nested) failed: %v", err)
+	}
+
+	if !filepath.IsAbs(repo.WorkTree()) {
+		t.Errorf("WorkTree() is not absolute: %s", repo.WorkTree())
+	}
+	if !filepath.IsAbs(repo.GitDir()) {
+		t.Errorf("GitDir() is not absolute: %s", repo.GitDir())
+	}
+	if !filepath.IsAbs(repo.CommonGitDir()) {
+		t.Errorf("CommonGitDir() is not absolute: %s", repo.CommonGitDir())
+	}
+	if filepath.Base(repo.GitDir()) == ".git" && repo.GitDir() == ".git" {
+		t.Errorf("GitDir() must not be the literal '.git', got %q", repo.GitDir())
+	}
+
+	wantRoot := evalSymlinks(t, repoB)
+	gotRoot := evalSymlinks(t, repo.WorkTree())
+	if gotRoot != wantRoot {
+		t.Errorf("WorkTree() = %q, want %q", gotRoot, wantRoot)
+	}
+
+	if _, err := os.Stat(repo.GitDir()); err != nil {
+		t.Errorf("GitDir() does not exist: %v", err)
+	}
+	gitDir := evalSymlinks(t, repo.GitDir())
+	if filepath.Dir(gitDir) != wantRoot {
+		t.Errorf("GitDir() %q is not inside B root %q", gitDir, wantRoot)
+	}
+}
+
+// TestOpenAccessorsAbsoluteForLinkedWorktree verifies accessors for a linked
+// worktree: GitDir() points at the per-worktree git dir, CommonGitDir() at the
+// main .git, both absolute.
+func TestOpenAccessorsAbsoluteForLinkedWorktree(t *testing.T) {
+	t.Parallel()
+
+	repoB := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, repoB)
+
+	wtParent, err := os.MkdirTemp("", "git-flow-linked-wt-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(wtParent)
+	wtPath := filepath.Join(wtParent, "wt")
+
+	if _, err := testutil.RunGit(t, repoB, "worktree", "add", wtPath, "-b", "wt-feature"); err != nil {
+		t.Fatalf("Failed to add linked worktree: %v", err)
+	}
+
+	repo, err := git.Open(wtPath)
+	if err != nil {
+		t.Fatalf("git.Open(linked worktree) failed: %v", err)
+	}
+
+	if !filepath.IsAbs(repo.WorkTree()) || !filepath.IsAbs(repo.GitDir()) || !filepath.IsAbs(repo.CommonGitDir()) {
+		t.Errorf("Expected all accessors absolute: worktree=%q gitDir=%q commonGitDir=%q",
+			repo.WorkTree(), repo.GitDir(), repo.CommonGitDir())
+	}
+
+	if _, err := os.Stat(repo.GitDir()); err != nil {
+		t.Errorf("per-worktree GitDir() does not exist: %v", err)
+	}
+
+	gitDir := evalSymlinks(t, repo.GitDir())
+	// Per-worktree git dir is <main .git>/worktrees/<name>.
+	if filepath.Base(filepath.Dir(gitDir)) != "worktrees" {
+		t.Errorf("Expected GitDir() to sit under .git/worktrees, got %q", gitDir)
+	}
+
+	wantCommon := evalSymlinks(t, filepath.Join(repoB, ".git"))
+	gotCommon := evalSymlinks(t, repo.CommonGitDir())
+	if gotCommon != wantCommon {
+		t.Errorf("CommonGitDir() = %q, want main .git %q", gotCommon, wantCommon)
+	}
+}
+
+// TestOpenEmptyStringReturnsError verifies git.Open("") errors without falling
+// back to the process working directory (which is itself a valid git repo).
+func TestOpenEmptyStringReturnsError(t *testing.T) {
+	t.Parallel()
+
+	repo, err := git.Open("")
+	if err == nil {
+		t.Fatal("Expected error for git.Open(\"\"), got nil")
+	}
+	if repo != nil {
+		t.Errorf("Expected nil repo for git.Open(\"\"), got %+v", repo)
+	}
+}
+
+// TestOpenNonRepoDirReturnsError verifies git.Open on a plain non-repo directory
+// errors rather than resolving an ancestor repo or the process CWD.
+func TestOpenNonRepoDirReturnsError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	repo, err := git.Open(dir)
+	if err == nil {
+		t.Fatal("Expected error for git.Open(non-repo dir), got nil")
+	}
+	if repo != nil {
+		t.Errorf("Expected nil repo for non-repo dir, got %+v", repo)
+	}
+}

--- a/test/internal/git/open_test.go
+++ b/test/internal/git/open_test.go
@@ -42,6 +42,12 @@ func relFromCwd(t *testing.T, target string) string {
 // TestOpenTargetsGivenRepoNotCwd verifies the core CWD-independence property:
 // git.Open(B) operates on repository B even though the process working directory
 // is neither B nor the second repo A, and a mutation on B's handle does not touch A.
+// Steps:
+// 1. Creates two independent test repositories A and B
+// 2. Opens a handle for B with git.Open(B)
+// 3. Creates branch feature/only-in-b through B's handle
+// 4. Verifies feature/only-in-b exists in B
+// 5. Verifies feature/only-in-b did not leak into A
 func TestOpenTargetsGivenRepoNotCwd(t *testing.T) {
 	t.Parallel()
 
@@ -73,6 +79,12 @@ func TestOpenTargetsGivenRepoNotCwd(t *testing.T) {
 // TestOpenAccessorsAreAbsoluteFromNestedSubdir verifies that opening a repo via a
 // genuinely relative path to a nested subdirectory yields absolute accessors that
 // resolve to the target repository's root and git dir.
+// Steps:
+// 1. Creates a test repository and a nested sub/dir inside it
+// 2. Computes a relative path from the process CWD to the nested dir
+// 3. Opens a handle with git.Open(relative nested path)
+// 4. Verifies WorkTree(), GitDir(), and CommonGitDir() are all absolute
+// 5. Verifies WorkTree() resolves to the repository root and GitDir() lives inside it
 func TestOpenAccessorsAreAbsoluteFromNestedSubdir(t *testing.T) {
 	t.Parallel()
 
@@ -122,6 +134,12 @@ func TestOpenAccessorsAreAbsoluteFromNestedSubdir(t *testing.T) {
 // TestOpenAccessorsAbsoluteForLinkedWorktree verifies accessors for a linked
 // worktree: GitDir() points at the per-worktree git dir, CommonGitDir() at the
 // main .git, both absolute.
+// Steps:
+// 1. Creates a test repository and adds a linked worktree via git worktree add
+// 2. Opens a handle for the linked worktree path
+// 3. Verifies WorkTree(), GitDir(), and CommonGitDir() are all absolute
+// 4. Verifies GitDir() points at the per-worktree dir under .git/worktrees
+// 5. Verifies CommonGitDir() points at the main repository's .git
 func TestOpenAccessorsAbsoluteForLinkedWorktree(t *testing.T) {
 	t.Parallel()
 
@@ -168,6 +186,10 @@ func TestOpenAccessorsAbsoluteForLinkedWorktree(t *testing.T) {
 
 // TestOpenEmptyStringReturnsError verifies git.Open("") errors without falling
 // back to the process working directory (which is itself a valid git repo).
+// Steps:
+// 1. Calls git.Open("") with an empty directory argument
+// 2. Verifies an error is returned
+// 3. Verifies the returned repo handle is nil
 func TestOpenEmptyStringReturnsError(t *testing.T) {
 	t.Parallel()
 
@@ -182,6 +204,11 @@ func TestOpenEmptyStringReturnsError(t *testing.T) {
 
 // TestOpenNonRepoDirReturnsError verifies git.Open on a plain non-repo directory
 // errors rather than resolving an ancestor repo or the process CWD.
+// Steps:
+// 1. Creates a plain temporary directory that is not a git repository
+// 2. Calls git.Open on that directory
+// 3. Verifies an error is returned
+// 4. Verifies the returned repo handle is nil
 func TestOpenNonRepoDirReturnsError(t *testing.T) {
 	t.Parallel()
 

--- a/test/internal/git/repo_test.go
+++ b/test/internal/git/repo_test.go
@@ -10,291 +10,220 @@ import (
 	"github.com/gittower/git-flow-next/test/testutil"
 )
 
-// withGitRepo changes to the provided directory, runs the testFunc, and changes back to the original directory after the test function is done
-func withGitRepo(t *testing.T, dir string, testFunc func()) {
-	// Save current directory
-	oldDir, err := os.Getwd()
+// openRepo opens a git.Repo handle for dir, failing the test on error. It is the
+// CWD-independent replacement for the old withGitRepo(os.Chdir) helper.
+func openRepo(t *testing.T, dir string) *git.Repo {
+	t.Helper()
+	repo, err := git.Open(dir)
 	if err != nil {
-		t.Fatalf("Failed to get current directory: %v", err)
+		t.Fatalf("git.Open(%q) failed: %v", dir, err)
 	}
+	return repo
+}
 
-	// Change to the test directory
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("Failed to change to test directory: %v", err)
+// setupConflictingBranches creates a feature branch and a diverging main branch
+// that both touch conflict.txt, per GIT_TEST_SCENARIOS.md (branch first, then
+// conflicting content). It leaves the repo checked out on main.
+func setupConflictingBranches(t *testing.T, dir string) {
+	t.Helper()
+	if _, err := testutil.RunGit(t, dir, "checkout", "-b", "feature"); err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
 	}
-
-	// Ensure we change back to the original directory when done
-	defer func() {
-		if err := os.Chdir(oldDir); err != nil {
-			t.Fatalf("Failed to change back to original directory: %v", err)
-		}
-	}()
-
-	// Run the test function
-	testFunc()
+	testutil.WriteFile(t, dir, "conflict.txt", "feature content")
+	if _, err := testutil.RunGit(t, dir, "add", "conflict.txt"); err != nil {
+		t.Fatalf("Failed to add file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Feature commit"); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "checkout", "main"); err != nil {
+		t.Fatalf("Failed to checkout main: %v", err)
+	}
+	testutil.WriteFile(t, dir, "conflict.txt", "main content")
+	if _, err := testutil.RunGit(t, dir, "add", "conflict.txt"); err != nil {
+		t.Fatalf("Failed to add file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Main commit"); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
 }
 
 func TestRemoteBranchExists_ExistingBranch(t *testing.T) {
-	// Setup test repo
+	t.Parallel()
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 
-	// Add a remote
-	remoteDir, err := testutil.AddRemote(t, dir, "origin", false) // Don't push all branches yet
+	remoteDir, err := testutil.AddRemote(t, dir, "origin", false)
 	if err != nil {
 		t.Fatalf("Failed to add remote: %v", err)
 	}
 	defer testutil.CleanupTestRepo(t, remoteDir)
 
-	// Create and push a feature branch
-	_, err = testutil.RunGit(t, dir, "checkout", "-b", "feature/test")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "checkout", "-b", "feature/test"); err != nil {
 		t.Fatalf("Failed to create branch: %v", err)
 	}
-
-	// Create a test file and commit it
 	testutil.WriteFile(t, dir, "test.txt", "test content")
-	_, err = testutil.RunGit(t, dir, "add", "test.txt")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "add", "test.txt"); err != nil {
 		t.Fatalf("Failed to add file: %v", err)
 	}
-	_, err = testutil.RunGit(t, dir, "commit", "-m", "test commit")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "commit", "-m", "test commit"); err != nil {
 		t.Fatalf("Failed to commit: %v", err)
 	}
-
-	// Push the branch with --set-upstream
-	_, err = testutil.RunGit(t, dir, "push", "-u", "origin", "feature/test")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "push", "-u", "origin", "feature/test"); err != nil {
 		t.Fatalf("Failed to push branch: %v", err)
 	}
-
-	// Fetch to update remote tracking branches
-	_, err = testutil.RunGit(t, dir, "fetch", "origin")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "fetch", "origin"); err != nil {
 		t.Fatalf("Failed to fetch from remote: %v", err)
 	}
 
-	// Use our helper to change to the test directory and run the test
-	withGitRepo(t, dir, func() {
-		// Check if the branch exists
-		exists := git.RemoteBranchExists("origin", "feature/test")
-		if !exists {
-			t.Error("Expected RemoteBranchExists to return true for existing branch")
-		}
-	})
+	repo := openRepo(t, dir)
+	if !repo.RemoteBranchExists("origin", "feature/test") {
+		t.Error("Expected RemoteBranchExists to return true for existing branch")
+	}
 }
 
 func TestRemoteBranchExists_NonExistentBranch(t *testing.T) {
-	// Setup test repo
+	t.Parallel()
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 
-	// Add a remote
 	remoteDir, err := testutil.AddRemote(t, dir, "origin", true)
 	if err != nil {
 		t.Fatalf("Failed to add remote: %v", err)
 	}
 	defer testutil.CleanupTestRepo(t, remoteDir)
 
-	// Fetch to update remote tracking branches
-	_, err = testutil.RunGit(t, dir, "fetch", "origin")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "fetch", "origin"); err != nil {
 		t.Fatalf("Failed to fetch from remote: %v", err)
 	}
 
-	// Use our helper to change to the test directory and run the test
-	withGitRepo(t, dir, func() {
-		// Check if a non-existent branch exists
-		exists := git.RemoteBranchExists("origin", "feature/non-existent")
-		if exists {
-			t.Error("Expected RemoteBranchExists to return false for non-existent branch")
-		}
-	})
+	repo := openRepo(t, dir)
+	if repo.RemoteBranchExists("origin", "feature/non-existent") {
+		t.Error("Expected RemoteBranchExists to return false for non-existent branch")
+	}
 }
 
 func TestDeleteNonExistentRemoteBranch(t *testing.T) {
-	// Setup test repo
+	t.Parallel()
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 
-	// Add a remote
 	remoteDir, err := testutil.AddRemote(t, dir, "origin", true)
 	if err != nil {
 		t.Fatalf("Failed to add remote: %v", err)
 	}
 	defer testutil.CleanupTestRepo(t, remoteDir)
 
-	// Use our helper to change to the test directory and run the test
-	withGitRepo(t, dir, func() {
-		// Try to delete a non-existent branch
-		err = git.DeleteRemoteBranch("origin", "feature/non-existent")
-		if err == nil {
-			t.Error("Expected an error when deleting non-existent remote branch, got nil")
-		}
-	})
+	repo := openRepo(t, dir)
+	if err := repo.DeleteRemoteBranch("origin", "feature/non-existent"); err == nil {
+		t.Error("Expected an error when deleting non-existent remote branch, got nil")
+	}
 }
 
 func TestDeleteExistingRemoteBranch(t *testing.T) {
-	// Setup test repo
+	t.Parallel()
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 
-	// Add a remote
 	remoteDir, err := testutil.AddRemote(t, dir, "origin", true)
 	if err != nil {
 		t.Fatalf("Failed to add remote: %v", err)
 	}
 	defer testutil.CleanupTestRepo(t, remoteDir)
 
-	// Create and push a feature branch
-	_, err = testutil.RunGit(t, dir, "checkout", "-b", "feature/test")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "checkout", "-b", "feature/test"); err != nil {
 		t.Fatalf("Failed to create branch: %v", err)
 	}
-
-	// Create a test file and commit it
 	testutil.WriteFile(t, dir, "test.txt", "test content")
-	_, err = testutil.RunGit(t, dir, "add", "test.txt")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "add", "test.txt"); err != nil {
 		t.Fatalf("Failed to add file: %v", err)
 	}
-	_, err = testutil.RunGit(t, dir, "commit", "-m", "test commit")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "commit", "-m", "test commit"); err != nil {
 		t.Fatalf("Failed to commit: %v", err)
 	}
-
-	// Push the branch
-	_, err = testutil.RunGit(t, dir, "push", "origin", "feature/test")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "push", "origin", "feature/test"); err != nil {
 		t.Fatalf("Failed to push branch: %v", err)
 	}
-
-	// Fetch to update remote tracking branches
-	_, err = testutil.RunGit(t, dir, "fetch", "origin")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "fetch", "origin"); err != nil {
 		t.Fatalf("Failed to fetch from remote: %v", err)
 	}
 
-	// Use our helper to change to the test directory and run the test
-	withGitRepo(t, dir, func() {
-		// Delete the remote branch
-		err = git.DeleteRemoteBranch("origin", "feature/test")
-		if err != nil {
-			t.Errorf("Expected no error when deleting existing remote branch, got: %v", err)
-		}
-	})
-
-	// Fetch from remote to update refs
-	_, err = testutil.RunGit(t, dir, "fetch", "origin", "--prune")
-	if err != nil {
-		t.Fatalf("Failed to fetch from remote: %v", err)
+	repo := openRepo(t, dir)
+	if err := repo.DeleteRemoteBranch("origin", "feature/test"); err != nil {
+		t.Errorf("Expected no error when deleting existing remote branch, got: %v", err)
 	}
 
-	// Verify branch was deleted by checking the remote tracking branch
-	_, err = testutil.RunGit(t, dir, "rev-parse", "--verify", "refs/remotes/origin/feature/test")
-	if err == nil {
+	if _, err = testutil.RunGit(t, dir, "fetch", "origin", "--prune"); err != nil {
+		t.Fatalf("Failed to fetch from remote: %v", err)
+	}
+	if _, err = testutil.RunGit(t, dir, "rev-parse", "--verify", "refs/remotes/origin/feature/test"); err == nil {
 		t.Error("Expected remote tracking branch to be deleted")
 	}
 }
 
 func TestDeleteBranchFromNonExistentRemote(t *testing.T) {
-	// Setup test repo
+	t.Parallel()
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 
-	// Use our helper to change to the test directory and run the test
-	withGitRepo(t, dir, func() {
-		// Try to delete a branch from a non-existent remote
-		err := git.DeleteRemoteBranch("non-existent-remote", "feature/test")
-		if err == nil {
-			t.Error("Expected an error when deleting from non-existent remote, got nil")
-		}
-	})
+	repo := openRepo(t, dir)
+	if err := repo.DeleteRemoteBranch("non-existent-remote", "feature/test"); err == nil {
+		t.Error("Expected an error when deleting from non-existent remote, got nil")
+	}
 }
 
-// TestGetTrackingBranch tests that the tracking branch is correctly identified.
-// Steps:
-// 1. Sets up a test repository with a remote
-// 2. Creates a feature branch and pushes it with tracking
-// 3. Calls GetTrackingBranch on the feature branch
-// 4. Verifies the correct remote tracking branch is returned (origin/feature/test)
 func TestGetTrackingBranch(t *testing.T) {
+	t.Parallel()
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 
-	// Add a remote
 	remoteDir, err := testutil.AddRemote(t, dir, "origin", false)
 	if err != nil {
 		t.Fatalf("Failed to add remote: %v", err)
 	}
 	defer testutil.CleanupTestRepo(t, remoteDir)
 
-	// Create and push a feature branch with tracking
-	_, err = testutil.RunGit(t, dir, "checkout", "-b", "feature/test")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "checkout", "-b", "feature/test"); err != nil {
 		t.Fatalf("Failed to create branch: %v", err)
 	}
-
 	testutil.WriteFile(t, dir, "test.txt", "test content")
-	_, err = testutil.RunGit(t, dir, "add", "test.txt")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "add", "test.txt"); err != nil {
 		t.Fatalf("Failed to add file: %v", err)
 	}
-	_, err = testutil.RunGit(t, dir, "commit", "-m", "test commit")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "commit", "-m", "test commit"); err != nil {
 		t.Fatalf("Failed to commit: %v", err)
 	}
-
-	// Push with --set-upstream to establish tracking
-	_, err = testutil.RunGit(t, dir, "push", "--set-upstream", "origin", "feature/test")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "push", "--set-upstream", "origin", "feature/test"); err != nil {
 		t.Fatalf("Failed to push branch: %v", err)
 	}
 
-	withGitRepo(t, dir, func() {
-		trackingBranch, err := git.GetTrackingBranch("feature/test")
-		if err != nil {
-			t.Fatalf("GetTrackingBranch returned unexpected error: %v", err)
-		}
-		expected := "origin/feature/test"
-		if trackingBranch != expected {
-			t.Errorf("Expected tracking branch '%s', got '%s'", expected, trackingBranch)
-		}
-	})
+	repo := openRepo(t, dir)
+	trackingBranch, err := repo.GetTrackingBranch("feature/test")
+	if err != nil {
+		t.Fatalf("GetTrackingBranch returned unexpected error: %v", err)
+	}
+	if trackingBranch != "origin/feature/test" {
+		t.Errorf("Expected tracking branch 'origin/feature/test', got '%s'", trackingBranch)
+	}
 }
 
-// TestGetTrackingBranchNoTracking tests behavior when branch has no tracking branch.
-// Steps:
-// 1. Sets up a test repository
-// 2. Creates a local-only branch without pushing
-// 3. Calls GetTrackingBranch on the local branch
-// 4. Verifies an appropriate error is returned
 func TestGetTrackingBranchNoTracking(t *testing.T) {
+	t.Parallel()
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 
-	// Create a local-only branch (no remote, no tracking)
-	_, err := testutil.RunGit(t, dir, "checkout", "-b", "feature/local-only")
-	if err != nil {
+	if _, err := testutil.RunGit(t, dir, "checkout", "-b", "feature/local-only"); err != nil {
 		t.Fatalf("Failed to create branch: %v", err)
 	}
 
-	withGitRepo(t, dir, func() {
-		_, err := git.GetTrackingBranch("feature/local-only")
-		if err == nil {
-			t.Error("Expected error for branch without tracking, got nil")
-		}
-	})
+	repo := openRepo(t, dir)
+	if _, err := repo.GetTrackingBranch("feature/local-only"); err == nil {
+		t.Error("Expected error for branch without tracking, got nil")
+	}
 }
 
-// TestCompareBranchWithRemoteEqual tests comparison when local equals remote.
-// Steps:
-// 1. Sets up a test repository with a remote
-// 2. Creates and pushes a feature branch with tracking
-// 3. Calls CompareBranchWithRemote (no changes made after push)
-// 4. Verifies SyncStatusEqual is returned with 0 commits difference
 func TestCompareBranchWithRemoteEqual(t *testing.T) {
+	t.Parallel()
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 
@@ -304,49 +233,35 @@ func TestCompareBranchWithRemoteEqual(t *testing.T) {
 	}
 	defer testutil.CleanupTestRepo(t, remoteDir)
 
-	// Create and push a feature branch
-	_, err = testutil.RunGit(t, dir, "checkout", "-b", "feature/test")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "checkout", "-b", "feature/test"); err != nil {
 		t.Fatalf("Failed to create branch: %v", err)
 	}
-
 	testutil.WriteFile(t, dir, "test.txt", "test content")
-	_, err = testutil.RunGit(t, dir, "add", "test.txt")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "add", "test.txt"); err != nil {
 		t.Fatalf("Failed to add file: %v", err)
 	}
-	_, err = testutil.RunGit(t, dir, "commit", "-m", "test commit")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "commit", "-m", "test commit"); err != nil {
 		t.Fatalf("Failed to commit: %v", err)
 	}
-
-	_, err = testutil.RunGit(t, dir, "push", "--set-upstream", "origin", "feature/test")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "push", "--set-upstream", "origin", "feature/test"); err != nil {
 		t.Fatalf("Failed to push branch: %v", err)
 	}
 
-	withGitRepo(t, dir, func() {
-		status, count, err := git.CompareBranchWithRemote("feature/test")
-		if err != nil {
-			t.Fatalf("CompareBranchWithRemote returned unexpected error: %v", err)
-		}
-		if status != git.SyncStatusEqual {
-			t.Errorf("Expected status SyncStatusEqual, got %s", status)
-		}
-		if count != 0 {
-			t.Errorf("Expected count 0, got %d", count)
-		}
-	})
+	repo := openRepo(t, dir)
+	status, count, err := repo.CompareBranchWithRemote("feature/test")
+	if err != nil {
+		t.Fatalf("CompareBranchWithRemote returned unexpected error: %v", err)
+	}
+	if status != git.SyncStatusEqual {
+		t.Errorf("Expected status SyncStatusEqual, got %s", status)
+	}
+	if count != 0 {
+		t.Errorf("Expected count 0, got %d", count)
+	}
 }
 
-// TestCompareBranchWithRemoteAhead tests comparison when local is ahead of remote.
-// Steps:
-// 1. Sets up a test repository with a remote
-// 2. Creates and pushes a feature branch with tracking
-// 3. Adds a new commit locally without pushing
-// 4. Calls CompareBranchWithRemote
-// 5. Verifies SyncStatusAhead is returned with correct commit count
 func TestCompareBranchWithRemoteAhead(t *testing.T) {
+	t.Parallel()
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 
@@ -356,61 +271,42 @@ func TestCompareBranchWithRemoteAhead(t *testing.T) {
 	}
 	defer testutil.CleanupTestRepo(t, remoteDir)
 
-	// Create and push a feature branch
-	_, err = testutil.RunGit(t, dir, "checkout", "-b", "feature/test")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "checkout", "-b", "feature/test"); err != nil {
 		t.Fatalf("Failed to create branch: %v", err)
 	}
-
 	testutil.WriteFile(t, dir, "test.txt", "test content")
-	_, err = testutil.RunGit(t, dir, "add", "test.txt")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "add", "test.txt"); err != nil {
 		t.Fatalf("Failed to add file: %v", err)
 	}
-	_, err = testutil.RunGit(t, dir, "commit", "-m", "test commit")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "commit", "-m", "test commit"); err != nil {
 		t.Fatalf("Failed to commit: %v", err)
 	}
-
-	_, err = testutil.RunGit(t, dir, "push", "--set-upstream", "origin", "feature/test")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "push", "--set-upstream", "origin", "feature/test"); err != nil {
 		t.Fatalf("Failed to push branch: %v", err)
 	}
-
-	// Add another commit locally without pushing
 	testutil.WriteFile(t, dir, "local.txt", "local content")
-	_, err = testutil.RunGit(t, dir, "add", "local.txt")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "add", "local.txt"); err != nil {
 		t.Fatalf("Failed to add file: %v", err)
 	}
-	_, err = testutil.RunGit(t, dir, "commit", "-m", "local commit")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "commit", "-m", "local commit"); err != nil {
 		t.Fatalf("Failed to commit: %v", err)
 	}
 
-	withGitRepo(t, dir, func() {
-		status, count, err := git.CompareBranchWithRemote("feature/test")
-		if err != nil {
-			t.Fatalf("CompareBranchWithRemote returned unexpected error: %v", err)
-		}
-		if status != git.SyncStatusAhead {
-			t.Errorf("Expected status SyncStatusAhead, got %s", status)
-		}
-		if count != 1 {
-			t.Errorf("Expected count 1, got %d", count)
-		}
-	})
+	repo := openRepo(t, dir)
+	status, count, err := repo.CompareBranchWithRemote("feature/test")
+	if err != nil {
+		t.Fatalf("CompareBranchWithRemote returned unexpected error: %v", err)
+	}
+	if status != git.SyncStatusAhead {
+		t.Errorf("Expected status SyncStatusAhead, got %s", status)
+	}
+	if count != 1 {
+		t.Errorf("Expected count 1, got %d", count)
+	}
 }
 
-// TestCompareBranchWithRemoteBehind tests comparison when local is behind remote.
-// Steps:
-// 1. Sets up a test repository with a remote
-// 2. Creates and pushes a feature branch with tracking
-// 3. Clones to second repo, adds commit, pushes to remote
-// 4. Fetches in original repo to update remote refs
-// 5. Calls CompareBranchWithRemote on original repo
-// 6. Verifies SyncStatusBehind is returned with correct commit count
 func TestCompareBranchWithRemoteBehind(t *testing.T) {
+	t.Parallel()
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 
@@ -420,84 +316,57 @@ func TestCompareBranchWithRemoteBehind(t *testing.T) {
 	}
 	defer testutil.CleanupTestRepo(t, remoteDir)
 
-	// Create and push a feature branch
-	_, err = testutil.RunGit(t, dir, "checkout", "-b", "feature/test")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "checkout", "-b", "feature/test"); err != nil {
 		t.Fatalf("Failed to create branch: %v", err)
 	}
-
 	testutil.WriteFile(t, dir, "test.txt", "test content")
-	_, err = testutil.RunGit(t, dir, "add", "test.txt")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "add", "test.txt"); err != nil {
 		t.Fatalf("Failed to add file: %v", err)
 	}
-	_, err = testutil.RunGit(t, dir, "commit", "-m", "test commit")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "commit", "-m", "test commit"); err != nil {
 		t.Fatalf("Failed to commit: %v", err)
 	}
-
-	_, err = testutil.RunGit(t, dir, "push", "--set-upstream", "origin", "feature/test")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "push", "--set-upstream", "origin", "feature/test"); err != nil {
 		t.Fatalf("Failed to push branch: %v", err)
 	}
 
-	// Clone to a second working copy and make changes
 	secondDir := t.TempDir()
-	_, err = testutil.RunGit(t, secondDir, "clone", remoteDir, ".")
-	if err != nil {
+	if _, err = testutil.RunGit(t, secondDir, "clone", remoteDir, "."); err != nil {
 		t.Fatalf("Failed to clone: %v", err)
 	}
 	testutil.ConfigureGitIdentity(t, secondDir)
-
-	_, err = testutil.RunGit(t, secondDir, "checkout", "feature/test")
-	if err != nil {
+	if _, err = testutil.RunGit(t, secondDir, "checkout", "feature/test"); err != nil {
 		t.Fatalf("Failed to checkout feature branch in second repo: %v", err)
 	}
-
 	testutil.WriteFile(t, secondDir, "remote-change.txt", "remote content")
-	_, err = testutil.RunGit(t, secondDir, "add", "remote-change.txt")
-	if err != nil {
+	if _, err = testutil.RunGit(t, secondDir, "add", "remote-change.txt"); err != nil {
 		t.Fatalf("Failed to add file in second repo: %v", err)
 	}
-	_, err = testutil.RunGit(t, secondDir, "commit", "-m", "remote commit")
-	if err != nil {
+	if _, err = testutil.RunGit(t, secondDir, "commit", "-m", "remote commit"); err != nil {
 		t.Fatalf("Failed to commit in second repo: %v", err)
 	}
-	_, err = testutil.RunGit(t, secondDir, "push", "origin", "feature/test")
-	if err != nil {
+	if _, err = testutil.RunGit(t, secondDir, "push", "origin", "feature/test"); err != nil {
 		t.Fatalf("Failed to push from second repo: %v", err)
 	}
-
-	// Fetch in original repo to update remote refs
-	_, err = testutil.RunGit(t, dir, "fetch", "origin")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "fetch", "origin"); err != nil {
 		t.Fatalf("Failed to fetch: %v", err)
 	}
 
-	withGitRepo(t, dir, func() {
-		status, count, err := git.CompareBranchWithRemote("feature/test")
-		if err != nil {
-			t.Fatalf("CompareBranchWithRemote returned unexpected error: %v", err)
-		}
-		if status != git.SyncStatusBehind {
-			t.Errorf("Expected status SyncStatusBehind, got %s", status)
-		}
-		if count != 1 {
-			t.Errorf("Expected count 1, got %d", count)
-		}
-	})
+	repo := openRepo(t, dir)
+	status, count, err := repo.CompareBranchWithRemote("feature/test")
+	if err != nil {
+		t.Fatalf("CompareBranchWithRemote returned unexpected error: %v", err)
+	}
+	if status != git.SyncStatusBehind {
+		t.Errorf("Expected status SyncStatusBehind, got %s", status)
+	}
+	if count != 1 {
+		t.Errorf("Expected count 1, got %d", count)
+	}
 }
 
-// TestCompareBranchWithRemoteDiverged tests comparison when local and remote have diverged.
-// Steps:
-// 1. Sets up a test repository with a remote
-// 2. Creates and pushes a feature branch with tracking
-// 3. Clones to second repo, adds commit, pushes to remote
-// 4. Adds different commit locally (without fetching first)
-// 5. Fetches in original repo to update remote refs
-// 6. Calls CompareBranchWithRemote
-// 7. Verifies SyncStatusDiverged is returned
 func TestCompareBranchWithRemoteDiverged(t *testing.T) {
+	t.Parallel()
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 
@@ -507,93 +376,65 @@ func TestCompareBranchWithRemoteDiverged(t *testing.T) {
 	}
 	defer testutil.CleanupTestRepo(t, remoteDir)
 
-	// Create and push a feature branch
-	_, err = testutil.RunGit(t, dir, "checkout", "-b", "feature/test")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "checkout", "-b", "feature/test"); err != nil {
 		t.Fatalf("Failed to create branch: %v", err)
 	}
-
 	testutil.WriteFile(t, dir, "test.txt", "test content")
-	_, err = testutil.RunGit(t, dir, "add", "test.txt")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "add", "test.txt"); err != nil {
 		t.Fatalf("Failed to add file: %v", err)
 	}
-	_, err = testutil.RunGit(t, dir, "commit", "-m", "test commit")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "commit", "-m", "test commit"); err != nil {
 		t.Fatalf("Failed to commit: %v", err)
 	}
-
-	_, err = testutil.RunGit(t, dir, "push", "--set-upstream", "origin", "feature/test")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "push", "--set-upstream", "origin", "feature/test"); err != nil {
 		t.Fatalf("Failed to push branch: %v", err)
 	}
 
-	// Clone to a second working copy and make changes
 	secondDir := t.TempDir()
-	_, err = testutil.RunGit(t, secondDir, "clone", remoteDir, ".")
-	if err != nil {
+	if _, err = testutil.RunGit(t, secondDir, "clone", remoteDir, "."); err != nil {
 		t.Fatalf("Failed to clone: %v", err)
 	}
 	testutil.ConfigureGitIdentity(t, secondDir)
-
-	_, err = testutil.RunGit(t, secondDir, "checkout", "feature/test")
-	if err != nil {
+	if _, err = testutil.RunGit(t, secondDir, "checkout", "feature/test"); err != nil {
 		t.Fatalf("Failed to checkout feature branch in second repo: %v", err)
 	}
-
 	testutil.WriteFile(t, secondDir, "remote-change.txt", "remote content")
-	_, err = testutil.RunGit(t, secondDir, "add", "remote-change.txt")
-	if err != nil {
+	if _, err = testutil.RunGit(t, secondDir, "add", "remote-change.txt"); err != nil {
 		t.Fatalf("Failed to add file in second repo: %v", err)
 	}
-	_, err = testutil.RunGit(t, secondDir, "commit", "-m", "remote commit")
-	if err != nil {
+	if _, err = testutil.RunGit(t, secondDir, "commit", "-m", "remote commit"); err != nil {
 		t.Fatalf("Failed to commit in second repo: %v", err)
 	}
-	_, err = testutil.RunGit(t, secondDir, "push", "origin", "feature/test")
-	if err != nil {
+	if _, err = testutil.RunGit(t, secondDir, "push", "origin", "feature/test"); err != nil {
 		t.Fatalf("Failed to push from second repo: %v", err)
 	}
 
-	// Add local commit (before fetching - creates divergence)
 	testutil.WriteFile(t, dir, "local-change.txt", "local content")
-	_, err = testutil.RunGit(t, dir, "add", "local-change.txt")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "add", "local-change.txt"); err != nil {
 		t.Fatalf("Failed to add file: %v", err)
 	}
-	_, err = testutil.RunGit(t, dir, "commit", "-m", "local commit")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "commit", "-m", "local commit"); err != nil {
 		t.Fatalf("Failed to commit: %v", err)
 	}
-
-	// Now fetch to update remote refs (creates divergence)
-	_, err = testutil.RunGit(t, dir, "fetch", "origin")
-	if err != nil {
+	if _, err = testutil.RunGit(t, dir, "fetch", "origin"); err != nil {
 		t.Fatalf("Failed to fetch: %v", err)
 	}
 
-	withGitRepo(t, dir, func() {
-		status, count, err := git.CompareBranchWithRemote("feature/test")
-		if err != nil {
-			t.Fatalf("CompareBranchWithRemote returned unexpected error: %v", err)
-		}
-		if status != git.SyncStatusDiverged {
-			t.Errorf("Expected status SyncStatusDiverged, got %s", status)
-		}
-		if count != 2 { // 1 ahead + 1 behind = 2 total
-			t.Errorf("Expected count 2 (1 ahead + 1 behind), got %d", count)
-		}
-	})
+	repo := openRepo(t, dir)
+	status, count, err := repo.CompareBranchWithRemote("feature/test")
+	if err != nil {
+		t.Fatalf("CompareBranchWithRemote returned unexpected error: %v", err)
+	}
+	if status != git.SyncStatusDiverged {
+		t.Errorf("Expected status SyncStatusDiverged, got %s", status)
+	}
+	if count != 2 {
+		t.Errorf("Expected count 2 (1 ahead + 1 behind), got %d", count)
+	}
 }
 
-// TestFetchBranch tests targeted fetch of a specific branch.
-// Steps:
-// 1. Sets up a test repository with a remote
-// 2. Pushes main branch to remote
-// 3. Clones to second repo, adds commit to main, pushes
-// 4. Calls FetchBranch for main in original repo
-// 5. Verifies the remote ref is updated
 func TestFetchBranch(t *testing.T) {
+	t.Parallel()
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 
@@ -603,61 +444,43 @@ func TestFetchBranch(t *testing.T) {
 	}
 	defer testutil.CleanupTestRepo(t, remoteDir)
 
-	// Get initial commit hash on origin/main
 	initialHash, err := testutil.RunGit(t, dir, "rev-parse", "origin/main")
 	if err != nil {
 		t.Fatalf("Failed to get initial hash: %v", err)
 	}
 
-	// Clone to a second working copy and make changes
 	secondDir := t.TempDir()
-	_, err = testutil.RunGit(t, secondDir, "clone", remoteDir, ".")
-	if err != nil {
+	if _, err = testutil.RunGit(t, secondDir, "clone", remoteDir, "."); err != nil {
 		t.Fatalf("Failed to clone: %v", err)
 	}
 	testutil.ConfigureGitIdentity(t, secondDir)
-
 	testutil.WriteFile(t, secondDir, "remote-change.txt", "remote content")
-	_, err = testutil.RunGit(t, secondDir, "add", "remote-change.txt")
-	if err != nil {
+	if _, err = testutil.RunGit(t, secondDir, "add", "remote-change.txt"); err != nil {
 		t.Fatalf("Failed to add file in second repo: %v", err)
 	}
-	_, err = testutil.RunGit(t, secondDir, "commit", "-m", "remote commit")
-	if err != nil {
+	if _, err = testutil.RunGit(t, secondDir, "commit", "-m", "remote commit"); err != nil {
 		t.Fatalf("Failed to commit in second repo: %v", err)
 	}
-	_, err = testutil.RunGit(t, secondDir, "push", "origin", "main")
-	if err != nil {
+	if _, err = testutil.RunGit(t, secondDir, "push", "origin", "main"); err != nil {
 		t.Fatalf("Failed to push from second repo: %v", err)
 	}
 
-	// Fetch the branch using FetchBranch
-	withGitRepo(t, dir, func() {
-		err := git.FetchBranch("origin", "main")
-		if err != nil {
-			t.Fatalf("FetchBranch returned unexpected error: %v", err)
-		}
-	})
+	repo := openRepo(t, dir)
+	if err := repo.FetchBranch("origin", "main"); err != nil {
+		t.Fatalf("FetchBranch returned unexpected error: %v", err)
+	}
 
-	// Verify the remote ref was updated
 	newHash, err := testutil.RunGit(t, dir, "rev-parse", "origin/main")
 	if err != nil {
 		t.Fatalf("Failed to get new hash: %v", err)
 	}
-
 	if initialHash == newHash {
 		t.Error("Expected origin/main to be updated after fetch, but hash unchanged")
 	}
 }
 
-// TestFetchBranchNonExistent tests fetch of a non-existent branch.
-// A missing remote ref is a benign condition that must be classified as ErrRemoteRefNotFound,
-// so the finish preflight can distinguish it from a fatal transport failure.
-// Steps:
-// 1. Sets up a test repository with a remote
-// 2. Calls FetchBranch for a branch that doesn't exist on remote
-// 3. Verifies the error wraps the ErrRemoteRefNotFound sentinel
 func TestFetchBranchNonExistent(t *testing.T) {
+	t.Parallel()
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 
@@ -667,233 +490,233 @@ func TestFetchBranchNonExistent(t *testing.T) {
 	}
 	defer testutil.CleanupTestRepo(t, remoteDir)
 
-	withGitRepo(t, dir, func() {
-		err := git.FetchBranch("origin", "non-existent-branch")
-		if err == nil {
-			t.Fatal("Expected error when fetching non-existent branch, got nil")
-		}
-		if !goerrors.Is(err, git.ErrRemoteRefNotFound) {
-			t.Errorf("Expected error to wrap ErrRemoteRefNotFound, got: %v", err)
-		}
-	})
+	repo := openRepo(t, dir)
+	err = repo.FetchBranch("origin", "non-existent-branch")
+	if err == nil {
+		t.Fatal("Expected error when fetching non-existent branch, got nil")
+	}
+	if !goerrors.Is(err, git.ErrRemoteRefNotFound) {
+		t.Errorf("Expected error to wrap ErrRemoteRefNotFound, got: %v", err)
+	}
 }
 
-// TestFetchBranchTransportFailure tests that a transport/connection failure is NOT misclassified
-// as a benign missing ref. Fetching from a bogus remote (a path that is not a git repository)
-// must return an error that does not wrap ErrRemoteRefNotFound, so the preflight treats it as fatal.
-// Steps:
-// 1. Sets up a test repository (no reachable remote for the bogus target)
-// 2. Calls FetchBranch against a non-existent remote path
-// 3. Verifies an error is returned that does NOT wrap ErrRemoteRefNotFound
 func TestFetchBranchTransportFailure(t *testing.T) {
+	t.Parallel()
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 
 	bogusRemote := filepath.Join(dir, "does-not-exist-remote.git")
 
-	withGitRepo(t, dir, func() {
-		err := git.FetchBranch(bogusRemote, "main")
-		if err == nil {
-			t.Fatal("Expected error when fetching from a non-existent remote, got nil")
-		}
-		if goerrors.Is(err, git.ErrRemoteRefNotFound) {
-			t.Errorf("Expected transport failure NOT to wrap ErrRemoteRefNotFound, got: %v", err)
-		}
-	})
+	repo := openRepo(t, dir)
+	err := repo.FetchBranch(bogusRemote, "main")
+	if err == nil {
+		t.Fatal("Expected error when fetching from a non-existent remote, got nil")
+	}
+	if goerrors.Is(err, git.ErrRemoteRefNotFound) {
+		t.Errorf("Expected transport failure NOT to wrap ErrRemoteRefNotFound, got: %v", err)
+	}
 }
 
-// TestIsGitMergeInProgressTrue tests detection of an active git merge conflict.
-// Steps:
-// 1. Sets up a test repository with two branches containing conflicting changes
-// 2. Starts a merge that produces a conflict
-// 3. Verifies IsGitMergeInProgress returns true
 func TestIsGitMergeInProgressTrue(t *testing.T) {
+	t.Parallel()
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 
-	// Create a branch with content
-	_, err := testutil.RunGit(t, dir, "checkout", "-b", "feature")
-	if err != nil {
-		t.Fatalf("Failed to create branch: %v", err)
-	}
-	testutil.WriteFile(t, dir, "conflict.txt", "feature content")
-	_, err = testutil.RunGit(t, dir, "add", "conflict.txt")
-	if err != nil {
-		t.Fatalf("Failed to add file: %v", err)
-	}
-	_, err = testutil.RunGit(t, dir, "commit", "-m", "Feature commit")
-	if err != nil {
-		t.Fatalf("Failed to commit: %v", err)
-	}
-
-	// Add conflicting content on main
-	_, err = testutil.RunGit(t, dir, "checkout", "main")
-	if err != nil {
-		t.Fatalf("Failed to checkout main: %v", err)
-	}
-	testutil.WriteFile(t, dir, "conflict.txt", "main content")
-	_, err = testutil.RunGit(t, dir, "add", "conflict.txt")
-	if err != nil {
-		t.Fatalf("Failed to add file: %v", err)
-	}
-	_, err = testutil.RunGit(t, dir, "commit", "-m", "Main commit")
-	if err != nil {
-		t.Fatalf("Failed to commit: %v", err)
-	}
-
-	// Start merge that will conflict
+	setupConflictingBranches(t, dir)
 	_, _ = testutil.RunGit(t, dir, "merge", "feature")
 
-	withGitRepo(t, dir, func() {
-		if !git.IsGitMergeInProgress() {
-			t.Error("Expected IsGitMergeInProgress to return true during merge conflict")
-		}
-	})
+	repo := openRepo(t, dir)
+	if !repo.IsGitMergeInProgress() {
+		t.Error("Expected IsGitMergeInProgress to return true during merge conflict")
+	}
 }
 
-// TestIsGitMergeInProgressFalse tests that clean repos are not detected as merging.
-// Steps:
-// 1. Sets up a clean test repository
-// 2. Verifies IsGitMergeInProgress returns false
 func TestIsGitMergeInProgressFalse(t *testing.T) {
+	t.Parallel()
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 
-	withGitRepo(t, dir, func() {
-		if git.IsGitMergeInProgress() {
-			t.Error("Expected IsGitMergeInProgress to return false on clean repo")
-		}
-	})
+	repo := openRepo(t, dir)
+	if repo.IsGitMergeInProgress() {
+		t.Error("Expected IsGitMergeInProgress to return false on clean repo")
+	}
 }
 
-// TestIsGitRebaseInProgressTrue tests detection of an active git rebase conflict.
-// Steps:
-// 1. Sets up a test repository with two branches containing conflicting changes
-// 2. Starts a rebase that produces a conflict
-// 3. Verifies IsGitRebaseInProgress returns true
 func TestIsGitRebaseInProgressTrue(t *testing.T) {
+	t.Parallel()
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 
-	// Create a branch with content
-	_, err := testutil.RunGit(t, dir, "checkout", "-b", "feature")
-	if err != nil {
-		t.Fatalf("Failed to create branch: %v", err)
-	}
-	testutil.WriteFile(t, dir, "conflict.txt", "feature content")
-	_, err = testutil.RunGit(t, dir, "add", "conflict.txt")
-	if err != nil {
-		t.Fatalf("Failed to add file: %v", err)
-	}
-	_, err = testutil.RunGit(t, dir, "commit", "-m", "Feature commit")
-	if err != nil {
-		t.Fatalf("Failed to commit: %v", err)
-	}
-
-	// Add conflicting content on main
-	_, err = testutil.RunGit(t, dir, "checkout", "main")
-	if err != nil {
-		t.Fatalf("Failed to checkout main: %v", err)
-	}
-	testutil.WriteFile(t, dir, "conflict.txt", "main content")
-	_, err = testutil.RunGit(t, dir, "add", "conflict.txt")
-	if err != nil {
-		t.Fatalf("Failed to add file: %v", err)
-	}
-	_, err = testutil.RunGit(t, dir, "commit", "-m", "Main commit")
-	if err != nil {
-		t.Fatalf("Failed to commit: %v", err)
-	}
-
-	// Switch to feature and rebase onto main (will conflict)
-	_, err = testutil.RunGit(t, dir, "checkout", "feature")
-	if err != nil {
+	setupConflictingBranches(t, dir)
+	if _, err := testutil.RunGit(t, dir, "checkout", "feature"); err != nil {
 		t.Fatalf("Failed to checkout feature: %v", err)
 	}
 	_, _ = testutil.RunGit(t, dir, "rebase", "main")
 
-	withGitRepo(t, dir, func() {
-		if !git.IsGitRebaseInProgress() {
-			t.Error("Expected IsGitRebaseInProgress to return true during rebase conflict")
-		}
-	})
+	repo := openRepo(t, dir)
+	if !repo.IsGitRebaseInProgress() {
+		t.Error("Expected IsGitRebaseInProgress to return true during rebase conflict")
+	}
 }
 
-// TestIsGitRebaseInProgressFalse tests that clean repos are not detected as rebasing.
-// Steps:
-// 1. Sets up a clean test repository
-// 2. Verifies IsGitRebaseInProgress returns false
 func TestIsGitRebaseInProgressFalse(t *testing.T) {
+	t.Parallel()
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 
-	withGitRepo(t, dir, func() {
-		if git.IsGitRebaseInProgress() {
-			t.Error("Expected IsGitRebaseInProgress to return false on clean repo")
-		}
-	})
+	repo := openRepo(t, dir)
+	if repo.IsGitRebaseInProgress() {
+		t.Error("Expected IsGitRebaseInProgress to return false on clean repo")
+	}
 }
 
-// TestIsGitSquashMergeInProgressTrue tests detection of an active squash merge conflict.
-// Steps:
-// 1. Sets up a test repository with two branches containing conflicting changes
-// 2. Starts a squash merge that produces a conflict
-// 3. Verifies IsGitSquashMergeInProgress returns true
 func TestIsGitSquashMergeInProgressTrue(t *testing.T) {
+	t.Parallel()
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 
-	// Create a branch with content
-	_, err := testutil.RunGit(t, dir, "checkout", "-b", "feature")
-	if err != nil {
-		t.Fatalf("Failed to create branch: %v", err)
-	}
-	testutil.WriteFile(t, dir, "conflict.txt", "feature content")
-	_, err = testutil.RunGit(t, dir, "add", "conflict.txt")
-	if err != nil {
-		t.Fatalf("Failed to add file: %v", err)
-	}
-	_, err = testutil.RunGit(t, dir, "commit", "-m", "Feature commit")
-	if err != nil {
-		t.Fatalf("Failed to commit: %v", err)
-	}
-
-	// Add conflicting content on main
-	_, err = testutil.RunGit(t, dir, "checkout", "main")
-	if err != nil {
-		t.Fatalf("Failed to checkout main: %v", err)
-	}
-	testutil.WriteFile(t, dir, "conflict.txt", "main content")
-	_, err = testutil.RunGit(t, dir, "add", "conflict.txt")
-	if err != nil {
-		t.Fatalf("Failed to add file: %v", err)
-	}
-	_, err = testutil.RunGit(t, dir, "commit", "-m", "Main commit")
-	if err != nil {
-		t.Fatalf("Failed to commit: %v", err)
-	}
-
-	// Start squash merge that will conflict
+	setupConflictingBranches(t, dir)
 	_, _ = testutil.RunGit(t, dir, "merge", "--squash", "feature")
 
-	withGitRepo(t, dir, func() {
-		if !git.IsGitSquashMergeInProgress() {
-			t.Error("Expected IsGitSquashMergeInProgress to return true during squash merge conflict")
-		}
-	})
+	repo := openRepo(t, dir)
+	if !repo.IsGitSquashMergeInProgress() {
+		t.Error("Expected IsGitSquashMergeInProgress to return true during squash merge conflict")
+	}
 }
 
-// TestIsGitSquashMergeInProgressFalse tests that clean repos are not detected as squash merging.
-// Steps:
-// 1. Sets up a clean test repository
-// 2. Verifies IsGitSquashMergeInProgress returns false
 func TestIsGitSquashMergeInProgressFalse(t *testing.T) {
+	t.Parallel()
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 
-	withGitRepo(t, dir, func() {
-		if git.IsGitSquashMergeInProgress() {
-			t.Error("Expected IsGitSquashMergeInProgress to return false on clean repo")
+	repo := openRepo(t, dir)
+	if repo.IsGitSquashMergeInProgress() {
+		t.Error("Expected IsGitSquashMergeInProgress to return false on clean repo")
+	}
+}
+
+// --- Scenario 4: in-progress detection off-CWD, with setup guards ---
+
+func TestRepoIsMergeInProgressTrueOffCwd(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	setupConflictingBranches(t, dir)
+	_, _ = testutil.RunGit(t, dir, "merge", "feature")
+
+	// Setup guard: confirm the conflict is genuinely in progress before asserting.
+	if _, err := os.Stat(filepath.Join(dir, ".git", "MERGE_HEAD")); err != nil {
+		t.Fatalf("Setup guard failed: MERGE_HEAD not present: %v", err)
+	}
+	status, err := testutil.RunGit(t, dir, "status", "--porcelain")
+	if err != nil {
+		t.Fatalf("Failed to read status: %v", err)
+	}
+	if !hasUnmergedEntry(status) {
+		t.Fatalf("Setup guard failed: expected a UU entry in status, got:\n%s", status)
+	}
+
+	repo := openRepo(t, dir)
+	if !repo.IsGitMergeInProgress() {
+		t.Error("Expected IsGitMergeInProgress to return true off-CWD")
+	}
+}
+
+func TestRepoIsRebaseInProgressTrueOffCwd(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	setupConflictingBranches(t, dir)
+	if _, err := testutil.RunGit(t, dir, "checkout", "feature"); err != nil {
+		t.Fatalf("Failed to checkout feature: %v", err)
+	}
+	_, _ = testutil.RunGit(t, dir, "rebase", "main")
+
+	// Setup guard: a rebase state dir must exist.
+	_, mergeErr := os.Stat(filepath.Join(dir, ".git", "rebase-merge"))
+	_, applyErr := os.Stat(filepath.Join(dir, ".git", "rebase-apply"))
+	if mergeErr != nil && applyErr != nil {
+		t.Fatalf("Setup guard failed: neither rebase-merge nor rebase-apply present")
+	}
+
+	repo := openRepo(t, dir)
+	if !repo.IsGitRebaseInProgress() {
+		t.Error("Expected IsGitRebaseInProgress to return true off-CWD")
+	}
+}
+
+func TestRepoIsSquashMergeInProgressTrueOffCwd(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	setupConflictingBranches(t, dir)
+	_, _ = testutil.RunGit(t, dir, "merge", "--squash", "feature")
+
+	// Setup guard: SQUASH_MSG present and no rebase-merge (squash, not rebase).
+	if _, err := os.Stat(filepath.Join(dir, ".git", "SQUASH_MSG")); err != nil {
+		t.Fatalf("Setup guard failed: SQUASH_MSG not present: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".git", "rebase-merge")); err == nil {
+		t.Fatalf("Setup guard failed: unexpected rebase-merge present for squash")
+	}
+
+	repo := openRepo(t, dir)
+	if !repo.IsGitSquashMergeInProgress() {
+		t.Error("Expected IsGitSquashMergeInProgress to return true off-CWD")
+	}
+}
+
+func TestRepoInProgressChecksIsolatedAcrossRepos(t *testing.T) {
+	t.Parallel()
+	repoA := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, repoA)
+	repoB := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, repoB)
+
+	// Repo A has a merge in progress; repo B is clean.
+	setupConflictingBranches(t, repoA)
+	_, _ = testutil.RunGit(t, repoA, "merge", "feature")
+	if _, err := os.Stat(filepath.Join(repoA, ".git", "MERGE_HEAD")); err != nil {
+		t.Fatalf("Setup guard failed: A has no MERGE_HEAD: %v", err)
+	}
+
+	repo := openRepo(t, repoB)
+	if repo.IsGitMergeInProgress() {
+		t.Error("B reported a merge in progress; A's state leaked")
+	}
+	if repo.IsGitRebaseInProgress() {
+		t.Error("B reported a rebase in progress; A's state leaked")
+	}
+	if repo.IsGitSquashMergeInProgress() {
+		t.Error("B reported a squash merge in progress; A's state leaked")
+	}
+}
+
+// hasUnmergedEntry reports whether git status --porcelain output contains an
+// unmerged (UU) entry.
+func hasUnmergedEntry(status string) bool {
+	for _, line := range splitLines(status) {
+		if len(line) >= 2 && line[0] == 'U' && line[1] == 'U' {
+			return true
 		}
-	})
+	}
+	return false
+}
+
+func splitLines(s string) []string {
+	var lines []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			lines = append(lines, s[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		lines = append(lines, s[start:])
+	}
+	return lines
 }

--- a/test/internal/git/repo_test.go
+++ b/test/internal/git/repo_test.go
@@ -21,11 +21,21 @@ func openRepo(t *testing.T, dir string) *git.Repo {
 	return repo
 }
 
-// setupConflictingBranches creates a feature branch and a diverging main branch
-// that both touch conflict.txt, per GIT_TEST_SCENARIOS.md (branch first, then
-// conflicting content). It leaves the repo checked out on main.
+// setupConflictingBranches seeds conflict.txt on the base, then has a feature
+// branch and the diverging main branch each modify it differently, producing a
+// modify/modify (UU) conflict per GIT_TEST_SCENARIOS.md. It leaves the repo
+// checked out on main.
 func setupConflictingBranches(t *testing.T, dir string) {
 	t.Helper()
+	// Seed the file on the base (main) so both sides modify a common ancestor
+	// version, yielding a UU (both-modified) conflict rather than AA (add/add).
+	testutil.WriteFile(t, dir, "conflict.txt", "base content")
+	if _, err := testutil.RunGit(t, dir, "add", "conflict.txt"); err != nil {
+		t.Fatalf("Failed to add base file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Base conflict file"); err != nil {
+		t.Fatalf("Failed to commit base file: %v", err)
+	}
 	if _, err := testutil.RunGit(t, dir, "checkout", "-b", "feature"); err != nil {
 		t.Fatalf("Failed to create feature branch: %v", err)
 	}

--- a/test/internal/git/worktree_test.go
+++ b/test/internal/git/worktree_test.go
@@ -6,160 +6,122 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gittower/git-flow-next/internal/git"
 	"github.com/gittower/git-flow-next/internal/mergestate"
 	"github.com/gittower/git-flow-next/test/testutil"
 )
 
 func TestGetGitDirInRegularRepo(t *testing.T) {
-	// Setup test repo
+	t.Parallel()
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 
-	// Change to the test directory
-	withGitRepo(t, dir, func() {
-		gitDir, err := git.GetGitDir()
-		if err != nil {
-			t.Fatalf("GetGitDir failed: %v", err)
-		}
+	repo := openRepo(t, dir)
+	gitDir := repo.GitDir()
 
-		// In a regular repo, GetGitDir should return ".git"
-		if gitDir != ".git" {
-			t.Errorf("Expected GetGitDir to return '.git' in regular repo, got %q", gitDir)
-		}
-	})
+	if !filepath.IsAbs(gitDir) {
+		t.Errorf("Expected GitDir() to be absolute, got %q", gitDir)
+	}
+	if _, err := os.Stat(gitDir); err != nil {
+		t.Errorf("GitDir() does not exist: %v", err)
+	}
 }
 
 func TestGetGitDirInWorktree(t *testing.T) {
-	// Setup main repo
+	t.Parallel()
 	mainRepo := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, mainRepo)
 
-	// Create a worktree
 	worktreePath, err := os.MkdirTemp("", "git-flow-worktree-test-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory for worktree: %v", err)
 	}
 	defer os.RemoveAll(worktreePath)
-
-	// Remove the directory so git worktree add can create it
 	os.RemoveAll(worktreePath)
 
-	// Create worktree
-	_, err = testutil.RunGit(t, mainRepo, "worktree", "add", worktreePath, "-b", "worktree-branch")
-	if err != nil {
+	if _, err = testutil.RunGit(t, mainRepo, "worktree", "add", worktreePath, "-b", "worktree-branch"); err != nil {
 		t.Fatalf("Failed to create worktree: %v", err)
 	}
 
-	// Change to worktree and verify GetGitDir returns worktree git dir
-	withGitRepo(t, worktreePath, func() {
-		gitDir, err := git.GetGitDir()
-		if err != nil {
-			t.Fatalf("GetGitDir failed in worktree: %v", err)
-		}
+	repo := openRepo(t, worktreePath)
+	gitDir := repo.GitDir()
 
-		// In a worktree, GetGitDir should NOT return ".git"
-		// It should return a path containing "worktrees"
-		if gitDir == ".git" {
-			t.Error("Expected GetGitDir to return actual git directory path in worktree, not '.git'")
-		}
-
-		if !strings.Contains(gitDir, "worktrees") {
-			t.Errorf("Expected GetGitDir path to contain 'worktrees', got %q", gitDir)
-		}
-	})
+	if !filepath.IsAbs(gitDir) {
+		t.Errorf("Expected worktree GitDir() to be absolute, got %q", gitDir)
+	}
+	if !strings.Contains(gitDir, "worktrees") {
+		t.Errorf("Expected GitDir() path to contain 'worktrees', got %q", gitDir)
+	}
 }
 
 func TestMergeStateSaveLoadInWorktree(t *testing.T) {
-	// Setup main repo
+	t.Parallel()
 	mainRepo := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, mainRepo)
 
-	// Create a worktree
 	worktreePath, err := os.MkdirTemp("", "git-flow-worktree-state-test-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory for worktree: %v", err)
 	}
 	defer os.RemoveAll(worktreePath)
-
-	// Remove the directory so git worktree add can create it
 	os.RemoveAll(worktreePath)
 
-	// Create worktree from main
-	_, err = testutil.RunGit(t, mainRepo, "worktree", "add", worktreePath, "-b", "worktree-branch")
-	if err != nil {
+	if _, err = testutil.RunGit(t, mainRepo, "worktree", "add", worktreePath, "-b", "worktree-branch"); err != nil {
 		t.Fatalf("Failed to create worktree: %v", err)
 	}
 
-	// Change to worktree and test merge state operations
-	withGitRepo(t, worktreePath, func() {
-		// Create test state using delete_branch step with an existing branch so that
-		// IsMergeInProgress validation passes (it checks branch existence for non-conflict steps)
-		state := &mergestate.MergeState{
-			Action:         "finish",
-			BranchType:     "feature",
-			BranchName:     "test-feature",
-			CurrentStep:    "delete_branch",
-			ParentBranch:   "main",
-			MergeStrategy:  "merge",
-			FullBranchName: "worktree-branch",
-		}
+	repo := openRepo(t, worktreePath)
 
-		// Test save
-		err := mergestate.SaveMergeState(state)
-		if err != nil {
-			t.Fatalf("SaveMergeState failed in worktree: %v", err)
-		}
+	state := &mergestate.MergeState{
+		Action:         "finish",
+		BranchType:     "feature",
+		BranchName:     "test-feature",
+		CurrentStep:    "delete_branch",
+		ParentBranch:   "main",
+		MergeStrategy:  "merge",
+		FullBranchName: "worktree-branch",
+	}
 
-		// Verify file was created in the correct location (worktree git dir, not .git)
-		gitDir, err := git.GetGitDir()
-		if err != nil {
-			t.Fatalf("GetGitDir failed: %v", err)
-		}
-		stateFilePath := filepath.Join(gitDir, "gitflow", "state", "merge.json")
-		if _, err := os.Stat(stateFilePath); os.IsNotExist(err) {
-			t.Errorf("State file was not created at expected path: %s", stateFilePath)
-		}
+	if err := mergestate.SaveMergeState(repo, state); err != nil {
+		t.Fatalf("SaveMergeState failed in worktree: %v", err)
+	}
 
-		// Test load
-		loaded, err := mergestate.LoadMergeState()
-		if err != nil {
-			t.Fatalf("LoadMergeState failed in worktree: %v", err)
-		}
-		if loaded == nil {
-			t.Fatal("LoadMergeState returned nil in worktree")
-		}
-		if loaded.BranchName != state.BranchName {
-			t.Errorf("Loaded state BranchName = %q, want %q", loaded.BranchName, state.BranchName)
-		}
-		if loaded.BranchType != state.BranchType {
-			t.Errorf("Loaded state BranchType = %q, want %q", loaded.BranchType, state.BranchType)
-		}
+	stateFilePath := filepath.Join(repo.GitDir(), "gitflow", "state", "merge.json")
+	if _, err := os.Stat(stateFilePath); os.IsNotExist(err) {
+		t.Errorf("State file was not created at expected path: %s", stateFilePath)
+	}
 
-		// Test IsMergeInProgress
-		if !mergestate.IsMergeInProgress() {
-			t.Error("IsMergeInProgress returned false after saving state in worktree")
-		}
+	loaded, err := mergestate.LoadMergeState(repo)
+	if err != nil {
+		t.Fatalf("LoadMergeState failed in worktree: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("LoadMergeState returned nil in worktree")
+	}
+	if loaded.BranchName != state.BranchName {
+		t.Errorf("Loaded state BranchName = %q, want %q", loaded.BranchName, state.BranchName)
+	}
+	if loaded.BranchType != state.BranchType {
+		t.Errorf("Loaded state BranchType = %q, want %q", loaded.BranchType, state.BranchType)
+	}
 
-		// Test clear
-		err = mergestate.ClearMergeState()
-		if err != nil {
-			t.Fatalf("ClearMergeState failed in worktree: %v", err)
-		}
+	if !mergestate.IsMergeInProgress(repo) {
+		t.Error("IsMergeInProgress returned false after saving state in worktree")
+	}
 
-		// Verify state was cleared
-		if mergestate.IsMergeInProgress() {
-			t.Error("IsMergeInProgress returned true after clearing state in worktree")
-		}
-	})
+	if err := mergestate.ClearMergeState(repo); err != nil {
+		t.Fatalf("ClearMergeState failed in worktree: %v", err)
+	}
+
+	if mergestate.IsMergeInProgress(repo) {
+		t.Error("IsMergeInProgress returned true after clearing state in worktree")
+	}
 }
 
 func TestMergeStateNotSharedBetweenWorktrees(t *testing.T) {
-	// Setup main repo
+	t.Parallel()
 	mainRepo := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, mainRepo)
 
-	// Create first worktree
 	worktree1, err := os.MkdirTemp("", "git-flow-worktree1-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory for worktree1: %v", err)
@@ -167,12 +129,10 @@ func TestMergeStateNotSharedBetweenWorktrees(t *testing.T) {
 	defer os.RemoveAll(worktree1)
 	os.RemoveAll(worktree1)
 
-	_, err = testutil.RunGit(t, mainRepo, "worktree", "add", worktree1, "-b", "worktree1-branch")
-	if err != nil {
+	if _, err = testutil.RunGit(t, mainRepo, "worktree", "add", worktree1, "-b", "worktree1-branch"); err != nil {
 		t.Fatalf("Failed to create worktree1: %v", err)
 	}
 
-	// Create second worktree
 	worktree2, err := os.MkdirTemp("", "git-flow-worktree2-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory for worktree2: %v", err)
@@ -180,47 +140,37 @@ func TestMergeStateNotSharedBetweenWorktrees(t *testing.T) {
 	defer os.RemoveAll(worktree2)
 	os.RemoveAll(worktree2)
 
-	_, err = testutil.RunGit(t, mainRepo, "worktree", "add", worktree2, "-b", "worktree2-branch")
-	if err != nil {
+	if _, err = testutil.RunGit(t, mainRepo, "worktree", "add", worktree2, "-b", "worktree2-branch"); err != nil {
 		t.Fatalf("Failed to create worktree2: %v", err)
 	}
 
-	// Save state in worktree1 using delete_branch step with an existing branch
-	// so that IsMergeInProgress validation passes
-	withGitRepo(t, worktree1, func() {
-		state := &mergestate.MergeState{
-			Action:         "finish",
-			BranchType:     "feature",
-			BranchName:     "worktree1-feature",
-			CurrentStep:    "delete_branch",
-			FullBranchName: "worktree1-branch",
-			ParentBranch:   "main",
-		}
-		err := mergestate.SaveMergeState(state)
-		if err != nil {
-			t.Fatalf("SaveMergeState failed in worktree1: %v", err)
-		}
-	})
+	repo1 := openRepo(t, worktree1)
+	repo2 := openRepo(t, worktree2)
 
-	// Verify state is NOT visible in worktree2
-	withGitRepo(t, worktree2, func() {
-		if mergestate.IsMergeInProgress() {
-			t.Error("Worktree2 should not see merge state from worktree1")
-		}
+	state := &mergestate.MergeState{
+		Action:         "finish",
+		BranchType:     "feature",
+		BranchName:     "worktree1-feature",
+		CurrentStep:    "delete_branch",
+		FullBranchName: "worktree1-branch",
+		ParentBranch:   "main",
+	}
+	if err := mergestate.SaveMergeState(repo1, state); err != nil {
+		t.Fatalf("SaveMergeState failed in worktree1: %v", err)
+	}
 
-		loaded, err := mergestate.LoadMergeState()
-		if err != nil {
-			t.Fatalf("LoadMergeState failed in worktree2: %v", err)
-		}
-		if loaded != nil {
-			t.Errorf("Worktree2 loaded state from worktree1: %+v", loaded)
-		}
-	})
+	if mergestate.IsMergeInProgress(repo2) {
+		t.Error("Worktree2 should not see merge state from worktree1")
+	}
+	loaded, err := mergestate.LoadMergeState(repo2)
+	if err != nil {
+		t.Fatalf("LoadMergeState failed in worktree2: %v", err)
+	}
+	if loaded != nil {
+		t.Errorf("Worktree2 loaded state from worktree1: %+v", loaded)
+	}
 
-	// Verify state is still in worktree1
-	withGitRepo(t, worktree1, func() {
-		if !mergestate.IsMergeInProgress() {
-			t.Error("Worktree1 should still have merge state")
-		}
-	})
+	if !mergestate.IsMergeInProgress(repo1) {
+		t.Error("Worktree1 should still have merge state")
+	}
 }

--- a/test/internal/git_config_test.go
+++ b/test/internal/git_config_test.go
@@ -11,18 +11,14 @@ import (
 // Steps:
 // 1. Sets up a test repository
 // 2. Adds multiple values for a single git config key using 'git config --add'
-// 3. Calls GetConfigAllValues for that key
+// 3. Calls repo.GetConfigAllValues for that key
 // 4. Verifies all values are returned in order
-// 5. Calls GetConfigAllValues for a non-existent key
+// 5. Calls repo.GetConfigAllValues for a non-existent key
 // 6. Verifies empty result with no error
 func TestGetConfigAllValues(t *testing.T) {
+	t.Parallel()
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
-
-	// Change to the test directory so git commands work
-	// (GetConfigAllValues uses git config which operates in current directory)
-	originalDir := t.TempDir() // dummy to satisfy the compiler
-	_ = originalDir
 
 	// Set multiple values for a single key
 	_, err := testutil.RunGit(t, dir, "config", "test.multivalue", "first")
@@ -38,10 +34,12 @@ func TestGetConfigAllValues(t *testing.T) {
 		t.Fatalf("Failed to add third config value: %v", err)
 	}
 
-	// We need to run the test from within the test directory
-	// since GetConfigAllValues uses git config which operates in the current directory
-	// Use a subprocess approach via testutil
-	values, err := git.GetConfigAllValuesInDir(dir, "test.multivalue")
+	repo, err := git.Open(dir)
+	if err != nil {
+		t.Fatalf("git.Open failed: %v", err)
+	}
+
+	values, err := repo.GetConfigAllValues("test.multivalue")
 	if err != nil {
 		t.Fatalf("GetConfigAllValues returned error: %v", err)
 	}
@@ -56,7 +54,7 @@ func TestGetConfigAllValues(t *testing.T) {
 	}
 
 	// Test non-existent key
-	values, err = git.GetConfigAllValuesInDir(dir, "test.nonexistent")
+	values, err = repo.GetConfigAllValues("test.nonexistent")
 	if err != nil {
 		t.Errorf("GetConfigAllValues for non-existent key returned error: %v", err)
 	}

--- a/test/internal/hooks/filters_test.go
+++ b/test/internal/hooks/filters_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gittower/git-flow-next/internal/git"
 	"github.com/gittower/git-flow-next/internal/hooks"
 	"github.com/gittower/git-flow-next/test/testutil"
 )
@@ -433,6 +434,68 @@ echo "Type: ${BRANCH_TYPE}, Name: ${BRANCH_NAME}, Base: ${BASE_BRANCH}, Version:
 	}
 }
 
+// TestFilterDiscoveredAndRunInTargetRepoOffCwd verifies that a filter configured
+// in repo B (via gitflow.path.hooks) is both discovered through B's handle-bound
+// config and executed with its working directory set to B's work tree, off-CWD.
+func TestFilterDiscoveredAndRunInTargetRepoOffCwd(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	customHooksDir, err := os.MkdirTemp("", "git-flow-offcwd-filter-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(customHooksDir)
+
+	markerFile := filepath.Join(dir, "filter-cwd.txt")
+	// Writes its working directory to the marker AND transforms the input.
+	script := `#!/bin/sh
+pwd > "` + markerFile + `"
+echo "v$1"
+`
+	createExecutableScript2(t, customHooksDir, "filter-flow-release-start-version", script)
+
+	// Point B's config at the custom hooks dir; discovery must read B's config.
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.path.hooks", customHooksDir); err != nil {
+		t.Fatalf("Failed to set gitflow.path.hooks: %v", err)
+	}
+
+	repo, err := git.Open(dir)
+	if err != nil {
+		t.Fatalf("git.Open failed: %v", err)
+	}
+
+	result, err := hooks.RunVersionFilter(repo.GitDir(), "release", "1.0.0")
+	if err != nil {
+		t.Fatalf("RunVersionFilter failed: %v", err)
+	}
+	if result != "v1.0.0" {
+		t.Errorf("Expected transformed value 'v1.0.0', got %q (filter not discovered in B?)", result)
+	}
+
+	content, err := os.ReadFile(markerFile)
+	if err != nil {
+		t.Fatalf("Filter did not run — marker missing: %v", err)
+	}
+	got := evalSymlinks(t, strings.TrimSpace(string(content)))
+	want := evalSymlinks(t, repo.WorkTree())
+	if got != want {
+		t.Errorf("Filter ran in %q, want target work tree %q", got, want)
+	}
+}
+
+// createExecutableScript2 creates an executable script in an arbitrary directory.
+func createExecutableScript2(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("Failed to create dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0755); err != nil {
+		t.Fatalf("Failed to create script %s: %v", name, err)
+	}
+}
+
 // TestGetFilterName tests the dynamic filter name generation.
 func TestGetFilterName(t *testing.T) {
 	tests := []struct {
@@ -487,18 +550,11 @@ echo "v${VERSION}"
 `
 	createExecutableScript(t, mainRepo, "filter-flow-release-start-version", script)
 
-	// Get the worktree's git directory
-	oldDir, _ := os.Getwd()
-	os.Chdir(worktreePath)
-	worktreeGitDirOutput, err := testutil.RunGit(t, worktreePath, "rev-parse", "--git-dir")
-	os.Chdir(oldDir)
-	if err != nil {
-		t.Fatalf("Failed to get worktree git directory: %v", err)
-	}
-	worktreeGitDir := strings.TrimSpace(worktreeGitDirOutput)
+	// Get the worktree's absolute git directory via a git.Repo handle.
+	wtGitDir := worktreeGitDir(t, worktreePath)
 
 	// Run version filter from worktree context
-	result, err := hooks.RunVersionFilter(worktreeGitDir, "release", "1.0.0")
+	result, err := hooks.RunVersionFilter(wtGitDir, "release", "1.0.0")
 	if err != nil {
 		t.Fatalf("RunVersionFilter failed in worktree: %v", err)
 	}
@@ -534,15 +590,8 @@ echo "Release ${VERSION} from worktree"
 `
 	createExecutableScript(t, mainRepo, "filter-flow-release-finish-tag-message", script)
 
-	// Get the worktree's git directory
-	oldDir, _ := os.Getwd()
-	os.Chdir(worktreePath)
-	worktreeGitDirOutput, err := testutil.RunGit(t, worktreePath, "rev-parse", "--git-dir")
-	os.Chdir(oldDir)
-	if err != nil {
-		t.Fatalf("Failed to get worktree git directory: %v", err)
-	}
-	worktreeGitDir := strings.TrimSpace(worktreeGitDirOutput)
+	// Get the worktree's absolute git directory via a git.Repo handle.
+	wtGitDir := worktreeGitDir(t, worktreePath)
 
 	ctx := hooks.FilterContext{
 		BranchType: "release",
@@ -553,7 +602,7 @@ echo "Release ${VERSION} from worktree"
 	}
 
 	// Run tag message filter from worktree context
-	result, err := hooks.RunTagMessageFilter(worktreeGitDir, "release", ctx)
+	result, err := hooks.RunTagMessageFilter(wtGitDir, "release", ctx)
 	if err != nil {
 		t.Fatalf("RunTagMessageFilter failed in worktree: %v", err)
 	}

--- a/test/internal/hooks/hooks_test.go
+++ b/test/internal/hooks/hooks_test.go
@@ -7,9 +7,31 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gittower/git-flow-next/internal/git"
 	"github.com/gittower/git-flow-next/internal/hooks"
 	"github.com/gittower/git-flow-next/test/testutil"
 )
+
+// worktreeGitDir returns the absolute per-worktree git dir for path via a
+// git.Repo handle, replacing the old os.Chdir + `git rev-parse --git-dir` dance.
+func worktreeGitDir(t *testing.T, path string) string {
+	t.Helper()
+	repo, err := git.Open(path)
+	if err != nil {
+		t.Fatalf("git.Open(%q) failed: %v", path, err)
+	}
+	return repo.GitDir()
+}
+
+// evalSymlinks normalizes a path so comparisons survive macOS's /var symlink.
+func evalSymlinks(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return path
+	}
+	return resolved
+}
 
 // createHookScript creates an executable hook script in the hooks directory.
 func createHookScript(t *testing.T, dir, name, content string) {
@@ -440,34 +462,12 @@ exit 0
 `
 	createHookScript(t, mainRepo, "pre-flow-feature-start", script)
 
-	// Get the worktree's git directory by running git rev-parse from the worktree
-	// Save current directory
-	oldDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Failed to get current directory: %v", err)
-	}
-
-	// Change to worktree directory to get its git dir
-	if err := os.Chdir(worktreePath); err != nil {
-		t.Fatalf("Failed to change to worktree directory: %v", err)
-	}
-
-	// Get git directory from worktree's perspective
-	worktreeGitDirOutput, err := testutil.RunGit(t, worktreePath, "rev-parse", "--git-dir")
-	if err != nil {
-		os.Chdir(oldDir)
-		t.Fatalf("Failed to get worktree git directory: %v", err)
-	}
-	worktreeGitDir := strings.TrimSpace(worktreeGitDirOutput)
-
-	// Restore original directory
-	if err := os.Chdir(oldDir); err != nil {
-		t.Fatalf("Failed to restore directory: %v", err)
-	}
+	// Get the worktree's absolute git directory via a git.Repo handle.
+	wtGitDir := worktreeGitDir(t, worktreePath)
 
 	// The worktree git dir should contain "worktrees" in the path
-	if !strings.Contains(worktreeGitDir, "worktrees") {
-		t.Errorf("Expected worktree git dir to contain 'worktrees', got: %s", worktreeGitDir)
+	if !strings.Contains(wtGitDir, "worktrees") {
+		t.Errorf("Expected worktree git dir to contain 'worktrees', got: %s", wtGitDir)
 	}
 
 	// Run the pre-hook using the worktree's git directory
@@ -479,7 +479,7 @@ exit 0
 		Origin:     "origin",
 	}
 
-	err = hooks.RunPreHook(worktreeGitDir, "feature", hooks.HookActionStart, ctx)
+	err = hooks.RunPreHook(wtGitDir, "feature", hooks.HookActionStart, ctx)
 	if err != nil {
 		t.Fatalf("RunPreHook failed in worktree: %v", err)
 	}
@@ -516,15 +516,8 @@ exit 0
 `
 	createHookScript(t, mainRepo, "post-flow-feature-finish", script)
 
-	// Get the worktree's git directory
-	oldDir, _ := os.Getwd()
-	os.Chdir(worktreePath)
-	worktreeGitDirOutput, err := testutil.RunGit(t, worktreePath, "rev-parse", "--git-dir")
-	os.Chdir(oldDir)
-	if err != nil {
-		t.Fatalf("Failed to get worktree git directory: %v", err)
-	}
-	worktreeGitDir := strings.TrimSpace(worktreeGitDirOutput)
+	// Get the worktree's absolute git directory via a git.Repo handle.
+	wtGitDir := worktreeGitDir(t, worktreePath)
 
 	ctx := hooks.HookContext{
 		BranchType: "feature",
@@ -535,7 +528,7 @@ exit 0
 		ExitCode:   0,
 	}
 
-	result := hooks.RunPostHook(worktreeGitDir, "feature", hooks.HookActionFinish, ctx)
+	result := hooks.RunPostHook(wtGitDir, "feature", hooks.HookActionFinish, ctx)
 	if !result.Executed {
 		t.Error("Expected post-hook to execute in worktree")
 	}
@@ -826,6 +819,92 @@ exit 0
 	err := hooks.RunPreHook(gitDir, "release", hooks.HookActionStart, ctx)
 	if err != nil {
 		t.Fatalf("Start hook failed: %v", err)
+	}
+}
+
+// TestRunPreHookExecutesInTargetWorkTreeOffCwd verifies a pre-hook fed the target
+// repo's absolute git dir runs with its working directory set to that repo's work
+// tree, not the process CWD.
+func TestRunPreHookExecutesInTargetWorkTreeOffCwd(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	markerFile := filepath.Join(dir, "prehook-cwd.txt")
+	script := `#!/bin/sh
+pwd > "` + markerFile + `"
+exit 0
+`
+	createHookScript(t, dir, "pre-flow-feature-start", script)
+
+	repo, err := git.Open(dir)
+	if err != nil {
+		t.Fatalf("git.Open failed: %v", err)
+	}
+
+	ctx := hooks.HookContext{
+		BranchType: "feature",
+		BranchName: "test",
+		FullBranch: "feature/test",
+		BaseBranch: "develop",
+		Origin:     "origin",
+	}
+
+	if err := hooks.RunPreHook(repo.GitDir(), "feature", hooks.HookActionStart, ctx); err != nil {
+		t.Fatalf("RunPreHook failed: %v", err)
+	}
+
+	content, err := os.ReadFile(markerFile)
+	if err != nil {
+		t.Fatalf("Hook did not run — marker missing: %v", err)
+	}
+	got := evalSymlinks(t, strings.TrimSpace(string(content)))
+	want := evalSymlinks(t, repo.WorkTree())
+	if got != want {
+		t.Errorf("Pre-hook ran in %q, want target work tree %q", got, want)
+	}
+}
+
+// TestRunPostHookExecutesInTargetWorkTreeOffCwd is the post-hook analogue.
+func TestRunPostHookExecutesInTargetWorkTreeOffCwd(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	markerFile := filepath.Join(dir, "posthook-cwd.txt")
+	script := `#!/bin/sh
+pwd > "` + markerFile + `"
+exit 0
+`
+	createHookScript(t, dir, "post-flow-feature-finish", script)
+
+	repo, err := git.Open(dir)
+	if err != nil {
+		t.Fatalf("git.Open failed: %v", err)
+	}
+
+	ctx := hooks.HookContext{
+		BranchType: "feature",
+		BranchName: "test",
+		FullBranch: "feature/test",
+		BaseBranch: "develop",
+		Origin:     "origin",
+		ExitCode:   0,
+	}
+
+	result := hooks.RunPostHook(repo.GitDir(), "feature", hooks.HookActionFinish, ctx)
+	if !result.Executed {
+		t.Fatal("Expected post-hook to execute")
+	}
+
+	content, err := os.ReadFile(markerFile)
+	if err != nil {
+		t.Fatalf("Hook did not run — marker missing: %v", err)
+	}
+	got := evalSymlinks(t, strings.TrimSpace(string(content)))
+	want := evalSymlinks(t, repo.WorkTree())
+	if got != want {
+		t.Errorf("Post-hook ran in %q, want target work tree %q", got, want)
 	}
 }
 
@@ -1319,15 +1398,8 @@ echo "post-$EXIT_CODE" >> "` + markerFile + `"
 `
 	createHookScript(t, mainRepo, "post-flow-release-start", postScript)
 
-	// Get worktree git directory
-	oldDir, _ := os.Getwd()
-	os.Chdir(worktreePath)
-	worktreeGitDirOutput, err := testutil.RunGit(t, worktreePath, "rev-parse", "--git-dir")
-	os.Chdir(oldDir)
-	if err != nil {
-		t.Fatalf("Failed to get worktree git directory: %v", err)
-	}
-	worktreeGitDir := strings.TrimSpace(worktreeGitDirOutput)
+	// Get worktree git directory via a git.Repo handle.
+	wtGitDir := worktreeGitDir(t, worktreePath)
 
 	ctx := hooks.HookContext{
 		BranchType: "release",
@@ -1339,7 +1411,7 @@ echo "post-$EXIT_CODE" >> "` + markerFile + `"
 	}
 
 	operationRan := false
-	err = hooks.WithHooks(worktreeGitDir, "release", hooks.HookActionStart, ctx, func() error {
+	err = hooks.WithHooks(wtGitDir, "release", hooks.HookActionStart, ctx, func() error {
 		operationRan = true
 		return nil
 	})

--- a/test/internal/mergestate/mergestate_test.go
+++ b/test/internal/mergestate/mergestate_test.go
@@ -81,6 +81,14 @@ func initRepoB(t *testing.T) *git.Repo {
 	return repo
 }
 
+// TestSaveMergeStateWritesUnderTargetGitDir verifies SaveMergeState persists to
+// the target repository's git dir, not the process working directory's repo.
+// Steps:
+// 1. Creates and opens a handle for target repository B
+// 2. Snapshots the CWD-implicit candidate state path before the operation
+// 3. Calls SaveMergeState with B's handle and a sample state
+// 4. Verifies the state file exists under B's git dir
+// 5. Verifies the ambient CWD candidate path is unchanged
 func TestSaveMergeStateWritesUnderTargetGitDir(t *testing.T) {
 	t.Parallel()
 	repo := initRepoB(t)
@@ -100,6 +108,14 @@ func TestSaveMergeStateWritesUnderTargetGitDir(t *testing.T) {
 	assertUnchanged(t, cwdCandidate, existedBefore, contentBefore)
 }
 
+// TestLoadMergeStateRoundTripsOffCwd verifies a saved merge state loads back
+// intact through the target repository's handle, independent of the CWD.
+// Steps:
+// 1. Creates and opens a handle for target repository B
+// 2. Saves a sample state through B's handle
+// 3. Loads the state back through B's handle
+// 4. Verifies all scalar fields match the saved state
+// 5. Verifies the ChildBranches slice round-trips correctly
 func TestLoadMergeStateRoundTripsOffCwd(t *testing.T) {
 	t.Parallel()
 	repo := initRepoB(t)
@@ -127,6 +143,13 @@ func TestLoadMergeStateRoundTripsOffCwd(t *testing.T) {
 	}
 }
 
+// TestClearMergeStateRemovesFileOffCwd verifies ClearMergeState removes the
+// state file under the target repository's git dir, independent of the CWD.
+// Steps:
+// 1. Creates and opens a handle for target repository B
+// 2. Saves a sample state and confirms the state file exists under B's git dir
+// 3. Calls ClearMergeState through B's handle
+// 4. Verifies the state file has been removed
 func TestClearMergeStateRemovesFileOffCwd(t *testing.T) {
 	t.Parallel()
 	repo := initRepoB(t)
@@ -147,6 +170,13 @@ func TestClearMergeStateRemovesFileOffCwd(t *testing.T) {
 	}
 }
 
+// TestLoadMergeStateAbsentReturnsNil verifies loading merge state from a repo
+// with no persisted state returns nil without an error.
+// Steps:
+// 1. Creates and opens a handle for target repository B with no saved state
+// 2. Calls LoadMergeState through B's handle
+// 3. Verifies no error is returned
+// 4. Verifies the returned state is nil
 func TestLoadMergeStateAbsentReturnsNil(t *testing.T) {
 	t.Parallel()
 	repo := initRepoB(t)

--- a/test/internal/mergestate/mergestate_test.go
+++ b/test/internal/mergestate/mergestate_test.go
@@ -1,0 +1,161 @@
+package mergestate_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gittower/git-flow-next/internal/git"
+	"github.com/gittower/git-flow-next/internal/mergestate"
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// sampleState returns a MergeState with the critical fields populated.
+func sampleState() *mergestate.MergeState {
+	return &mergestate.MergeState{
+		Action:         "finish",
+		BranchType:     "feature",
+		BranchName:     "cwd-indep",
+		CurrentStep:    "delete_branch",
+		ParentBranch:   "main",
+		MergeStrategy:  "merge",
+		FullBranchName: "feature/cwd-indep",
+		ChildBranches:  []string{"develop"},
+	}
+}
+
+// cwdCandidateStatePath returns the merge-state path that a CWD-implicit
+// implementation would have written to: the state file under the process
+// working directory's own git dir (the git-flow-next checkout).
+func cwdCandidateStatePath(t *testing.T) string {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working directory: %v", err)
+	}
+	repo, err := git.Open(cwd)
+	if err != nil {
+		t.Fatalf("Failed to open ambient repo: %v", err)
+	}
+	return filepath.Join(repo.GitDir(), "gitflow", "state", "merge.json")
+}
+
+// snapshotFile records whether path exists and its contents.
+func snapshotFile(t *testing.T, path string) (existed bool, content []byte) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		t.Fatalf("Failed to snapshot %s: %v", path, err)
+	}
+	return true, data
+}
+
+func assertUnchanged(t *testing.T, path string, existedBefore bool, contentBefore []byte) {
+	t.Helper()
+	existedAfter, contentAfter := snapshotFile(t, path)
+	if existedBefore != existedAfter {
+		t.Errorf("Ambient CWD state path existence changed (before=%v after=%v): %s", existedBefore, existedAfter, path)
+	}
+	if existedBefore && !bytes.Equal(contentBefore, contentAfter) {
+		t.Errorf("Ambient CWD state path content changed unexpectedly: %s", path)
+	}
+}
+
+func initRepoB(t *testing.T) *git.Repo {
+	t.Helper()
+	dir := testutil.SetupTestRepo(t)
+	t.Cleanup(func() { testutil.CleanupTestRepo(t, dir) })
+	// Mark the repo git-flow-initialized via git config directly (no binary
+	// dependency): merge-state persistence only needs a resolvable git dir.
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.version", "1.0"); err != nil {
+		t.Fatalf("Failed to set gitflow.version in B: %v", err)
+	}
+	repo, err := git.Open(dir)
+	if err != nil {
+		t.Fatalf("Failed to open B: %v", err)
+	}
+	return repo
+}
+
+func TestSaveMergeStateWritesUnderTargetGitDir(t *testing.T) {
+	t.Parallel()
+	repo := initRepoB(t)
+
+	cwdCandidate := cwdCandidateStatePath(t)
+	existedBefore, contentBefore := snapshotFile(t, cwdCandidate)
+
+	if err := mergestate.SaveMergeState(repo, sampleState()); err != nil {
+		t.Fatalf("SaveMergeState failed: %v", err)
+	}
+
+	target := filepath.Join(repo.GitDir(), "gitflow", "state", "merge.json")
+	if _, err := os.Stat(target); err != nil {
+		t.Errorf("Expected state file at B's git dir %s: %v", target, err)
+	}
+
+	assertUnchanged(t, cwdCandidate, existedBefore, contentBefore)
+}
+
+func TestLoadMergeStateRoundTripsOffCwd(t *testing.T) {
+	t.Parallel()
+	repo := initRepoB(t)
+
+	want := sampleState()
+	if err := mergestate.SaveMergeState(repo, want); err != nil {
+		t.Fatalf("SaveMergeState failed: %v", err)
+	}
+
+	got, err := mergestate.LoadMergeState(repo)
+	if err != nil {
+		t.Fatalf("LoadMergeState failed: %v", err)
+	}
+	if got == nil {
+		t.Fatal("LoadMergeState returned nil")
+	}
+	if got.Action != want.Action || got.BranchType != want.BranchType ||
+		got.BranchName != want.BranchName || got.CurrentStep != want.CurrentStep ||
+		got.ParentBranch != want.ParentBranch || got.MergeStrategy != want.MergeStrategy ||
+		got.FullBranchName != want.FullBranchName {
+		t.Errorf("Loaded state does not match saved state:\n got=%+v\nwant=%+v", got, want)
+	}
+	if len(got.ChildBranches) != 1 || got.ChildBranches[0] != "develop" {
+		t.Errorf("ChildBranches not round-tripped: %v", got.ChildBranches)
+	}
+}
+
+func TestClearMergeStateRemovesFileOffCwd(t *testing.T) {
+	t.Parallel()
+	repo := initRepoB(t)
+
+	if err := mergestate.SaveMergeState(repo, sampleState()); err != nil {
+		t.Fatalf("SaveMergeState failed: %v", err)
+	}
+	target := filepath.Join(repo.GitDir(), "gitflow", "state", "merge.json")
+	if _, err := os.Stat(target); err != nil {
+		t.Fatalf("Precondition failed: state file not created: %v", err)
+	}
+
+	if err := mergestate.ClearMergeState(repo); err != nil {
+		t.Fatalf("ClearMergeState failed: %v", err)
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Errorf("Expected state file removed, stat err = %v", err)
+	}
+}
+
+func TestLoadMergeStateAbsentReturnsNil(t *testing.T) {
+	t.Parallel()
+	repo := initRepoB(t)
+
+	got, err := mergestate.LoadMergeState(repo)
+	if err != nil {
+		t.Errorf("Expected no error for absent state, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("Expected nil state when absent, got %+v", got)
+	}
+}


### PR DESCRIPTION
Introduces an explicit `git.Repo` handle so `internal/git` and `internal/config` operate on a repository resolved to absolute paths, removing their dependence on the process working directory below the CLI entry point.

`git.Open(dir)` validates the target is a real repo (erroring on an empty or non-repo dir rather than silently falling back to the CWD) and resolves an absolute work tree, git dir, and common git dir. A single command factory in `internal/git` is the only place `cmd.Dir` is set for repo-bound git operations. The handle is threaded through `internal/git`, `internal/config`, `internal/mergestate`, `internal/hooks`, and every `cmd/` caller: `config.Load(repo)` replaces `config.LoadConfig()`, `GetGitDir()` gives way to absolute accessors, and merge-state, in-progress detection, and hook/filter discovery all resolve against the handle's absolute git dir. The CLI boundary opens one handle for the invocation directory (memoized in `cmd/repo.go`) and normalizes relative path arguments — `init --file` and the tag message-file (both `--messagefile` and `gitflow.<type>.finish.messagefile`) — to absolute against the invocation directory, so user-visible relative-path behavior is unchanged even though git no longer inherits the CWD. The payoff lands in the test suite: all 76 `os.Chdir` calls are gone and the migrated in-process tests gain `t.Parallel()`.

Resolves #144

## Remarks

- No new user-facing flag, command, or config key; there is intentionally no `--repo`/`-C`.
- A relative `gitflow.<type>.finish.messagefile` keeps its invocation-directory meaning (the spec's decided default), rather than switching to work-tree-relative.
- The linked-worktree hooks-root bug remains out of scope: accessors are asserted absolute for a worktree, but the worktree hooks-directory fix is not part of this change.
- Acceptance gates verified: zero `os.Getwd()` in `internal/git`/`internal/config` production, zero `os.Chdir` in `test/`, the sole repo-bound `exec.Command("git", ...)` is the command factory (the repository-less refname check in `internal/util` invokes git directly), and git-dir resolution never returns a relative path. Suite passes normally and with `go test ./... -shuffle=on`.
- Pre-existing unrelated failure: `TestFinishPushRejectedNonFastForward` fails on `main` as well (the #99 parent-sync-check behavior), so it is not introduced by this PR.

**Review focus:**
- `internal/git/repo.go` — `git.Repo`, `Open`, absolute accessors, and the `gitCommand` factory (the single `cmd.Dir` boundary)
- `cmd/repo.go` — `openRepo()` memoization and `normalizeInvocationPath()` for relative-path preservation
- `internal/config/resolver.go` and `cmd/finish.go` — tag message-file normalization across Layer 2 config and Layer 3 CLI