### PR TITLE
test(cmd): Scope config and gpg env to subprocesses

### DIFF
--- a/test/cmd/delete_test.go
+++ b/test/cmd/delete_test.go
@@ -1015,40 +1015,41 @@ func TestDeleteWithMultiValueBaseConfigWarns(t *testing.T) {
 // 7. Verifies no cleanup warning is printed and the branch is deleted
 func TestDeleteWithBaseConfigInNonLocalScopeNoWarning(t *testing.T) {
 	// Isolate the global config to a temp file so nothing touches the
-	// developer's real global config. RunGit/RunGitFlow exec inheriting
-	// os.Environ(), so the subprocess sees this override.
-	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(t.TempDir(), "global-gitconfig"))
+	// developer's real global config. The override is passed through each
+	// subprocess env (not the test process env) so it stays scoped to this
+	// test and is safe under parallel execution.
+	env := []string{"GIT_CONFIG_GLOBAL=" + filepath.Join(t.TempDir(), "global-gitconfig")}
 
 	// Setup
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 
 	// Initialize git-flow with defaults
-	output, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	output, err := runGitFlowWithEnv(t, dir, env, "init", "--defaults")
 	if err != nil {
 		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
 	}
 
 	// Create feature branch (stores base config locally)
-	output, err = testutil.RunGitFlow(t, dir, "feature", "start", "scoped-base")
+	output, err = runGitFlowWithEnv(t, dir, env, "feature", "start", "scoped-base")
 	if err != nil {
 		t.Fatalf("Failed to start feature branch: %v\nOutput: %s", err, output)
 	}
 
 	// Remove the local base key to simulate a branch not started locally
-	_, err = testutil.RunGit(t, dir, "config", "--local", "--unset", "gitflow.branch.feature/scoped-base.base")
+	_, err = testutil.RunGitWithEnv(t, dir, env, "config", "--local", "--unset", "gitflow.branch.feature/scoped-base.base")
 	if err != nil {
 		t.Fatalf("Failed to unset local base config: %v", err)
 	}
 
 	// Add the base key to the global scope only (lands in the isolated GIT_CONFIG_GLOBAL file)
-	_, err = testutil.RunGit(t, dir, "config", "--global", "--add", "gitflow.branch.feature/scoped-base.base", "develop")
+	_, err = testutil.RunGitWithEnv(t, dir, env, "config", "--global", "--add", "gitflow.branch.feature/scoped-base.base", "develop")
 	if err != nil {
 		t.Fatalf("Failed to add global base config: %v", err)
 	}
 
 	// Delete the feature branch
-	output, err = testutil.RunGitFlow(t, dir, "feature", "delete", "scoped-base")
+	output, err = runGitFlowWithEnv(t, dir, env, "feature", "delete", "scoped-base")
 	if err != nil {
 		t.Fatalf("Failed to delete feature branch: %v\nOutput: %s", err, output)
 	}

--- a/test/cmd/integrate_tags_test.go
+++ b/test/cmd/integrate_tags_test.go
@@ -67,20 +67,13 @@ func TestIntegrateSignedTag(t *testing.T) {
 		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
 	}
 
-	// Ephemeral GPG home so we never touch the developer's keyring.
+	// Ephemeral GPG home so we never touch the developer's keyring. It is
+	// passed through each subprocess env that needs it (never the test process
+	// env) so it stays scoped to this test and is safe under parallel execution.
 	gnupgHome := t.TempDir()
 	if err := os.Chmod(gnupgHome, 0700); err != nil {
 		t.Skipf("cannot secure GNUPGHOME: %v", err)
 	}
-	prev, hadPrev := os.LookupEnv("GNUPGHOME")
-	os.Setenv("GNUPGHOME", gnupgHome)
-	defer func() {
-		if hadPrev {
-			os.Setenv("GNUPGHOME", prev)
-		} else {
-			os.Unsetenv("GNUPGHOME")
-		}
-	}()
 
 	genCmd := exec.Command("gpg", "--batch", "--pinentry-mode", "loopback", "--passphrase", "",
 		"--quick-generate-key", "Test Signer <test@example.com>", "default", "default", "0")
@@ -95,7 +88,7 @@ func TestIntegrateSignedTag(t *testing.T) {
 
 	integAddCommit(t, dir, "develop", "c.txt", "C", "Add C on develop")
 
-	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop", "--tag", "v2.0.0", "--sign")
+	out, err := runGitFlowWithEnv(t, dir, []string{"GNUPGHOME=" + gnupgHome}, "integrate", "develop", "--tag", "v2.0.0", "--sign")
 	if err != nil {
 		t.Fatalf("integrate develop --tag --sign failed: %v\nOutput: %s", err, out)
 	}

--- a/test/testutil/git.go
+++ b/test/testutil/git.go
@@ -90,11 +90,22 @@ func ConfigureGitIdentity(t *testing.T, dir string) {
 
 // RunGit runs a git command in the specified directory and returns its output
 func RunGit(t *testing.T, dir string, args ...string) (string, error) {
+	return RunGitWithEnv(t, dir, nil, args...)
+}
+
+// RunGitWithEnv runs a git command in the specified directory with extra
+// environment variables appended to the child process env, returning its output.
+// The extra env is scoped to the subprocess only — it never mutates the test
+// process environment — so concurrent tests can isolate settings like
+// GIT_CONFIG_GLOBAL without leaking into each other (see RunGit for the
+// no-extra-env case).
+func RunGitWithEnv(t *testing.T, dir string, env []string, args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
 	// Set GIT_EDITOR to colon (:) to prevent interactive editor from opening
 	// The colon is a shell builtin that does nothing and returns success
 	cmd.Env = append(os.Environ(), "GIT_EDITOR=:")
+	cmd.Env = append(cmd.Env, env...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return string(output), fmt.Errorf("git command failed: %w\nOutput: %s", err, output)

--- a/test/testutil/git.go
+++ b/test/testutil/git.go
@@ -102,10 +102,12 @@ func RunGit(t *testing.T, dir string, args ...string) (string, error) {
 func RunGitWithEnv(t *testing.T, dir string, env []string, args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
-	// Set GIT_EDITOR to colon (:) to prevent interactive editor from opening
-	// The colon is a shell builtin that does nothing and returns success
-	cmd.Env = append(os.Environ(), "GIT_EDITOR=:")
-	cmd.Env = append(cmd.Env, env...)
+	cmd.Env = append(os.Environ(), env...)
+	// Set GIT_EDITOR to colon (:) to prevent interactive editor from opening.
+	// The colon is a shell builtin that does nothing and returns success.
+	// Appended last so it always wins over any caller-supplied GIT_EDITOR
+	// (exec dedups env keeping the final value), keeping git non-interactive.
+	cmd.Env = append(cmd.Env, "GIT_EDITOR=:")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return string(output), fmt.Errorf("git command failed: %w\nOutput: %s", err, output)


### PR DESCRIPTION
Removes the two process-global environment mutations in `test/cmd` so the command tests can later run in parallel, without changing what any test asserts.

`TestDeleteWithBaseConfigInNonLocalScopeNoWarning` set `GIT_CONFIG_GLOBAL` via `t.Setenv`, and `TestIntegrateSignedTag` set `GNUPGHOME` via `os.Setenv` with a deferred restore. Because `testutil.RunGit`/`RunGitFlow` build the child env from `os.Environ()`, those writes leak into every concurrently executing subprocess, and `t.Setenv` is incompatible with `t.Parallel()` — so both tests block safe parallelization. This adds `testutil.RunGitWithEnv`, which appends caller-supplied variables to the git subprocess env only, and routes both tests through it (and the existing `runGitFlowWithEnv`) so each isolation is scoped to the child processes that need it. `RunGit` now delegates to `RunGitWithEnv`, preserving its central `GIT_EDITOR` override and behavior for all existing callers. This is sub-spec A of #165; it does not add `t.Parallel()` yet.

Resolves #163

### Remarks
- Behavior is unchanged: no test assertion, expected output, or exit code is modified; the developer's real global config and GPG keyring stay untouched.
- The `grep -rnE '\b(os\.Setenv|os\.Unsetenv|t\.Setenv)\b' test/cmd/` gate now returns zero matches.
- `TestIntegrateSignedTag` skips locally because gpg-agent cannot start in the sandbox (key generation fails before the signing path); the env-threading itself is verified end-to-end by the delete test, which passes through the same helper. CI exercises the signing path.

**Review focus:**
- `test/testutil/git.go` — `RunGitWithEnv` and the `RunGit` delegation (the central `GIT_EDITOR` override is preserved)
- `test/cmd/delete_test.go` — every subprocess touching global scope (`init`, `feature start`, unset, `--global --add`, `feature delete`) receives the isolated `GIT_CONFIG_GLOBAL`
- `test/cmd/integrate_tags_test.go` — `GNUPGHOME` reaches only the keyring-touching subprocesses