### PR TITLE
feat(completion): support tab completion for "git flow" subcommand

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,152 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	// Disable Cobra's default completion command; we provide our own
+	// that adds git-subcommand integration for "git flow".
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
+	rootCmd.AddCommand(completionCmd)
+}
+
+var completionCmd = &cobra.Command{
+	Use:       "completion {bash|zsh|fish|powershell}",
+	Short:     "Generate shell completion scripts",
+	Long:      completionLong,
+	Args:      cobra.ExactValidArgs(1),
+	ValidArgs: []string{"bash", "zsh", "fish", "powershell"},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		switch args[0] {
+		case "bash":
+			return genBashCompletion(os.Stdout)
+		case "zsh":
+			return rootCmd.GenZshCompletion(os.Stdout)
+		case "fish":
+			return genFishCompletion(os.Stdout)
+		case "powershell":
+			return rootCmd.GenPowerShellCompletionWithDesc(os.Stdout)
+		}
+		return nil
+	},
+}
+
+const completionLong = `Generate shell completion scripts for git-flow.
+
+For bash, zsh, and fish the generated scripts provide tab completion for
+both "git-flow" (direct) and "git flow" (git subcommand) invocation styles.
+PowerShell completion supports "git-flow" only.
+
+Bash:
+
+  source <(git flow completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  git flow completion bash > /etc/bash_completion.d/git-flow
+  # macOS (Homebrew):
+  git flow completion bash > $(brew --prefix)/etc/bash_completion.d/git-flow
+
+Zsh:
+
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it first:
+  echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  git flow completion zsh > "${fpath[1]}/_git-flow"
+
+  # You will need to start a new shell for this setup to take effect.
+
+Fish:
+
+  git flow completion fish | source
+
+  # To load completions for each session, execute once:
+  git flow completion fish > ~/.config/fish/completions/git-flow.fish
+
+PowerShell:
+
+  git flow completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, add the output of
+  # the above command to your PowerShell profile.
+`
+
+// genBashCompletion generates bash completion with a bridge for "git flow" usage.
+// Git's bash completion calls _git_<subcommand>() when completing "git <subcommand>",
+// so we append a _git_flow() function that remaps the completion context and
+// delegates to Cobra's __start_git-flow.
+func genBashCompletion(w io.Writer) error {
+	if err := rootCmd.GenBashCompletionV2(w, true); err != nil {
+		return err
+	}
+	_, err := fmt.Fprint(w, bashBridge)
+	return err
+}
+
+const bashBridge = `
+# Bridge for "git flow" subcommand completion.
+# Git's bash completion calls _git_flow() when the user types "git flow <tab>".
+# This remaps the completion context so Cobra sees "git-flow ..." and delegates.
+_git_flow()
+{
+    # Rewrite "git flow" to "git-flow" so Cobra recognises the binary name.
+    # Both forms are 8 characters, so COMP_POINT stays unchanged.
+    COMP_LINE="${COMP_LINE/git flow/git-flow}"
+    COMP_WORDS=("git-flow" "${COMP_WORDS[@]:2}")
+    ((COMP_CWORD--))
+
+    # Reset compopt to match the defaults Cobra expects when compopt is available
+    # ("complete -o default", no nospace). Git's completion context may have set
+    # options that interfere with trailing-space behaviour.
+    if [[ $(type -t compopt) = "builtin" ]]; then
+        compopt -o default +o nospace
+    fi
+
+    __start_git-flow
+}
+`
+
+// genFishCompletion generates fish completion with support for "git flow" usage.
+// Fish has no automatic git-subcommand discovery, so we append registrations
+// that delegate to git-flow's __complete when the user types "git flow <tab>".
+func genFishCompletion(w io.Writer) error {
+	if err := rootCmd.GenFishCompletion(w, true); err != nil {
+		return err
+	}
+	_, err := fmt.Fprint(w, fishBridge)
+	return err
+}
+
+const fishBridge = `
+# Bridge for "git flow" subcommand completion.
+# Registers completions for "git flow ..." by delegating to git-flow's
+# Cobra-generated __complete command.
+function __fish_git_flow_complete
+    set -l tokens (commandline -opc)
+    set -l current (commandline -ct)
+    # Skip "git" and "flow", pass the rest to git-flow __complete
+    set -l args $tokens[3..-1]
+
+    set -l results (GIT_FLOW_ACTIVE_HELP=0 git-flow __complete $args $current 2>/dev/null)
+    if test (count $results) -eq 0
+        return
+    end
+
+    # The last line is the completion directive; strip it
+    set -e results[-1]
+    string join \n -- $results
+end
+
+# Register "flow" as a git subcommand
+complete -c git -f -n '__fish_use_subcommand' -a flow -d 'Manage branches with git-flow'
+
+# Delegate deeper completions to git-flow
+complete -c git -f -n '__fish_seen_subcommand_from flow' -a '(__fish_git_flow_complete)'
+`

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ This directory contains comprehensive manpage-style documentation for all git-fl
 - **git-flow-release.1.md** - Release branch management
 - **git-flow-hotfix.1.md** - Hotfix branch management
 - **git-flow-overview.1.md** - Repository workflow overview
+- **git-flow-completion.1.md** - Shell completion script generation
 
 ### Configuration Documentation (Section 5)
 - **gitflow-config.5.md** - Complete configuration reference and examples

--- a/docs/git-flow-completion.1.md
+++ b/docs/git-flow-completion.1.md
@@ -1,0 +1,110 @@
+# GIT-FLOW-COMPLETION(1)
+
+## NAME
+
+git-flow-completion - Generate shell completion scripts
+
+## SYNOPSIS
+
+**git-flow completion** *shell*
+
+## DESCRIPTION
+
+Generate shell completion scripts for git-flow. For bash, zsh, and fish the generated scripts provide tab completion for both **git-flow** (direct invocation) and **git flow** (git subcommand) command forms. PowerShell completion supports **git-flow** only.
+
+Supported shells: **bash**, **zsh**, **fish**, **powershell**.
+
+## SHELL-SPECIFIC BEHAVIOUR
+
+### Bash
+
+The generated script includes Cobra's standard completion for the **git-flow** binary plus a `_git_flow()` bridge function. Git's bash completion system calls `_git_<subcommand>()` when completing **git \<subcommand\>**, so this bridge remaps the completion context and delegates to Cobra's `__start_git-flow`.
+
+### Zsh
+
+No bridge is needed. Cobra's output defines a `_git-flow` function, and zsh's built-in **_git** completion auto-discovers `_git-<subcommand>` functions. Both **git-flow** and **git flow** completion work once the script is sourced or placed in **fpath**.
+
+### Fish
+
+The generated script includes Cobra's standard completion for **git-flow** plus a bridge that registers completions for the **git** command when the subcommand is **flow**. Deeper completions are delegated to git-flow's built-in `__complete` mechanism.
+
+### PowerShell
+
+Uses Cobra's standard PowerShell completion for the **git-flow** binary. No subcommand bridge is provided, so **git flow** completion is not supported in PowerShell.
+
+## INSTALLATION
+
+### Bash
+
+```bash
+# Load in the current session
+source <(git flow completion bash)
+
+# Persist for all sessions (Linux)
+git flow completion bash > /etc/bash_completion.d/git-flow
+
+# Persist for all sessions (macOS with Homebrew)
+git flow completion bash > $(brew --prefix)/etc/bash_completion.d/git-flow
+```
+
+### Zsh
+
+```bash
+# Enable completion if not already configured
+echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+# Install the completion function
+git flow completion zsh > "${fpath[1]}/_git-flow"
+
+# Restart your shell
+```
+
+### Fish
+
+```bash
+# Load in the current session
+git flow completion fish | source
+
+# Persist for all sessions
+git flow completion fish > ~/.config/fish/completions/git-flow.fish
+```
+
+### PowerShell
+
+```powershell
+# Load in the current session
+git flow completion powershell | Out-String | Invoke-Expression
+
+# Persist: add the above to your PowerShell profile
+```
+
+## EXAMPLES
+
+### Generate and preview bash completion
+
+```bash
+git flow completion bash
+```
+
+### Install bash completion system-wide
+
+```bash
+sudo git flow completion bash > /etc/bash_completion.d/git-flow
+```
+
+### Install zsh completion for the current user
+
+```bash
+mkdir -p ~/.zsh/completions
+echo 'fpath=(~/.zsh/completions $fpath)' >> ~/.zshrc
+git flow completion zsh > ~/.zsh/completions/_git-flow
+```
+
+## EXIT STATUS
+
+**0**
+: Completion script generated successfully
+
+## SEE ALSO
+
+**git-flow**(1), **bash**(1), **zshcompsys**(1), **fish**(1)

--- a/docs/git-flow.1.md
+++ b/docs/git-flow.1.md
@@ -147,7 +147,7 @@ git flow config add topic bugfix develop --prefix=bug/
 
 ## SEE ALSO
 
-**git-flow-init**(1), **git-flow-config**(1), **git-flow-start**(1), **git-flow-finish**(1), **git-flow-integrate**(1), **git-flow-update**(1), **git-flow-delete**(1), **git-flow-track**(1), **gitflow-config**(5), **git**(1)
+**git-flow-init**(1), **git-flow-config**(1), **git-flow-completion**(1), **git-flow-start**(1), **git-flow-finish**(1), **git-flow-integrate**(1), **git-flow-update**(1), **git-flow-delete**(1), **git-flow-track**(1), **gitflow-config**(5), **git**(1)
 
 ## AUTHORS
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ Comprehensive manpage-style documentation for git-flow-next commands and configu
 | **git-flow config** | Manage configuration | [git-flow-config(1)](git-flow-config.1.md) |
 | **git-flow overview** | Repository status | [git-flow-overview(1)](git-flow-overview.1.md) |
 | **git-flow integrate** | Integrate a base branch into its parent | [git-flow-integrate(1)](git-flow-integrate.1.md) |
+| **git-flow completion** | Generate shell completion scripts | [git-flow-completion(1)](git-flow-completion.1.md) |
 
 ## Topic Branch Commands
 

--- a/test/cmd/completion_test.go
+++ b/test/cmd/completion_test.go
@@ -1,0 +1,110 @@
+package cmd_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// TestCompletionBash verifies that "completion bash" generates valid output
+// including Cobra's standard completion and the _git_flow bridge function.
+func TestCompletionBash(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	output, err := testutil.RunGitFlow(t, dir, "completion", "bash")
+	if err != nil {
+		t.Fatalf("completion bash failed: %v\nOutput: %s", err, output)
+	}
+
+	// Cobra's standard completion function
+	if !strings.Contains(output, "__start_git-flow") {
+		t.Error("expected bash completion to contain __start_git-flow")
+	}
+	// Standard registration for "git-flow" direct invocation
+	if !strings.Contains(output, "complete -o default -F __start_git-flow git-flow") {
+		t.Error("expected bash completion to register complete for git-flow")
+	}
+	// Bridge function for "git flow" subcommand
+	if !strings.Contains(output, "_git_flow()") {
+		t.Error("expected bash completion to contain _git_flow bridge function")
+	}
+}
+
+// TestCompletionZsh verifies that "completion zsh" generates valid output
+// with the _git-flow function that zsh's _git auto-discovers.
+func TestCompletionZsh(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	output, err := testutil.RunGitFlow(t, dir, "completion", "zsh")
+	if err != nil {
+		t.Fatalf("completion zsh failed: %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(output, "_git-flow") {
+		t.Error("expected zsh completion to contain _git-flow function")
+	}
+}
+
+// TestCompletionFish verifies that "completion fish" generates valid output
+// including the git subcommand bridge.
+func TestCompletionFish(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	output, err := testutil.RunGitFlow(t, dir, "completion", "fish")
+	if err != nil {
+		t.Fatalf("completion fish failed: %v\nOutput: %s", err, output)
+	}
+
+	// Cobra's standard fish completion
+	if !strings.Contains(output, "complete -c git-flow") {
+		t.Error("expected fish completion to contain registrations for git-flow")
+	}
+	// Bridge: register "flow" as a git subcommand
+	if !strings.Contains(output, "__fish_git_flow_complete") {
+		t.Error("expected fish completion to contain __fish_git_flow_complete bridge")
+	}
+	if !strings.Contains(output, `complete -c git -f -n '__fish_use_subcommand' -a flow`) {
+		t.Error("expected fish completion to register 'flow' as a git subcommand")
+	}
+}
+
+// TestCompletionPowerShell verifies that "completion powershell" generates valid output.
+func TestCompletionPowerShell(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	output, err := testutil.RunGitFlow(t, dir, "completion", "powershell")
+	if err != nil {
+		t.Fatalf("completion powershell failed: %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(output, "git-flow") {
+		t.Error("expected powershell completion to reference git-flow")
+	}
+}
+
+// TestCompletionInvalidShell verifies that an invalid shell argument is rejected.
+func TestCompletionInvalidShell(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	_, err := testutil.RunGitFlow(t, dir, "completion", "invalid")
+	if err == nil {
+		t.Error("expected completion with invalid shell to fail")
+	}
+}
+
+// TestCompletionNoArgs verifies that running completion without arguments fails.
+func TestCompletionNoArgs(t *testing.T) {
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	_, err := testutil.RunGitFlow(t, dir, "completion")
+	if err == nil {
+		t.Error("expected completion without arguments to fail")
+	}
+}


### PR DESCRIPTION
Replace Cobra's default completion command with a custom one that generates scripts supporting both `git-flow` and `git flow` invocation.

This solution still leverages Cobra's internal completion, but appends shell-specific bridge functions that teach each shell how to delegate `git flow <tab>` to Cobra's existing `git-flow` completion logic.

Bash gets a `_git_flow()` bridge (the function Git's completion system calls for `git flow`), fish gets git-subcommand registration, and zsh works out of the box via Cobra's `_git-flow` auto-discovery.

## Summary

- **Bash**: append a `_git_flow()` bridge that remaps `COMP_WORDS`/`COMP_CWORD` and delegates to Cobra's `__start_git-flow`
- **Zsh**: no bridge needed; Cobra's `_git-flow` function is auto-discovered by zsh's `_git` completion
- **Fish**: register `flow` as a git subcommand and delegate deeper completions to `git-flow __complete`

Resolves #34
