### PR TITLE
fix(config): Roll back failed base additions

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -457,6 +457,9 @@ func executeConfigAddBase(repo *git.Repo, name, parent, upstreamStrategy, downst
 	if err := repo.BranchExists(name); err != nil {
 		// Branch doesn't exist, create it
 		if err := repo.CreateBranch(name, parent); err != nil {
+			if rollbackErr := repo.UnsetConfigSection(fmt.Sprintf("gitflow.branch.%s", name)); rollbackErr != nil {
+				err = fmt.Errorf("%w; failed to roll back configuration: %w", err, rollbackErr)
+			}
 			return &errors.GitError{Operation: fmt.Sprintf("create branch '%s'", name), Err: err}
 		}
 		fmt.Printf("✓ Created branch '%s'\n", name)

--- a/docs/git-flow-config.1.md
+++ b/docs/git-flow-config.1.md
@@ -28,7 +28,7 @@ Branch names are matched **case-insensitively**. The case used when a branch is 
 ### Adding Configuration
 
 **add base** *name* [*parent*] [*options*]
-: Add a base branch configuration. Creates the Git branch immediately if it doesn't exist.
+: Add a base branch configuration. Creates the Git branch immediately if it doesn't exist. If branch creation fails, the new configuration is removed.
 
 **add topic** *name* *parent* [*options*]  
 : Add a topic branch type configuration. Saves configuration for use with start command.

--- a/test/cmd/config_test.go
+++ b/test/cmd/config_test.go
@@ -1335,6 +1335,115 @@ func TestConfigEditTopicStartingPointResolvesCaseInsensitively(t *testing.T) {
 	assertNoLineContains(t, cfg, "gitflow.branch.v9_release.", "edit topic starting point")
 }
 
+func setupConfigAddBaseMissingParentRef(t *testing.T) string {
+	t.Helper()
+	tempDir := testutil.SetupTestRepo(t)
+	t.Cleanup(func() { testutil.CleanupTestRepo(t, tempDir) })
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+	if _, err := testutil.RunGit(t, tempDir, "checkout", "main"); err != nil {
+		t.Fatalf("Failed to check out main: %v", err)
+	}
+	if _, err := testutil.RunGit(t, tempDir, "branch", "-D", "develop"); err != nil {
+		t.Fatalf("Failed to delete develop: %v", err)
+	}
+
+	return tempDir
+}
+
+// TestConfigAddBaseRollsBackConfigWhenBranchCreationFails tests that a failed
+// branch creation removes the saved base configuration.
+// Steps:
+// 1. Initializes git-flow and removes the configured develop ref
+// 2. Attempts to add qa with the missing develop ref
+// 3. Verifies branch creation fails and the qa configuration is absent
+// 4. Verifies config list does not show qa
+func TestConfigAddBaseRollsBackConfigWhenBranchCreationFails(t *testing.T) {
+	t.Parallel()
+	tempDir := setupConfigAddBaseMissingParentRef(t)
+
+	output, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "qa", "develop")
+	if err == nil {
+		t.Fatalf("Expected branch creation to fail, got success\nOutput: %s", output)
+	}
+	if !strings.Contains(output, "create branch 'qa'") {
+		t.Errorf("Expected branch creation error, got:\n%s", output)
+	}
+
+	cfg := gitflowBranchConfig(t, tempDir)
+	assertNoLineContains(t, cfg, "gitflow.branch.qa.", "failed add rollback")
+
+	listOutput, err := testutil.RunGitFlow(t, tempDir, "config", "list")
+	if err != nil {
+		t.Fatalf("Expected config list to succeed, got error: %v\nOutput: %s", err, listOutput)
+	}
+	assertNoLineContains(t, listOutput, "  qa ", "failed add rollback")
+}
+
+// TestConfigAddBaseCanRetryAfterBranchCreationFails tests that a failed base
+// addition can be retried after restoring the missing parent ref.
+// Steps:
+// 1. Initializes git-flow with the configured develop ref removed
+// 2. Verifies adding qa fails while develop is missing
+// 3. Restores develop and retries the add
+// 4. Verifies the qa configuration and ref are created
+func TestConfigAddBaseCanRetryAfterBranchCreationFails(t *testing.T) {
+	t.Parallel()
+	tempDir := setupConfigAddBaseMissingParentRef(t)
+
+	if output, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "qa", "develop"); err == nil {
+		t.Fatalf("Expected initial branch creation to fail, got success\nOutput: %s", output)
+	}
+	if _, err := testutil.RunGit(t, tempDir, "branch", "develop", "main"); err != nil {
+		t.Fatalf("Failed to recreate develop: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "qa", "develop")
+	if err != nil {
+		t.Fatalf("Expected retry to succeed, got error: %v\nOutput: %s", err, output)
+	}
+
+	cfg := gitflowBranchConfig(t, tempDir)
+	assertContainsLine(t, cfg, "gitflow.branch.qa.type base", "retry after failed add")
+	assertContainsLine(t, cfg, "gitflow.branch.qa.parent develop", "retry after failed add")
+	if !refExists(t, tempDir, "qa") {
+		t.Error("Expected refs/heads/qa to exist after retry")
+	}
+}
+
+// TestConfigAddBaseUsesExistingRef tests that an existing branch bypasses
+// branch creation while saving the base configuration.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Creates a plain qa branch from main
+// 3. Adds qa as a base branch with main as its parent
+// 4. Verifies no branch is created and the base configuration is saved
+func TestConfigAddBaseUsesExistingRef(t *testing.T) {
+	t.Parallel()
+	tempDir := testutil.SetupTestRepo(t)
+	t.Cleanup(func() { testutil.CleanupTestRepo(t, tempDir) })
+
+	if _, err := testutil.RunGitFlow(t, tempDir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+	if _, err := testutil.RunGit(t, tempDir, "branch", "qa", "main"); err != nil {
+		t.Fatalf("Failed to create qa branch: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, tempDir, "config", "add", "base", "qa", "main")
+	if err != nil {
+		t.Fatalf("Expected add with existing ref to succeed, got error: %v\nOutput: %s", err, output)
+	}
+	if strings.Contains(output, "Created branch 'qa'") {
+		t.Errorf("Expected existing qa ref to skip branch creation, got:\n%s", output)
+	}
+
+	cfg := gitflowBranchConfig(t, tempDir)
+	assertContainsLine(t, cfg, "gitflow.branch.qa.type base", "existing ref add")
+}
+
 // mustOpenRepo opens a git.Repo handle for dir, failing the test on error.
 func mustOpenRepo(t *testing.T, dir string) *git.Repo {
 	t.Helper()


### PR DESCRIPTION
Rolls back the saved branch config when `config add base` cannot create the Git branch, preventing orphaned base definitions.

The failed add now removes `gitflow.branch.<name>` before returning the existing branch-creation error. If rollback itself fails, both errors are preserved. Integration coverage verifies cleanup and a successful retry, and the config manpage documents the all-or-nothing behavior.

Resolves #130