### PR TITLE
fix(hooks): Resolve hooks and filters against the active worktree

### DIFF
--- a/TESTING_GUIDELINES.md
+++ b/TESTING_GUIDELINES.md
@@ -427,9 +427,11 @@ func TestExample(t *testing.T) {
 
 `git.Open` resolves the work tree, git dir, and common git dir to absolute
 paths, so accessors like `repo.GitDir()` are always absolute (never the bare
-`.git`). Feed `repo.GitDir()` to the hooks/filters helpers
-(`hooks.RunPreHook(repo.GitDir(), …)`). Because nothing depends on the process
-working directory, these tests are safe to run with `t.Parallel()`.
+`.git`). Pass the handle itself to the hooks/filters helpers
+(`hooks.RunPreHook(repo, …)`); they read `repo.WorkTree()` and
+`repo.CommonGitDir()` so hooks resolve against the active worktree. Because
+nothing depends on the process working directory, these tests are safe to run
+with `t.Parallel()`.
 
 ### Migration Note: `os.Chdir()` Eliminated
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -62,9 +62,6 @@ func executeDelete(repo *git.Repo, branchType string, name string, force *bool, 
 		return &errors.BranchNotFoundError{BranchName: fullBranchName}
 	}
 
-	// Get git directory for hooks
-	gitDir := repo.GitDir()
-
 	// Get remote name from config
 	remoteName := cfg.Remote
 
@@ -81,7 +78,7 @@ func executeDelete(repo *git.Repo, branchType string, name string, force *bool, 
 	}
 
 	// Run delete operation wrapped with hooks
-	return hooks.WithHooks(gitDir, branchType, hooks.HookActionDelete, hookCtx, func() error {
+	return hooks.WithHooks(repo, branchType, hooks.HookActionDelete, hookCtx, func() error {
 		return performDelete(repo, branchType, name, fullBranchName, branchConfig, force, remote, fetch, cfg)
 	})
 }

--- a/cmd/finish.go
+++ b/cmd/finish.go
@@ -295,8 +295,6 @@ func finishBranch(repo *git.Repo, cfg *config.Config, branchType string, name st
 	resolvedOptions := config.ResolveFinishOptions(cfg, branchType, shortName, tagOptions, retentionOptions, mergeOptions, fetch, noVerify, push, pushTag)
 
 	// Run pre-hook before starting finish operation
-	gitDir := repo.GitDir()
-
 	hookCtx := hooks.HookContext{
 		BranchType: branchType,
 		BranchName: shortName,
@@ -309,7 +307,7 @@ func finishBranch(repo *git.Repo, cfg *config.Config, branchType string, name st
 		hookCtx.Version = shortName
 	}
 
-	if err := hooks.RunPreHook(gitDir, branchType, hooks.HookActionFinish, hookCtx); err != nil {
+	if err := hooks.RunPreHook(repo, branchType, hooks.HookActionFinish, hookCtx); err != nil {
 		return err
 	}
 
@@ -692,8 +690,6 @@ func handleCreateTagStep(repo *git.Repo, cfg *config.Config, state *mergestate.M
 	if resolvedOptions.ShouldTag {
 		// Apply tag message filter for any branch type configured with tagging
 		// The filter script (filter-flow-{branchType}-finish-tag-message) decides what to do
-		gitDir := repo.GitDir()
-
 		remote := cfg.Remote
 
 		ctx := hooks.FilterContext{
@@ -706,7 +702,7 @@ func handleCreateTagStep(repo *git.Repo, cfg *config.Config, state *mergestate.M
 			Origin:     remote,
 		}
 
-		filteredMessage, err := hooks.RunTagMessageFilter(gitDir, state.BranchType, ctx)
+		filteredMessage, err := hooks.RunTagMessageFilter(repo, state.BranchType, ctx)
 		if err != nil {
 			return &errors.GitError{Operation: "run tag message filter", Err: err}
 		}
@@ -812,7 +808,6 @@ func handleDeleteBranchStep(repo *git.Repo, cfg *config.Config, state *mergestat
 	fmt.Printf("Successfully finished branch '%s' and updated %d child base branches\n", state.FullBranchName, len(state.UpdatedBranches))
 
 	// Run post-hook after successful completion
-	gitDir := repo.GitDir()
 	hookCtx := hooks.HookContext{
 		BranchType: state.BranchType,
 		BranchName: state.BranchName,
@@ -826,7 +821,7 @@ func handleDeleteBranchStep(repo *git.Repo, cfg *config.Config, state *mergestat
 		hookCtx.Version = state.BranchName
 	}
 
-	result := hooks.RunPostHook(gitDir, state.BranchType, hooks.HookActionFinish, hookCtx)
+	result := hooks.RunPostHook(repo, state.BranchType, hooks.HookActionFinish, hookCtx)
 	if result.Executed && result.Output != "" {
 		fmt.Print(result.Output)
 	}

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -97,9 +97,6 @@ func publish(repo *git.Repo, branchType string, name string, cliPushOptions []st
 		return &errors.RemoteNotConfiguredError{Remote: remote, Operation: "publish branch"}
 	}
 
-	// Get git directory for hooks
-	gitDir := repo.GitDir()
-
 	// Build hook context
 	hookCtx := hooks.HookContext{
 		BranchType: branchType,
@@ -120,7 +117,7 @@ func publish(repo *git.Repo, branchType string, name string, cliPushOptions []st
 	pushOptions := resolvePushOptions(repo, cfg, branchType, cliPushOptions, noPushOption)
 
 	// Run publish operation wrapped with hooks
-	return hooks.WithHooks(gitDir, branchType, hooks.HookActionPublish, hookCtx, func() error {
+	return hooks.WithHooks(repo, branchType, hooks.HookActionPublish, hookCtx, func() error {
 		return executePublish(repo, fullBranchName, shortName, branchType, remote, pushOptions)
 	})
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -38,13 +38,10 @@ func start(repo *git.Repo, branchType string, name string, base string, shouldFe
 		return &errors.NotInitializedError{}
 	}
 
-	// Get git directory for hooks and filters
-	gitDir := repo.GitDir()
-
 	// Apply version filter for any branch type. The filter script
 	// (filter-flow-{branchType}-start-version) decides what to do; when no name
 	// was provided, it runs with an empty version argument and may supply one.
-	filteredName, err := hooks.RunVersionFilter(gitDir, branchType, name)
+	filteredName, err := hooks.RunVersionFilter(repo, branchType, name)
 	if err != nil {
 		return &errors.GitError{Operation: "run version filter", Err: err}
 	}
@@ -103,7 +100,7 @@ func start(repo *git.Repo, branchType string, name string, base string, shouldFe
 	}
 
 	// Run start operation wrapped with hooks
-	return hooks.WithHooks(gitDir, branchType, hooks.HookActionStart, hookCtx, func() error {
+	return hooks.WithHooks(repo, branchType, hooks.HookActionStart, hookCtx, func() error {
 		return executeStart(repo, branchType, name, base, shouldFetch, cfg, branchConfig, fullBranchName, startPoint)
 	})
 }

--- a/cmd/track.go
+++ b/cmd/track.go
@@ -76,9 +76,6 @@ func track(repo *git.Repo, branchType string, name string) error {
 		return &errors.RemoteNotConfiguredError{Remote: remote, Operation: "track branch"}
 	}
 
-	// Get git directory for hooks
-	gitDir := repo.GitDir()
-
 	// Build hook context
 	hookCtx := hooks.HookContext{
 		BranchType: branchType,
@@ -92,7 +89,7 @@ func track(repo *git.Repo, branchType string, name string) error {
 	}
 
 	// Run track operation wrapped with hooks
-	return hooks.WithHooks(gitDir, branchType, hooks.HookActionTrack, hookCtx, func() error {
+	return hooks.WithHooks(repo, branchType, hooks.HookActionTrack, hookCtx, func() error {
 		return executeTrack(repo, fullBranchName, remote)
 	})
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -201,9 +201,6 @@ func executeUpdate(repo *git.Repo, branchType string, name string, useRebase, co
 
 	// If we detected a branch type, run with hooks
 	if detectedBranchType != "" {
-		// Get git directory for hooks
-		gitDir := repo.GitDir()
-
 		// Get remote name from config
 		remoteName := cfg.Remote
 
@@ -220,7 +217,7 @@ func executeUpdate(repo *git.Repo, branchType string, name string, useRebase, co
 		}
 
 		// Run update operation wrapped with hooks
-		return hooks.WithHooks(gitDir, detectedBranchType, hooks.HookActionUpdate, hookCtx, func() error {
+		return hooks.WithHooks(repo, detectedBranchType, hooks.HookActionUpdate, hookCtx, func() error {
 			return update.UpdateBranchFromParent(repo, branchName, parentBranch, strategy, true, state)
 		})
 	}

--- a/internal/hooks/filters.go
+++ b/internal/hooks/filters.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/gittower/git-flow-next/internal/git"
 )
 
 // isWindows controls how hook/filter scripts are located and executed. It is a
@@ -28,9 +30,9 @@ func scriptCommand(path string, args ...string) *exec.Cmd {
 // The filter script name is: filter-flow-{branchType}-start-version
 // If the filter does not exist or is not executable, the original version is returned.
 // If the filter exits with a non-zero status, an error is returned.
-func RunVersionFilter(gitDir string, branchType string, version string) (string, error) {
+func RunVersionFilter(repo *git.Repo, branchType string, version string) (string, error) {
 	filterName := GetFilterName(branchType, "start", FilterTargetVersion)
-	hooksDir := getHooksDir(gitDir)
+	hooksDir := getHooksDir(repo.WorkTree(), repo.CommonGitDir())
 	scriptPath := filepath.Join(hooksDir, filterName)
 
 	// Check if filter exists and is executable
@@ -38,9 +40,8 @@ func RunVersionFilter(gitDir string, branchType string, version string) (string,
 		return version, nil
 	}
 
-	// Execute the filter with version as argument
-	repoRoot := filepath.Dir(getCommonGitDir(gitDir))
-	result, err := runFilter(scriptPath, version, nil, repoRoot)
+	// Execute the filter with version as argument, from the active worktree root
+	result, err := runFilter(scriptPath, version, nil, repo.WorkTree())
 	if err != nil {
 		return "", fmt.Errorf("version filter '%s' failed: %w", filterName, err)
 	}
@@ -57,9 +58,9 @@ func RunVersionFilter(gitDir string, branchType string, version string) (string,
 // The filter script name is: filter-flow-{branchType}-finish-tag-message
 // If the filter does not exist or is not executable, the original message is returned.
 // If the filter exits with a non-zero status, an error is returned.
-func RunTagMessageFilter(gitDir string, branchType string, ctx FilterContext) (string, error) {
+func RunTagMessageFilter(repo *git.Repo, branchType string, ctx FilterContext) (string, error) {
 	filterName := GetFilterName(branchType, "finish", FilterTargetTagMessage)
-	hooksDir := getHooksDir(gitDir)
+	hooksDir := getHooksDir(repo.WorkTree(), repo.CommonGitDir())
 	scriptPath := filepath.Join(hooksDir, filterName)
 
 	// Check if filter exists and is executable
@@ -70,10 +71,9 @@ func RunTagMessageFilter(gitDir string, branchType string, ctx FilterContext) (s
 	// Build environment variables for the filter
 	env := buildFilterEnv(ctx)
 
-	// Execute the filter with version and message as arguments
-	// The filter receives: $1 = version, $2 = message
-	repoRoot := filepath.Dir(getCommonGitDir(gitDir))
-	result, err := runFilterWithArgs(scriptPath, []string{ctx.Version, ctx.TagMessage}, env, repoRoot)
+	// Execute the filter with version and message as arguments, from the active
+	// worktree root. The filter receives: $1 = version, $2 = message
+	result, err := runFilterWithArgs(scriptPath, []string{ctx.Version, ctx.TagMessage}, env, repo.WorkTree())
 	if err != nil {
 		return "", fmt.Errorf("tag message filter '%s' failed: %w", filterName, err)
 	}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -11,8 +11,8 @@ import (
 
 // RunPreHook executes a pre-hook script. Returns an error if the hook fails (non-zero exit).
 // If the hook does not exist or is not executable, it returns nil (no error).
-func RunPreHook(gitDir string, branchType string, action HookAction, ctx HookContext) error {
-	result := runHook(gitDir, HookPre, branchType, action, ctx)
+func RunPreHook(repo *git.Repo, branchType string, action HookAction, ctx HookContext) error {
+	result := runHook(repo, HookPre, branchType, action, ctx)
 	if result.Error != nil {
 		return result.Error
 	}
@@ -30,8 +30,8 @@ func RunPreHook(gitDir string, branchType string, action HookAction, ctx HookCon
 // RunPostHook executes a post-hook script. The result is returned but errors do not
 // cause the operation to fail. If the hook does not exist or is not executable,
 // it returns a result with Executed=false.
-func RunPostHook(gitDir string, branchType string, action HookAction, ctx HookContext) HookResult {
-	return runHook(gitDir, HookPost, branchType, action, ctx)
+func RunPostHook(repo *git.Repo, branchType string, action HookAction, ctx HookContext) HookResult {
+	return runHook(repo, HookPost, branchType, action, ctx)
 }
 
 // configLookup reads a single git config value for the repository rooted at dir.
@@ -58,45 +58,25 @@ func resolveHooksPath(hooksPath, repoRoot string) string {
 // Resolution follows three-level precedence:
 //  1. gitflow.path.hooks - git-flow-specific override (avh compatibility)
 //  2. core.hooksPath - Git's native hooks path configuration
-//  3. .git/hooks - default location (worktree-aware)
-func getHooksDir(gitDir string) string {
-	commonDir := getCommonGitDir(gitDir)
-	repoRoot := filepath.Dir(commonDir)
-
+//  3. <commonGitDir>/hooks - default location
+//
+// Relative paths (levels 1 and 2) and the configLookup base are resolved
+// against worktreeRoot, the active worktree, so a linked worktree resolves them
+// against its own checkout rather than the main one. The default location stays
+// anchored to the common git dir, which linked worktrees legitimately share.
+func getHooksDir(worktreeRoot, commonGitDir string) string {
 	// 1. git-flow-specific override (avh compatibility)
-	if hooksPath, err := configLookup(repoRoot, "gitflow.path.hooks"); err == nil && hooksPath != "" {
-		return resolveHooksPath(hooksPath, repoRoot)
+	if hooksPath, err := configLookup(worktreeRoot, "gitflow.path.hooks"); err == nil && hooksPath != "" {
+		return resolveHooksPath(hooksPath, worktreeRoot)
 	}
 
 	// 2. Git's core.hooksPath
-	if hooksPath, err := configLookup(repoRoot, "core.hooksPath"); err == nil && hooksPath != "" {
-		return resolveHooksPath(hooksPath, repoRoot)
+	if hooksPath, err := configLookup(worktreeRoot, "core.hooksPath"); err == nil && hooksPath != "" {
+		return resolveHooksPath(hooksPath, worktreeRoot)
 	}
 
-	// 3. Default: .git/hooks (worktree-aware)
-	return filepath.Join(commonDir, "hooks")
-}
-
-// getCommonGitDir returns the common git directory from a git directory path.
-// For regular repositories, this returns the gitDir unchanged.
-// For worktrees (where gitDir is like /repo/.git/worktrees/<name>), this returns /repo/.git
-func getCommonGitDir(gitDir string) string {
-	// Normalize the path
-	gitDir = filepath.Clean(gitDir)
-
-	// Check if this looks like a worktree git dir
-	// Pattern: .../worktrees/<worktree-name>
-	parent := filepath.Dir(gitDir)
-	parentBase := filepath.Base(parent)
-
-	if parentBase == "worktrees" {
-		// This is a worktree git directory
-		// Go up two levels: worktrees/<name> -> .git
-		return filepath.Dir(parent)
-	}
-
-	// Not a worktree, return as-is
-	return gitDir
+	// 3. Default: <commonGitDir>/hooks (shared across linked worktrees)
+	return filepath.Join(commonGitDir, "hooks")
 }
 
 // BuildHookArgs constructs the positional arguments for a hook based on the action.
@@ -123,9 +103,9 @@ func BuildHookArgs(action HookAction, ctx HookContext) []string {
 }
 
 // runHook executes a hook script and returns the result.
-func runHook(gitDir string, phase HookPhase, branchType string, action HookAction, ctx HookContext) HookResult {
+func runHook(repo *git.Repo, phase HookPhase, branchType string, action HookAction, ctx HookContext) HookResult {
 	hookName := fmt.Sprintf("%s-flow-%s-%s", phase, branchType, action)
-	hooksDir := getHooksDir(gitDir)
+	hooksDir := getHooksDir(repo.WorkTree(), repo.CommonGitDir())
 	hookPath := filepath.Join(hooksDir, hookName)
 
 	// Check if hook exists and is executable
@@ -149,7 +129,7 @@ func runHook(gitDir string, phase HookPhase, branchType string, action HookActio
 	// Execute hook with arguments
 	cmd := scriptCommand(hookPath, args...)
 	cmd.Env = env
-	cmd.Dir = filepath.Dir(gitDir) // Repository root
+	cmd.Dir = repo.WorkTree() // Active worktree root
 
 	output, err := cmd.CombinedOutput()
 
@@ -202,9 +182,9 @@ func buildHookEnv(ctx HookContext, phase HookPhase) []string {
 // The pre-hook is run before the operation. If it fails, the operation is not executed.
 // The post-hook is run after the operation, regardless of success or failure.
 // The context's ExitCode is set based on the operation result before running the post-hook.
-func WithHooks(gitDir string, branchType string, action HookAction, ctx HookContext, operation func() error) error {
+func WithHooks(repo *git.Repo, branchType string, action HookAction, ctx HookContext, operation func() error) error {
 	// Run pre-hook
-	if err := RunPreHook(gitDir, branchType, action, ctx); err != nil {
+	if err := RunPreHook(repo, branchType, action, ctx); err != nil {
 		return err
 	}
 
@@ -219,7 +199,7 @@ func WithHooks(gitDir string, branchType string, action HookAction, ctx HookCont
 	}
 
 	// Run post-hook (ignore errors from post-hook)
-	result := RunPostHook(gitDir, branchType, action, ctx)
+	result := RunPostHook(repo, branchType, action, ctx)
 	if result.Executed && result.Output != "" {
 		// Print post-hook output for visibility
 		fmt.Print(result.Output)

--- a/test/internal/hooks/filters_test.go
+++ b/test/internal/hooks/filters_test.go
@@ -56,8 +56,8 @@ fi
 `
 	createExecutableScript(t, dir, "filter-flow-release-start-version", script)
 
-	gitDir := filepath.Join(dir, ".git")
-	result, err := hooks.RunVersionFilter(gitDir, "release", "1.0.0")
+	repo := openRepo(t, dir)
+	result, err := hooks.RunVersionFilter(repo, "release", "1.0.0")
 	if err != nil {
 		t.Fatalf("RunVersionFilter failed: %v", err)
 	}
@@ -83,8 +83,8 @@ fi
 `
 	createExecutableScript(t, dir, "filter-flow-release-start-version", script)
 
-	gitDir := filepath.Join(dir, ".git")
-	result, err := hooks.RunVersionFilter(gitDir, "release", "v1.0.0")
+	repo := openRepo(t, dir)
+	result, err := hooks.RunVersionFilter(repo, "release", "v1.0.0")
 	if err != nil {
 		t.Fatalf("RunVersionFilter failed: %v", err)
 	}
@@ -99,8 +99,8 @@ func TestVersionFilterNonExistentReturnsOriginal(t *testing.T) {
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 
-	gitDir := filepath.Join(dir, ".git")
-	result, err := hooks.RunVersionFilter(gitDir, "release", "1.0.0")
+	repo := openRepo(t, dir)
+	result, err := hooks.RunVersionFilter(repo, "release", "1.0.0")
 	if err != nil {
 		t.Fatalf("RunVersionFilter failed: %v", err)
 	}
@@ -124,8 +124,8 @@ echo "modified-$1"
 `
 	createNonExecutableScript(t, dir, "filter-flow-release-start-version", script)
 
-	gitDir := filepath.Join(dir, ".git")
-	result, err := hooks.RunVersionFilter(gitDir, "release", "1.0.0")
+	repo := openRepo(t, dir)
+	result, err := hooks.RunVersionFilter(repo, "release", "1.0.0")
 	if err != nil {
 		t.Fatalf("RunVersionFilter failed: %v", err)
 	}
@@ -148,8 +148,8 @@ exit 1
 `
 	createExecutableScript(t, dir, "filter-flow-release-start-version", script)
 
-	gitDir := filepath.Join(dir, ".git")
-	_, err := hooks.RunVersionFilter(gitDir, "release", "1.0.0")
+	repo := openRepo(t, dir)
+	_, err := hooks.RunVersionFilter(repo, "release", "1.0.0")
 	if err == nil {
 		t.Fatal("Expected error for non-zero exit code, got nil")
 	}
@@ -166,8 +166,8 @@ func TestVersionFilterEmptyOutputReturnsOriginal(t *testing.T) {
 `
 	createExecutableScript(t, dir, "filter-flow-release-start-version", script)
 
-	gitDir := filepath.Join(dir, ".git")
-	result, err := hooks.RunVersionFilter(gitDir, "release", "1.0.0")
+	repo := openRepo(t, dir)
+	result, err := hooks.RunVersionFilter(repo, "release", "1.0.0")
 	if err != nil {
 		t.Fatalf("RunVersionFilter failed: %v", err)
 	}
@@ -189,8 +189,8 @@ echo "hotfix-$1"
 `
 	createExecutableScript(t, dir, "filter-flow-hotfix-start-version", script)
 
-	gitDir := filepath.Join(dir, ".git")
-	result, err := hooks.RunVersionFilter(gitDir, "hotfix", "1.0.1")
+	repo := openRepo(t, dir)
+	result, err := hooks.RunVersionFilter(repo, "hotfix", "1.0.1")
 	if err != nil {
 		t.Fatalf("RunVersionFilter failed: %v", err)
 	}
@@ -211,8 +211,8 @@ echo "custom-$1"
 `
 	createExecutableScript(t, dir, "filter-flow-epic-start-version", script)
 
-	gitDir := filepath.Join(dir, ".git")
-	result, err := hooks.RunVersionFilter(gitDir, "epic", "my-epic")
+	repo := openRepo(t, dir)
+	result, err := hooks.RunVersionFilter(repo, "epic", "my-epic")
 	if err != nil {
 		t.Fatalf("RunVersionFilter failed: %v", err)
 	}
@@ -237,7 +237,7 @@ Release ${VERSION} - Auto-generated"
 `
 	createExecutableScript(t, dir, "filter-flow-release-finish-tag-message", script)
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.FilterContext{
 		BranchType: "release",
 		BranchName: "1.0.0",
@@ -246,7 +246,7 @@ Release ${VERSION} - Auto-generated"
 		BaseBranch: "main",
 	}
 
-	result, err := hooks.RunTagMessageFilter(gitDir, "release", ctx)
+	result, err := hooks.RunTagMessageFilter(repo, "release", ctx)
 	if err != nil {
 		t.Fatalf("RunTagMessageFilter failed: %v", err)
 	}
@@ -262,7 +262,7 @@ func TestTagMessageFilterNonExistentReturnsOriginal(t *testing.T) {
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.FilterContext{
 		BranchType: "release",
 		BranchName: "1.0.0",
@@ -271,7 +271,7 @@ func TestTagMessageFilterNonExistentReturnsOriginal(t *testing.T) {
 		BaseBranch: "main",
 	}
 
-	result, err := hooks.RunTagMessageFilter(gitDir, "release", ctx)
+	result, err := hooks.RunTagMessageFilter(repo, "release", ctx)
 	if err != nil {
 		t.Fatalf("RunTagMessageFilter failed: %v", err)
 	}
@@ -295,7 +295,7 @@ echo "modified message"
 `
 	createNonExecutableScript(t, dir, "filter-flow-release-finish-tag-message", script)
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.FilterContext{
 		BranchType: "release",
 		BranchName: "1.0.0",
@@ -304,7 +304,7 @@ echo "modified message"
 		BaseBranch: "main",
 	}
 
-	result, err := hooks.RunTagMessageFilter(gitDir, "release", ctx)
+	result, err := hooks.RunTagMessageFilter(repo, "release", ctx)
 	if err != nil {
 		t.Fatalf("RunTagMessageFilter failed: %v", err)
 	}
@@ -326,7 +326,7 @@ exit 1
 `
 	createExecutableScript(t, dir, "filter-flow-release-finish-tag-message", script)
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.FilterContext{
 		BranchType: "release",
 		BranchName: "1.0.0",
@@ -335,7 +335,7 @@ exit 1
 		BaseBranch: "main",
 	}
 
-	_, err := hooks.RunTagMessageFilter(gitDir, "release", ctx)
+	_, err := hooks.RunTagMessageFilter(repo, "release", ctx)
 	if err == nil {
 		t.Fatal("Expected error for non-zero exit code, got nil")
 	}
@@ -353,7 +353,7 @@ echo "Hotfix ${VERSION}"
 `
 	createExecutableScript(t, dir, "filter-flow-hotfix-finish-tag-message", script)
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.FilterContext{
 		BranchType: "hotfix",
 		BranchName: "1.0.1",
@@ -362,7 +362,7 @@ echo "Hotfix ${VERSION}"
 		BaseBranch: "main",
 	}
 
-	result, err := hooks.RunTagMessageFilter(gitDir, "hotfix", ctx)
+	result, err := hooks.RunTagMessageFilter(repo, "hotfix", ctx)
 	if err != nil {
 		t.Fatalf("RunTagMessageFilter failed: %v", err)
 	}
@@ -384,7 +384,7 @@ echo "Epic ${VERSION} completed"
 `
 	createExecutableScript(t, dir, "filter-flow-epic-finish-tag-message", script)
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.FilterContext{
 		BranchType: "epic",
 		BranchName: "my-epic",
@@ -393,7 +393,7 @@ echo "Epic ${VERSION} completed"
 		BaseBranch: "main",
 	}
 
-	result, err := hooks.RunTagMessageFilter(gitDir, "epic", ctx)
+	result, err := hooks.RunTagMessageFilter(repo, "epic", ctx)
 	if err != nil {
 		t.Fatalf("RunTagMessageFilter failed: %v", err)
 	}
@@ -414,7 +414,7 @@ echo "Type: ${BRANCH_TYPE}, Name: ${BRANCH_NAME}, Base: ${BASE_BRANCH}, Version:
 `
 	createExecutableScript(t, dir, "filter-flow-release-finish-tag-message", script)
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.FilterContext{
 		BranchType: "release",
 		BranchName: "my-release",
@@ -423,7 +423,7 @@ echo "Type: ${BRANCH_TYPE}, Name: ${BRANCH_NAME}, Base: ${BASE_BRANCH}, Version:
 		BaseBranch: "main",
 	}
 
-	result, err := hooks.RunTagMessageFilter(gitDir, "release", ctx)
+	result, err := hooks.RunTagMessageFilter(repo, "release", ctx)
 	if err != nil {
 		t.Fatalf("RunTagMessageFilter failed: %v", err)
 	}
@@ -466,7 +466,7 @@ echo "v$1"
 		t.Fatalf("git.Open failed: %v", err)
 	}
 
-	result, err := hooks.RunVersionFilter(repo.GitDir(), "release", "1.0.0")
+	result, err := hooks.RunVersionFilter(repo, "release", "1.0.0")
 	if err != nil {
 		t.Fatalf("RunVersionFilter failed: %v", err)
 	}
@@ -550,11 +550,14 @@ echo "v${VERSION}"
 `
 	createExecutableScript(t, mainRepo, "filter-flow-release-start-version", script)
 
-	// Get the worktree's absolute git directory via a git.Repo handle.
-	wtGitDir := worktreeGitDir(t, worktreePath)
+	// Open a git.Repo handle for the worktree.
+	repo, err := git.Open(worktreePath)
+	if err != nil {
+		t.Fatalf("git.Open failed: %v", err)
+	}
 
 	// Run version filter from worktree context
-	result, err := hooks.RunVersionFilter(wtGitDir, "release", "1.0.0")
+	result, err := hooks.RunVersionFilter(repo, "release", "1.0.0")
 	if err != nil {
 		t.Fatalf("RunVersionFilter failed in worktree: %v", err)
 	}
@@ -590,8 +593,11 @@ echo "Release ${VERSION} from worktree"
 `
 	createExecutableScript(t, mainRepo, "filter-flow-release-finish-tag-message", script)
 
-	// Get the worktree's absolute git directory via a git.Repo handle.
-	wtGitDir := worktreeGitDir(t, worktreePath)
+	// Open a git.Repo handle for the worktree.
+	repo, err := git.Open(worktreePath)
+	if err != nil {
+		t.Fatalf("git.Open failed: %v", err)
+	}
 
 	ctx := hooks.FilterContext{
 		BranchType: "release",
@@ -602,12 +608,113 @@ echo "Release ${VERSION} from worktree"
 	}
 
 	// Run tag message filter from worktree context
-	result, err := hooks.RunTagMessageFilter(wtGitDir, "release", ctx)
+	result, err := hooks.RunTagMessageFilter(repo, "release", ctx)
 	if err != nil {
 		t.Fatalf("RunTagMessageFilter failed in worktree: %v", err)
 	}
 
 	if result != "Release 2.0.0 from worktree" {
 		t.Errorf("Expected 'Release 2.0.0 from worktree', got '%s'", result)
+	}
+}
+
+// TestVersionFilterRelativePathResolvesInWorktree (Scenario 6) verifies that a
+// version filter configured via a relative gitflow.path.hooks is discovered and
+// executed against the active worktree root: the worktree filter transforms the
+// version and runs with cwd == worktree root, while the main-checkout control
+// filter never runs.
+func TestVersionFilterRelativePathResolvesInWorktree(t *testing.T) {
+	t.Parallel()
+	mainRepo, worktreePath, repo := setupWorktree(t, "wt-versionfilter")
+
+	wtMarker := filepath.Join(worktreePath, "vf-marker.txt")
+	mainMarker := filepath.Join(mainRepo, "vf-main-marker.txt")
+	wtScript := `#!/bin/sh
+pwd > "` + wtMarker + `"
+echo "v$1"
+`
+	mainScript := `#!/bin/sh
+pwd > "` + mainMarker + `"
+echo "MAIN$1"
+`
+	createExecutableScript2(t, filepath.Join(worktreePath, ".githooks"), "filter-flow-release-start-version", wtScript)
+	createExecutableScript2(t, filepath.Join(mainRepo, ".githooks"), "filter-flow-release-start-version", mainScript)
+
+	if _, err := testutil.RunGit(t, worktreePath, "config", "gitflow.path.hooks", ".githooks"); err != nil {
+		t.Fatalf("Failed to set gitflow.path.hooks: %v", err)
+	}
+
+	result, err := hooks.RunVersionFilter(repo, "release", "1.0.0")
+	if err != nil {
+		t.Fatalf("RunVersionFilter failed: %v", err)
+	}
+	if result != "v1.0.0" {
+		t.Errorf("Expected worktree filter output 'v1.0.0', got %q", result)
+	}
+
+	content, err := os.ReadFile(wtMarker)
+	if err != nil {
+		t.Fatalf("Worktree filter did not run — marker missing: %v", err)
+	}
+	got := evalSymlinks(t, strings.TrimSpace(string(content)))
+	want := evalSymlinks(t, repo.WorkTree())
+	if got != want {
+		t.Errorf("Filter ran in %q, want active worktree root %q", got, want)
+	}
+	if _, err := os.Stat(mainMarker); !os.IsNotExist(err) {
+		t.Errorf("Main-checkout control filter ran (marker %q exists), expected it not to", mainMarker)
+	}
+}
+
+// TestTagMessageFilterRelativePathResolvesInWorktree (Scenario 7) is the
+// tag-message-filter analogue of Scenario 6.
+func TestTagMessageFilterRelativePathResolvesInWorktree(t *testing.T) {
+	t.Parallel()
+	mainRepo, worktreePath, repo := setupWorktree(t, "wt-tagfilter")
+
+	wtMarker := filepath.Join(worktreePath, "tf-marker.txt")
+	mainMarker := filepath.Join(mainRepo, "tf-main-marker.txt")
+	wtScript := `#!/bin/sh
+pwd > "` + wtMarker + `"
+echo "Release $1 from worktree"
+`
+	mainScript := `#!/bin/sh
+pwd > "` + mainMarker + `"
+echo "MAIN $1"
+`
+	createExecutableScript2(t, filepath.Join(worktreePath, ".githooks"), "filter-flow-release-finish-tag-message", wtScript)
+	createExecutableScript2(t, filepath.Join(mainRepo, ".githooks"), "filter-flow-release-finish-tag-message", mainScript)
+
+	if _, err := testutil.RunGit(t, worktreePath, "config", "gitflow.path.hooks", ".githooks"); err != nil {
+		t.Fatalf("Failed to set gitflow.path.hooks: %v", err)
+	}
+
+	ctx := hooks.FilterContext{
+		BranchType: "release",
+		BranchName: "2.0.0",
+		Version:    "2.0.0",
+		TagMessage: "orig",
+		BaseBranch: "main",
+	}
+
+	result, err := hooks.RunTagMessageFilter(repo, "release", ctx)
+	if err != nil {
+		t.Fatalf("RunTagMessageFilter failed: %v", err)
+	}
+	if result != "Release 2.0.0 from worktree" {
+		t.Errorf("Expected worktree filter output 'Release 2.0.0 from worktree', got %q", result)
+	}
+
+	content, err := os.ReadFile(wtMarker)
+	if err != nil {
+		t.Fatalf("Worktree filter did not run — marker missing: %v", err)
+	}
+	got := evalSymlinks(t, strings.TrimSpace(string(content)))
+	want := evalSymlinks(t, repo.WorkTree())
+	if got != want {
+		t.Errorf("Filter ran in %q, want active worktree root %q", got, want)
+	}
+	if _, err := os.Stat(mainMarker); !os.IsNotExist(err) {
+		t.Errorf("Main-checkout control filter ran (marker %q exists), expected it not to", mainMarker)
 	}
 }

--- a/test/internal/hooks/hooks_test.go
+++ b/test/internal/hooks/hooks_test.go
@@ -12,15 +12,40 @@ import (
 	"github.com/gittower/git-flow-next/test/testutil"
 )
 
-// worktreeGitDir returns the absolute per-worktree git dir for path via a
-// git.Repo handle, replacing the old os.Chdir + `git rev-parse --git-dir` dance.
-func worktreeGitDir(t *testing.T, path string) string {
+// openRepo opens a git.Repo handle for dir, failing the test on error.
+func openRepo(t *testing.T, dir string) *git.Repo {
 	t.Helper()
-	repo, err := git.Open(path)
+	repo, err := git.Open(dir)
 	if err != nil {
-		t.Fatalf("git.Open(%q) failed: %v", path, err)
+		t.Fatalf("git.Open(%q) failed: %v", dir, err)
 	}
-	return repo.GitDir()
+	return repo
+}
+
+// setupWorktree creates a main repository plus a linked worktree on the given
+// branch and returns the main repo path, the worktree path, and a git.Repo
+// handle opened at the worktree. Cleanup is registered via t.Cleanup so it is
+// safe under t.Parallel().
+func setupWorktree(t *testing.T, branch string) (mainRepo, worktreePath string, repo *git.Repo) {
+	t.Helper()
+	mainRepo = testutil.SetupTestRepo(t)
+	t.Cleanup(func() { testutil.CleanupTestRepo(t, mainRepo) })
+
+	var err error
+	worktreePath, err = os.MkdirTemp("", "git-flow-worktree-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory for worktree: %v", err)
+	}
+	// Remove the directory so `git worktree add` can create it.
+	os.RemoveAll(worktreePath)
+	t.Cleanup(func() { os.RemoveAll(worktreePath) })
+
+	if _, err = testutil.RunGit(t, mainRepo, "worktree", "add", worktreePath, "-b", branch); err != nil {
+		t.Fatalf("Failed to create worktree: %v", err)
+	}
+
+	repo = openRepo(t, worktreePath)
+	return mainRepo, worktreePath, repo
 }
 
 // evalSymlinks normalizes a path so comparisons survive macOS's /var symlink.
@@ -73,7 +98,7 @@ exit 0
 `
 	createHookScript(t, dir, "pre-flow-feature-start", script)
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.HookContext{
 		BranchType: "feature",
 		BranchName: "my-feature",
@@ -82,7 +107,7 @@ exit 0
 		Origin:     "origin",
 	}
 
-	err := hooks.RunPreHook(gitDir, "feature", hooks.HookActionStart, ctx)
+	err := hooks.RunPreHook(repo, "feature", hooks.HookActionStart, ctx)
 	if err != nil {
 		t.Fatalf("RunPreHook failed unexpectedly: %v", err)
 	}
@@ -100,7 +125,7 @@ exit 1
 `
 	createHookScript(t, dir, "pre-flow-release-start", script)
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.HookContext{
 		BranchType: "release",
 		BranchName: "1.0.0",
@@ -110,7 +135,7 @@ exit 1
 		Version:    "1.0.0",
 	}
 
-	err := hooks.RunPreHook(gitDir, "release", hooks.HookActionStart, ctx)
+	err := hooks.RunPreHook(repo, "release", hooks.HookActionStart, ctx)
 	if err == nil {
 		t.Fatal("Expected error for failing pre-hook, got nil")
 	}
@@ -124,7 +149,7 @@ func TestPreHookNonExistent(t *testing.T) {
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.HookContext{
 		BranchType: "feature",
 		BranchName: "my-feature",
@@ -133,7 +158,7 @@ func TestPreHookNonExistent(t *testing.T) {
 		Origin:     "origin",
 	}
 
-	err := hooks.RunPreHook(gitDir, "feature", hooks.HookActionStart, ctx)
+	err := hooks.RunPreHook(repo, "feature", hooks.HookActionStart, ctx)
 	if err != nil {
 		t.Fatalf("Expected no error for non-existent hook, got: %v", err)
 	}
@@ -153,7 +178,7 @@ exit 1
 `
 	createNonExecutableHookScript(t, dir, "pre-flow-feature-start", script)
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.HookContext{
 		BranchType: "feature",
 		BranchName: "my-feature",
@@ -163,7 +188,7 @@ exit 1
 	}
 
 	// Should not error because script is not executable
-	err := hooks.RunPreHook(gitDir, "feature", hooks.HookActionStart, ctx)
+	err := hooks.RunPreHook(repo, "feature", hooks.HookActionStart, ctx)
 	if err != nil {
 		t.Fatalf("Expected no error for non-executable hook, got: %v", err)
 	}
@@ -180,7 +205,7 @@ echo "Post-hook: $BRANCH_TYPE/$BRANCH_NAME completed with exit code $EXIT_CODE"
 `
 	createHookScript(t, dir, "post-flow-feature-finish", script)
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.HookContext{
 		BranchType: "feature",
 		BranchName: "my-feature",
@@ -190,7 +215,7 @@ echo "Post-hook: $BRANCH_TYPE/$BRANCH_NAME completed with exit code $EXIT_CODE"
 		ExitCode:   0,
 	}
 
-	result := hooks.RunPostHook(gitDir, "feature", hooks.HookActionFinish, ctx)
+	result := hooks.RunPostHook(repo, "feature", hooks.HookActionFinish, ctx)
 	if !result.Executed {
 		t.Fatal("Expected post-hook to execute")
 	}
@@ -207,7 +232,7 @@ func TestPostHookNonExistent(t *testing.T) {
 	dir := testutil.SetupTestRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.HookContext{
 		BranchType: "feature",
 		BranchName: "my-feature",
@@ -217,7 +242,7 @@ func TestPostHookNonExistent(t *testing.T) {
 		ExitCode:   0,
 	}
 
-	result := hooks.RunPostHook(gitDir, "feature", hooks.HookActionFinish, ctx)
+	result := hooks.RunPostHook(repo, "feature", hooks.HookActionFinish, ctx)
 	if result.Executed {
 		t.Fatal("Expected Executed=false for non-existent hook")
 	}
@@ -234,7 +259,7 @@ exit 1
 `
 	createHookScript(t, dir, "post-flow-feature-finish", script)
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.HookContext{
 		BranchType: "feature",
 		BranchName: "my-feature",
@@ -244,7 +269,7 @@ exit 1
 		ExitCode:   0,
 	}
 
-	result := hooks.RunPostHook(gitDir, "feature", hooks.HookActionFinish, ctx)
+	result := hooks.RunPostHook(repo, "feature", hooks.HookActionFinish, ctx)
 	if !result.Executed {
 		t.Fatal("Expected post-hook to execute")
 	}
@@ -277,7 +302,7 @@ echo "post-$EXIT_CODE" >> "` + markerFile + `"
 `
 	createHookScript(t, dir, "post-flow-feature-start", postScript)
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.HookContext{
 		BranchType: "feature",
 		BranchName: "my-feature",
@@ -287,7 +312,7 @@ echo "post-$EXIT_CODE" >> "` + markerFile + `"
 	}
 
 	operationRan := false
-	err := hooks.WithHooks(gitDir, "feature", hooks.HookActionStart, ctx, func() error {
+	err := hooks.WithHooks(repo, "feature", hooks.HookActionStart, ctx, func() error {
 		operationRan = true
 		return nil
 	})
@@ -329,7 +354,7 @@ exit 1
 `
 	createHookScript(t, dir, "pre-flow-release-start", preScript)
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.HookContext{
 		BranchType: "release",
 		BranchName: "1.0.0",
@@ -340,7 +365,7 @@ exit 1
 	}
 
 	operationRan := false
-	err := hooks.WithHooks(gitDir, "release", hooks.HookActionStart, ctx, func() error {
+	err := hooks.WithHooks(repo, "release", hooks.HookActionStart, ctx, func() error {
 		operationRan = true
 		return nil
 	})
@@ -369,7 +394,7 @@ echo "VERSION=$VERSION"
 `
 	createHookScript(t, dir, "pre-flow-release-start", script)
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.HookContext{
 		BranchType: "release",
 		BranchName: "2.0.0",
@@ -379,7 +404,7 @@ echo "VERSION=$VERSION"
 		Version:    "2.0.0",
 	}
 
-	err := hooks.RunPreHook(gitDir, "release", hooks.HookActionStart, ctx)
+	err := hooks.RunPreHook(repo, "release", hooks.HookActionStart, ctx)
 	if err != nil {
 		t.Fatalf("RunPreHook failed: %v", err)
 	}
@@ -407,7 +432,7 @@ exit 0
 `
 			createHookScript(t, dir, hookName, script)
 
-			gitDir := filepath.Join(dir, ".git")
+			repo := openRepo(t, dir)
 			ctx := hooks.HookContext{
 				BranchType: "feature",
 				BranchName: "test",
@@ -416,7 +441,7 @@ exit 0
 				Origin:     "origin",
 			}
 
-			err := hooks.RunPreHook(gitDir, "feature", action, ctx)
+			err := hooks.RunPreHook(repo, "feature", action, ctx)
 			if err != nil {
 				t.Errorf("RunPreHook failed for action %s: %v", action, err)
 			}
@@ -462,15 +487,18 @@ exit 0
 `
 	createHookScript(t, mainRepo, "pre-flow-feature-start", script)
 
-	// Get the worktree's absolute git directory via a git.Repo handle.
-	wtGitDir := worktreeGitDir(t, worktreePath)
-
-	// The worktree git dir should contain "worktrees" in the path
-	if !strings.Contains(wtGitDir, "worktrees") {
-		t.Errorf("Expected worktree git dir to contain 'worktrees', got: %s", wtGitDir)
+	// Open a git.Repo handle for the worktree.
+	repo, err := git.Open(worktreePath)
+	if err != nil {
+		t.Fatalf("git.Open failed: %v", err)
 	}
 
-	// Run the pre-hook using the worktree's git directory
+	// The worktree git dir should contain "worktrees" in the path
+	if !strings.Contains(repo.GitDir(), "worktrees") {
+		t.Errorf("Expected worktree git dir to contain 'worktrees', got: %s", repo.GitDir())
+	}
+
+	// Run the pre-hook using the worktree repo handle
 	ctx := hooks.HookContext{
 		BranchType: "feature",
 		BranchName: "test-worktree-feature",
@@ -479,7 +507,7 @@ exit 0
 		Origin:     "origin",
 	}
 
-	err = hooks.RunPreHook(wtGitDir, "feature", hooks.HookActionStart, ctx)
+	err = hooks.RunPreHook(repo, "feature", hooks.HookActionStart, ctx)
 	if err != nil {
 		t.Fatalf("RunPreHook failed in worktree: %v", err)
 	}
@@ -516,8 +544,11 @@ exit 0
 `
 	createHookScript(t, mainRepo, "post-flow-feature-finish", script)
 
-	// Get the worktree's absolute git directory via a git.Repo handle.
-	wtGitDir := worktreeGitDir(t, worktreePath)
+	// Open a git.Repo handle for the worktree.
+	repo, err := git.Open(worktreePath)
+	if err != nil {
+		t.Fatalf("git.Open failed: %v", err)
+	}
 
 	ctx := hooks.HookContext{
 		BranchType: "feature",
@@ -528,7 +559,7 @@ exit 0
 		ExitCode:   0,
 	}
 
-	result := hooks.RunPostHook(wtGitDir, "feature", hooks.HookActionFinish, ctx)
+	result := hooks.RunPostHook(repo, "feature", hooks.HookActionFinish, ctx)
 	if !result.Executed {
 		t.Error("Expected post-hook to execute in worktree")
 	}
@@ -692,7 +723,7 @@ echo "ARG4=$4"
 `
 	createHookScript(t, dir, "pre-flow-feature-start", script)
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.HookContext{
 		BranchType: "feature",
 		BranchName: "test-feature",
@@ -702,7 +733,7 @@ echo "ARG4=$4"
 	}
 
 	// Run hook and check it doesn't fail (arguments are passed correctly)
-	err := hooks.RunPreHook(gitDir, "feature", hooks.HookActionStart, ctx)
+	err := hooks.RunPreHook(repo, "feature", hooks.HookActionStart, ctx)
 	if err != nil {
 		t.Fatalf("RunPreHook failed: %v", err)
 	}
@@ -744,7 +775,7 @@ exit 0
 `
 	createHookScript(t, dir, "pre-flow-feature-start", script)
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.HookContext{
 		BranchType: "feature",
 		BranchName: "consistency-test",
@@ -753,7 +784,7 @@ exit 0
 		Origin:     "origin",
 	}
 
-	err := hooks.RunPreHook(gitDir, "feature", hooks.HookActionStart, ctx)
+	err := hooks.RunPreHook(repo, "feature", hooks.HookActionStart, ctx)
 	if err != nil {
 		t.Fatalf("Hook failed - positional args don't match env vars: %v", err)
 	}
@@ -775,7 +806,7 @@ exit 0
 `
 	createHookScript(t, dir, "pre-flow-feature-finish", script)
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.HookContext{
 		BranchType: "feature",
 		BranchName: "my-feature",
@@ -784,7 +815,7 @@ exit 0
 		Origin:     "origin",
 	}
 
-	err := hooks.RunPreHook(gitDir, "feature", hooks.HookActionFinish, ctx)
+	err := hooks.RunPreHook(repo, "feature", hooks.HookActionFinish, ctx)
 	if err != nil {
 		t.Fatalf("Finish hook failed: %v", err)
 	}
@@ -806,7 +837,7 @@ exit 0
 `
 	createHookScript(t, dir, "pre-flow-release-start", script)
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.HookContext{
 		BranchType: "release",
 		BranchName: "1.0.0",
@@ -816,7 +847,7 @@ exit 0
 		Version:    "1.0.0",
 	}
 
-	err := hooks.RunPreHook(gitDir, "release", hooks.HookActionStart, ctx)
+	err := hooks.RunPreHook(repo, "release", hooks.HookActionStart, ctx)
 	if err != nil {
 		t.Fatalf("Start hook failed: %v", err)
 	}
@@ -850,7 +881,7 @@ exit 0
 		Origin:     "origin",
 	}
 
-	if err := hooks.RunPreHook(repo.GitDir(), "feature", hooks.HookActionStart, ctx); err != nil {
+	if err := hooks.RunPreHook(repo, "feature", hooks.HookActionStart, ctx); err != nil {
 		t.Fatalf("RunPreHook failed: %v", err)
 	}
 
@@ -892,7 +923,7 @@ exit 0
 		ExitCode:   0,
 	}
 
-	result := hooks.RunPostHook(repo.GitDir(), "feature", hooks.HookActionFinish, ctx)
+	result := hooks.RunPostHook(repo, "feature", hooks.HookActionFinish, ctx)
 	if !result.Executed {
 		t.Fatal("Expected post-hook to execute")
 	}
@@ -937,7 +968,7 @@ exit 0
 `
 	createHookScript(t, dir, "pre-flow-feature-start", script)
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.HookContext{
 		BranchType: "feature",
 		BranchName: "test",
@@ -946,7 +977,7 @@ exit 0
 		Origin:     "origin",
 	}
 
-	err := hooks.RunPreHook(gitDir, "feature", hooks.HookActionStart, ctx)
+	err := hooks.RunPreHook(repo, "feature", hooks.HookActionStart, ctx)
 	if err != nil {
 		t.Fatalf("RunPreHook failed: %v", err)
 	}
@@ -988,7 +1019,7 @@ exit 0
 		t.Fatalf("Failed to set gitflow.path.hooks: %v", err)
 	}
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.HookContext{
 		BranchType: "feature",
 		BranchName: "test",
@@ -997,7 +1028,7 @@ exit 0
 		Origin:     "origin",
 	}
 
-	err = hooks.RunPreHook(gitDir, "feature", hooks.HookActionStart, ctx)
+	err = hooks.RunPreHook(repo, "feature", hooks.HookActionStart, ctx)
 	if err != nil {
 		t.Fatalf("RunPreHook failed: %v", err)
 	}
@@ -1034,7 +1065,7 @@ exit 0
 		t.Fatalf("Failed to set gitflow.path.hooks: %v", err)
 	}
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.HookContext{
 		BranchType: "feature",
 		BranchName: "test",
@@ -1043,7 +1074,7 @@ exit 0
 		Origin:     "origin",
 	}
 
-	err = hooks.RunPreHook(gitDir, "feature", hooks.HookActionStart, ctx)
+	err = hooks.RunPreHook(repo, "feature", hooks.HookActionStart, ctx)
 	if err != nil {
 		t.Fatalf("RunPreHook failed: %v", err)
 	}
@@ -1085,7 +1116,7 @@ exit 0
 		t.Fatalf("Failed to set core.hooksPath: %v", err)
 	}
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.HookContext{
 		BranchType: "feature",
 		BranchName: "test",
@@ -1094,7 +1125,7 @@ exit 0
 		Origin:     "origin",
 	}
 
-	err = hooks.RunPreHook(gitDir, "feature", hooks.HookActionStart, ctx)
+	err = hooks.RunPreHook(repo, "feature", hooks.HookActionStart, ctx)
 	if err != nil {
 		t.Fatalf("RunPreHook failed: %v", err)
 	}
@@ -1131,7 +1162,7 @@ exit 0
 		t.Fatalf("Failed to set core.hooksPath: %v", err)
 	}
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.HookContext{
 		BranchType: "feature",
 		BranchName: "test",
@@ -1140,7 +1171,7 @@ exit 0
 		Origin:     "origin",
 	}
 
-	err = hooks.RunPreHook(gitDir, "feature", hooks.HookActionStart, ctx)
+	err = hooks.RunPreHook(repo, "feature", hooks.HookActionStart, ctx)
 	if err != nil {
 		t.Fatalf("RunPreHook failed: %v", err)
 	}
@@ -1198,7 +1229,7 @@ exit 0
 		t.Fatalf("Failed to set core.hooksPath: %v", err)
 	}
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.HookContext{
 		BranchType: "feature",
 		BranchName: "test",
@@ -1207,7 +1238,7 @@ exit 0
 		Origin:     "origin",
 	}
 
-	err = hooks.RunPreHook(gitDir, "feature", hooks.HookActionStart, ctx)
+	err = hooks.RunPreHook(repo, "feature", hooks.HookActionStart, ctx)
 	if err != nil {
 		t.Fatalf("RunPreHook failed: %v", err)
 	}
@@ -1249,7 +1280,7 @@ exit 0
 		t.Fatalf("Failed to set core.hooksPath: %v", err)
 	}
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.HookContext{
 		BranchType: "release",
 		BranchName: "1.0.0",
@@ -1259,7 +1290,7 @@ exit 0
 		Version:    "1.0.0",
 	}
 
-	err = hooks.RunPreHook(gitDir, "release", hooks.HookActionStart, ctx)
+	err = hooks.RunPreHook(repo, "release", hooks.HookActionStart, ctx)
 	if err != nil {
 		t.Fatalf("RunPreHook failed: %v", err)
 	}
@@ -1301,7 +1332,7 @@ echo "BRANCH=$BRANCH EXIT_CODE=$EXIT_CODE" > "` + markerFile + `"
 		t.Fatalf("Failed to set gitflow.path.hooks: %v", err)
 	}
 
-	gitDir := filepath.Join(dir, ".git")
+	repo := openRepo(t, dir)
 	ctx := hooks.HookContext{
 		BranchType: "feature",
 		BranchName: "my-feature",
@@ -1311,7 +1342,7 @@ echo "BRANCH=$BRANCH EXIT_CODE=$EXIT_CODE" > "` + markerFile + `"
 		ExitCode:   0,
 	}
 
-	result := hooks.RunPostHook(gitDir, "feature", hooks.HookActionFinish, ctx)
+	result := hooks.RunPostHook(repo, "feature", hooks.HookActionFinish, ctx)
 	if !result.Executed {
 		t.Fatal("Expected post-hook to execute from gitflow.path.hooks")
 	}
@@ -1353,8 +1384,8 @@ echo "v${VERSION}"
 		t.Fatalf("Failed to set gitflow.path.hooks: %v", err)
 	}
 
-	gitDir := filepath.Join(dir, ".git")
-	result, err := hooks.RunVersionFilter(gitDir, "release", "1.0.0")
+	repo := openRepo(t, dir)
+	result, err := hooks.RunVersionFilter(repo, "release", "1.0.0")
 	if err != nil {
 		t.Fatalf("RunVersionFilter failed: %v", err)
 	}
@@ -1398,8 +1429,11 @@ echo "post-$EXIT_CODE" >> "` + markerFile + `"
 `
 	createHookScript(t, mainRepo, "post-flow-release-start", postScript)
 
-	// Get worktree git directory via a git.Repo handle.
-	wtGitDir := worktreeGitDir(t, worktreePath)
+	// Open a git.Repo handle for the worktree.
+	repo, err := git.Open(worktreePath)
+	if err != nil {
+		t.Fatalf("git.Open failed: %v", err)
+	}
 
 	ctx := hooks.HookContext{
 		BranchType: "release",
@@ -1411,7 +1445,7 @@ echo "post-$EXIT_CODE" >> "` + markerFile + `"
 	}
 
 	operationRan := false
-	err = hooks.WithHooks(wtGitDir, "release", hooks.HookActionStart, ctx, func() error {
+	err = hooks.WithHooks(repo, "release", hooks.HookActionStart, ctx, func() error {
 		operationRan = true
 		return nil
 	})
@@ -1438,5 +1472,229 @@ echo "post-$EXIT_CODE" >> "` + markerFile + `"
 	}
 	if lines[1] != "post-0" {
 		t.Errorf("Expected second line to be 'post-0', got '%s'", lines[1])
+	}
+}
+
+// TestPreHookDefaultLocationRunsInWorktreeCwd (Scenario 1) verifies that a
+// default-location hook (in the shared common .git/hooks) runs with its working
+// directory set to the active worktree root, not the git-internal
+// worktrees/<name> parent that filepath.Dir(repo.GitDir()) used to yield.
+func TestPreHookDefaultLocationRunsInWorktreeCwd(t *testing.T) {
+	t.Parallel()
+	mainRepo, worktreePath, repo := setupWorktree(t, "wt-prehook-default")
+
+	markerFile := filepath.Join(worktreePath, "marker.txt")
+	script := `#!/bin/sh
+pwd > "` + markerFile + `"
+exit 0
+`
+	// Shared common hooks location (main repo's .git/hooks).
+	createHookScript(t, mainRepo, "pre-flow-feature-start", script)
+
+	ctx := hooks.HookContext{
+		BranchType: "feature",
+		BranchName: "test",
+		FullBranch: "feature/test",
+		BaseBranch: "develop",
+		Origin:     "origin",
+	}
+
+	if err := hooks.RunPreHook(repo, "feature", hooks.HookActionStart, ctx); err != nil {
+		t.Fatalf("RunPreHook failed: %v", err)
+	}
+
+	content, err := os.ReadFile(markerFile)
+	if err != nil {
+		t.Fatalf("Hook did not run — marker missing: %v", err)
+	}
+	got := evalSymlinks(t, strings.TrimSpace(string(content)))
+	want := evalSymlinks(t, repo.WorkTree())
+	if got != want {
+		t.Errorf("Pre-hook ran in %q, want active worktree root %q", got, want)
+	}
+}
+
+// TestPreHookRelativeGitflowPathHooksResolvesInWorktree (Scenario 2) verifies
+// that a relative gitflow.path.hooks resolves against the active worktree root,
+// so the worktree hook runs and the main-checkout control hook does not.
+func TestPreHookRelativeGitflowPathHooksResolvesInWorktree(t *testing.T) {
+	t.Parallel()
+	mainRepo, worktreePath, repo := setupWorktree(t, "wt-prehook-gitflowpath")
+
+	wtMarker := filepath.Join(worktreePath, "wt-marker.txt")
+	mainMarker := filepath.Join(mainRepo, "main-marker.txt")
+	wtScript := `#!/bin/sh
+pwd > "` + wtMarker + `"
+exit 0
+`
+	mainScript := `#!/bin/sh
+pwd > "` + mainMarker + `"
+exit 0
+`
+	createHookScriptInDir(t, filepath.Join(worktreePath, ".githooks"), "pre-flow-feature-start", wtScript)
+	createHookScriptInDir(t, filepath.Join(mainRepo, ".githooks"), "pre-flow-feature-start", mainScript)
+
+	if _, err := testutil.RunGit(t, worktreePath, "config", "gitflow.path.hooks", ".githooks"); err != nil {
+		t.Fatalf("Failed to set gitflow.path.hooks: %v", err)
+	}
+
+	ctx := hooks.HookContext{
+		BranchType: "feature",
+		BranchName: "test",
+		FullBranch: "feature/test",
+		BaseBranch: "develop",
+		Origin:     "origin",
+	}
+
+	if err := hooks.RunPreHook(repo, "feature", hooks.HookActionStart, ctx); err != nil {
+		t.Fatalf("RunPreHook failed: %v", err)
+	}
+
+	content, err := os.ReadFile(wtMarker)
+	if err != nil {
+		t.Fatalf("Worktree hook did not run — marker missing: %v", err)
+	}
+	got := evalSymlinks(t, strings.TrimSpace(string(content)))
+	want := evalSymlinks(t, repo.WorkTree())
+	if got != want {
+		t.Errorf("Pre-hook ran in %q, want active worktree root %q", got, want)
+	}
+	if _, err := os.Stat(mainMarker); !os.IsNotExist(err) {
+		t.Errorf("Main-checkout control hook ran (marker %q exists), expected it not to", mainMarker)
+	}
+}
+
+// TestPreHookRelativeCoreHooksPathResolvesInWorktree (Scenario 3) is the
+// core.hooksPath analogue of Scenario 2.
+func TestPreHookRelativeCoreHooksPathResolvesInWorktree(t *testing.T) {
+	t.Parallel()
+	mainRepo, worktreePath, repo := setupWorktree(t, "wt-prehook-corehookspath")
+
+	wtMarker := filepath.Join(worktreePath, "wt-marker.txt")
+	mainMarker := filepath.Join(mainRepo, "main-marker.txt")
+	wtScript := `#!/bin/sh
+pwd > "` + wtMarker + `"
+exit 0
+`
+	mainScript := `#!/bin/sh
+pwd > "` + mainMarker + `"
+exit 0
+`
+	createHookScriptInDir(t, filepath.Join(worktreePath, ".githooks"), "pre-flow-feature-start", wtScript)
+	createHookScriptInDir(t, filepath.Join(mainRepo, ".githooks"), "pre-flow-feature-start", mainScript)
+
+	if _, err := testutil.RunGit(t, worktreePath, "config", "core.hooksPath", ".githooks"); err != nil {
+		t.Fatalf("Failed to set core.hooksPath: %v", err)
+	}
+
+	ctx := hooks.HookContext{
+		BranchType: "feature",
+		BranchName: "test",
+		FullBranch: "feature/test",
+		BaseBranch: "develop",
+		Origin:     "origin",
+	}
+
+	if err := hooks.RunPreHook(repo, "feature", hooks.HookActionStart, ctx); err != nil {
+		t.Fatalf("RunPreHook failed: %v", err)
+	}
+
+	content, err := os.ReadFile(wtMarker)
+	if err != nil {
+		t.Fatalf("Worktree hook did not run — marker missing: %v", err)
+	}
+	got := evalSymlinks(t, strings.TrimSpace(string(content)))
+	want := evalSymlinks(t, repo.WorkTree())
+	if got != want {
+		t.Errorf("Pre-hook ran in %q, want active worktree root %q", got, want)
+	}
+	if _, err := os.Stat(mainMarker); !os.IsNotExist(err) {
+		t.Errorf("Main-checkout control hook ran (marker %q exists), expected it not to", mainMarker)
+	}
+}
+
+// TestPostHookDefaultLocationRunsInWorktreeCwd (Scenario 4) confirms the fix
+// threads through the post-hook path: a default-location post-hook runs with its
+// working directory set to the active worktree root.
+func TestPostHookDefaultLocationRunsInWorktreeCwd(t *testing.T) {
+	t.Parallel()
+	mainRepo, worktreePath, repo := setupWorktree(t, "wt-posthook-default")
+
+	markerFile := filepath.Join(worktreePath, "post-marker.txt")
+	script := `#!/bin/sh
+pwd > "` + markerFile + `"
+exit 0
+`
+	createHookScript(t, mainRepo, "post-flow-feature-finish", script)
+
+	ctx := hooks.HookContext{
+		BranchType: "feature",
+		BranchName: "test",
+		FullBranch: "feature/test",
+		BaseBranch: "develop",
+		Origin:     "origin",
+		ExitCode:   0,
+	}
+
+	result := hooks.RunPostHook(repo, "feature", hooks.HookActionFinish, ctx)
+	if !result.Executed {
+		t.Fatal("Expected post-hook to execute")
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("Expected exit code 0, got %d", result.ExitCode)
+	}
+
+	content, err := os.ReadFile(markerFile)
+	if err != nil {
+		t.Fatalf("Hook did not run — marker missing: %v", err)
+	}
+	got := evalSymlinks(t, strings.TrimSpace(string(content)))
+	want := evalSymlinks(t, repo.WorkTree())
+	if got != want {
+		t.Errorf("Post-hook ran in %q, want active worktree root %q", got, want)
+	}
+}
+
+// TestPreHookRelativeGitflowPathHooksInPlainRepo (Scenario 5) is the regression
+// guard: in a plain (non-worktree) repo a relative gitflow.path.hooks resolves
+// against the checkout root, which equals the worktree root, so behavior is
+// unchanged.
+func TestPreHookRelativeGitflowPathHooksInPlainRepo(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	markerFile := filepath.Join(dir, "plain-marker.txt")
+	script := `#!/bin/sh
+pwd > "` + markerFile + `"
+exit 0
+`
+	createHookScriptInDir(t, filepath.Join(dir, ".githooks"), "pre-flow-feature-start", script)
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.path.hooks", ".githooks"); err != nil {
+		t.Fatalf("Failed to set gitflow.path.hooks: %v", err)
+	}
+
+	repo := openRepo(t, dir)
+	ctx := hooks.HookContext{
+		BranchType: "feature",
+		BranchName: "test",
+		FullBranch: "feature/test",
+		BaseBranch: "develop",
+		Origin:     "origin",
+	}
+
+	if err := hooks.RunPreHook(repo, "feature", hooks.HookActionStart, ctx); err != nil {
+		t.Fatalf("RunPreHook failed: %v", err)
+	}
+
+	content, err := os.ReadFile(markerFile)
+	if err != nil {
+		t.Fatalf("Hook did not run — marker missing: %v", err)
+	}
+	got := evalSymlinks(t, strings.TrimSpace(string(content)))
+	want := evalSymlinks(t, repo.WorkTree())
+	if got != want {
+		t.Errorf("Pre-hook ran in %q, want repo root %q", got, want)
 	}
 }

--- a/test/internal/hooks/hooks_test.go
+++ b/test/internal/hooks/hooks_test.go
@@ -37,8 +37,14 @@ func setupWorktree(t *testing.T, branch string) (mainRepo, worktreePath string, 
 		t.Fatalf("Failed to create temp directory for worktree: %v", err)
 	}
 	// Remove the directory so `git worktree add` can create it.
-	os.RemoveAll(worktreePath)
-	t.Cleanup(func() { os.RemoveAll(worktreePath) })
+	if err = os.RemoveAll(worktreePath); err != nil {
+		t.Fatalf("Failed to clear worktree path %q: %v", worktreePath, err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(worktreePath); err != nil {
+			t.Errorf("Failed to cleanup worktree %q: %v", worktreePath, err)
+		}
+	})
 
 	if _, err = testutil.RunGit(t, mainRepo, "worktree", "add", worktreePath, "-b", branch); err != nil {
 		t.Fatalf("Failed to create worktree: %v", err)


### PR DESCRIPTION
Resolves hooks and filters against the active worktree so linked worktrees discover and run them from their own checkout instead of the main one.

Inside a linked worktree, hook and filter discovery derived its root from the common git dir, so a relative `gitflow.path.hooks` / `core.hooksPath` and the config lookup resolved against the main checkout, and each hook/filter process ran with its working directory set to a git-internal path (`.git/worktrees`) rather than a checkout. This threads the active worktree root (`Repo.WorkTree()`) and the common git dir (`Repo.CommonGitDir()`) through the hook and filter runners: relative paths and the config lookup now resolve against the worktree root, `cmd.Dir` is the worktree root, and default `.git/hooks` discovery stays anchored to the common git dir, which linked worktrees legitimately share. The public entry points (`RunPreHook`, `RunPostHook`, `WithHooks`, `RunVersionFilter`, `RunTagMessageFilter`) now take a `*git.Repo`, the string-parsing `getCommonGitDir` heuristic is retired, and all six `cmd/*.go` call sites pass the already-open repo. Changes touch `internal/hooks/hooks.go`, `internal/hooks/filters.go`, and the finish/start/update/delete/track/publish commands.

Resolves #145

## Remarks

- Absolute `gitflow.path.hooks` / `core.hooksPath` and non-worktree repos are unchanged; only the resolution base for relative paths and the process working directory move to the active worktree.
- The three-level precedence (`gitflow.path.hooks` → `core.hooksPath` → default) is preserved.
- Adds seven worktree scenarios across `hooks_test.go` and `filters_test.go` covering default-location, relative `gitflow.path.hooks` and `core.hooksPath`, post-hook parity, version and tag-message filters, and a plain-repo regression guard, each with a main-checkout negative control and a `pwd`-marker cwd assertion.

**Review focus:**
- `internal/hooks/hooks.go` - `getHooksDir` signature and the worktree-root vs common-git-dir split
- `internal/hooks/filters.go` - `RunVersionFilter` / `RunTagMessageFilter` now running from the worktree root