### PR TITLE
feat(config): Add shared committable .gitflow config

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -249,6 +249,45 @@ git flow release finish v1.0 --tag  # Force tagging for this invocation
 
 Not every option spans all three layers. Layer 1 is reserved for essential branch-type properties — many command options exist only at Layer 2 and Layer 3. For example, `sign`, `keep`, and publish `push-options` are purely operational and have no Layer 1 equivalent.
 
+## Shared Configuration (.gitflow)
+
+By default git-flow configuration lives in `.git/config`, which is never committed, so every clone must run `git flow init`. A committable `.gitflow` file at the repository root lets a team share one configuration.
+
+git-flow does not read `.gitflow` directly during operations — it **copies** the `gitflow.*` keys into the clone's local `.git/config`, so every read site sees the shared values and native git precedence still applies.
+
+### Creating and using .gitflow
+
+```bash
+# Author .gitflow and copy it into local config, then commit it
+git flow init --defaults --shared
+git add .gitflow && git commit -m "Add shared git-flow configuration"
+
+# On a fresh clone, activate the committed configuration
+git flow init            # or set gitflow.shared.autoInit=true to activate automatically
+
+# Keep local config in step with .gitflow
+git flow config status   # exit 0 in sync, exit 6 on drift
+git flow config sync     # re-copy .gitflow into local config
+
+# Edit the shared file (and re-sync local) instead of local-only config
+git flow config edit topic feature --shared --prefix feat/
+git flow config add topic qa develop --shared
+```
+
+### Shared-managed keys and control keys
+
+The copy moves the whole `gitflow.*` namespace **except** the control keys `gitflow.shared.*` and per-branch runtime metadata `gitflow.branch.<branch>.base`. Keys outside `gitflow.*` (e.g. `core.*`, `alias.*`) are never copied, and multi-value keys keep their order.
+
+```bash
+# Activate a committed .gitflow automatically on your clones (read from global/local, never copied)
+git config --global gitflow.shared.autoInit true
+
+# Allow copying the executable hook path key from a trusted .gitflow
+git config gitflow.shared.trustHooks true
+```
+
+When `gitflow.shared.trustHooks` is unset, the `gitflow.path.hooks` key is not copied from `.gitflow` (and is removed from local on the next sync if it was previously copied); non-interactive auto-init refuses when an untrusted shared hook path is present. See `docs/gitflow-config.5.md` for the full first-run activation and hook-trust semantics.
+
 ## Legacy Compatibility
 
 ### Git-Flow-AVH Compatibility

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -263,7 +263,7 @@ git flow init --defaults --shared
 git add .gitflow && git commit -m "Add shared git-flow configuration"
 
 # On a fresh clone, activate the committed configuration
-git flow init            # or set gitflow.shared.autoInit=true to activate automatically
+git flow config sync     # or set gitflow.shared.autoInit=true to activate automatically
 
 # Keep local config in step with .gitflow
 git flow config status   # exit 0 in sync, exit 6 on drift

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -407,8 +407,14 @@ func persistConfig(repo *git.Repo, cfg *config.Config, shared bool) error {
 		if err := config.SaveConfigWithScope(cfg, git.ConfigScopeFile, config.SharedConfigPath(repo)); err != nil {
 			return err
 		}
-		if _, err := config.CopySharedToLocal(repo); err != nil {
+		result, err := config.CopySharedToLocal(repo)
+		if err != nil {
 			return err
+		}
+		// Mirror `config sync`: make the hook-trust filter visible so users editing
+		// shared config know a hook path was withheld from local until trusted.
+		for _, k := range result.SkippedHookKeys {
+			fmt.Fprintf(os.Stderr, "Warning: skipped shared hook path %q; set gitflow.shared.trustHooks=true to apply it.\n", k)
 		}
 		return nil
 	}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -428,13 +428,18 @@ func removeBranchSection(repo *git.Repo, shared bool, branchName string) error {
 }
 
 func executeConfigAddBase(repo *git.Repo, name, parent, upstreamStrategy, downstreamStrategy string, autoUpdate bool, shared bool) error {
-	// Validate that git-flow is initialized
-	initialized, err := config.IsInitialized(repo)
-	if err != nil {
-		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
-	}
-	if !initialized {
-		return &errors.NotInitializedError{}
+	// Validate that git-flow is initialized. Only gate LOCAL edits: for --shared
+	// the target is the .gitflow file (whose existence loadConfigForEdit enforces
+	// with the correct "run 'git flow init --shared'" suggestion), so a fresh
+	// clone with a .gitflow but no local init can still edit the shared file.
+	if !shared {
+		initialized, err := config.IsInitialized(repo)
+		if err != nil {
+			return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
+		}
+		if !initialized {
+			return &errors.NotInitializedError{}
+		}
 	}
 
 	// Validate branch name
@@ -516,13 +521,18 @@ func executeConfigAddBase(repo *git.Repo, name, parent, upstreamStrategy, downst
 }
 
 func executeConfigAddTopic(repo *git.Repo, name, parent, prefix, startingPoint, upstreamStrategy, downstreamStrategy string, tag bool, shared bool) error {
-	// Validate that git-flow is initialized
-	initialized, err := config.IsInitialized(repo)
-	if err != nil {
-		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
-	}
-	if !initialized {
-		return &errors.NotInitializedError{}
+	// Validate that git-flow is initialized. Only gate LOCAL edits: for --shared
+	// the target is the .gitflow file (whose existence loadConfigForEdit enforces
+	// with the correct "run 'git flow init --shared'" suggestion), so a fresh
+	// clone with a .gitflow but no local init can still edit the shared file.
+	if !shared {
+		initialized, err := config.IsInitialized(repo)
+		if err != nil {
+			return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
+		}
+		if !initialized {
+			return &errors.NotInitializedError{}
+		}
 	}
 
 	// Validate branch name
@@ -601,13 +611,18 @@ func executeConfigAddTopic(repo *git.Repo, name, parent, prefix, startingPoint, 
 }
 
 func executeConfigEditBase(repo *git.Repo, name, upstreamStrategy, downstreamStrategy string, autoUpdate bool, shared bool) error {
-	// Validate that git-flow is initialized
-	initialized, err := config.IsInitialized(repo)
-	if err != nil {
-		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
-	}
-	if !initialized {
-		return &errors.NotInitializedError{}
+	// Validate that git-flow is initialized. Only gate LOCAL edits: for --shared
+	// the target is the .gitflow file (whose existence loadConfigForEdit enforces
+	// with the correct "run 'git flow init --shared'" suggestion), so a fresh
+	// clone with a .gitflow but no local init can still edit the shared file.
+	if !shared {
+		initialized, err := config.IsInitialized(repo)
+		if err != nil {
+			return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
+		}
+		if !initialized {
+			return &errors.NotInitializedError{}
+		}
 	}
 
 	// Load current configuration
@@ -660,13 +675,18 @@ func executeConfigEditBase(repo *git.Repo, name, upstreamStrategy, downstreamStr
 }
 
 func executeConfigEditTopic(repo *git.Repo, name, prefix, startingPoint, upstreamStrategy, downstreamStrategy string, tag bool, shared bool) error {
-	// Validate that git-flow is initialized
-	initialized, err := config.IsInitialized(repo)
-	if err != nil {
-		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
-	}
-	if !initialized {
-		return &errors.NotInitializedError{}
+	// Validate that git-flow is initialized. Only gate LOCAL edits: for --shared
+	// the target is the .gitflow file (whose existence loadConfigForEdit enforces
+	// with the correct "run 'git flow init --shared'" suggestion), so a fresh
+	// clone with a .gitflow but no local init can still edit the shared file.
+	if !shared {
+		initialized, err := config.IsInitialized(repo)
+		if err != nil {
+			return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
+		}
+		if !initialized {
+			return &errors.NotInitializedError{}
+		}
 	}
 
 	// Load current configuration
@@ -730,13 +750,18 @@ func executeConfigEditTopic(repo *git.Repo, name, prefix, startingPoint, upstrea
 }
 
 func executeConfigRenameBase(repo *git.Repo, oldName, newName string, shared bool) error {
-	// Validate that git-flow is initialized
-	initialized, err := config.IsInitialized(repo)
-	if err != nil {
-		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
-	}
-	if !initialized {
-		return &errors.NotInitializedError{}
+	// Validate that git-flow is initialized. Only gate LOCAL edits: for --shared
+	// the target is the .gitflow file (whose existence loadConfigForEdit enforces
+	// with the correct "run 'git flow init --shared'" suggestion), so a fresh
+	// clone with a .gitflow but no local init can still edit the shared file.
+	if !shared {
+		initialized, err := config.IsInitialized(repo)
+		if err != nil {
+			return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
+		}
+		if !initialized {
+			return &errors.NotInitializedError{}
+		}
 	}
 
 	// Validate new branch name
@@ -818,13 +843,18 @@ func executeConfigRenameBase(repo *git.Repo, oldName, newName string, shared boo
 }
 
 func executeConfigRenameTopic(repo *git.Repo, oldName, newName string, shared bool) error {
-	// Validate that git-flow is initialized
-	initialized, err := config.IsInitialized(repo)
-	if err != nil {
-		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
-	}
-	if !initialized {
-		return &errors.NotInitializedError{}
+	// Validate that git-flow is initialized. Only gate LOCAL edits: for --shared
+	// the target is the .gitflow file (whose existence loadConfigForEdit enforces
+	// with the correct "run 'git flow init --shared'" suggestion), so a fresh
+	// clone with a .gitflow but no local init can still edit the shared file.
+	if !shared {
+		initialized, err := config.IsInitialized(repo)
+		if err != nil {
+			return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
+		}
+		if !initialized {
+			return &errors.NotInitializedError{}
+		}
 	}
 
 	// Validate new branch name
@@ -879,13 +909,18 @@ func executeConfigRenameTopic(repo *git.Repo, oldName, newName string, shared bo
 }
 
 func executeConfigDeleteBase(repo *git.Repo, name string, shared bool) error {
-	// Validate that git-flow is initialized
-	initialized, err := config.IsInitialized(repo)
-	if err != nil {
-		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
-	}
-	if !initialized {
-		return &errors.NotInitializedError{}
+	// Validate that git-flow is initialized. Only gate LOCAL edits: for --shared
+	// the target is the .gitflow file (whose existence loadConfigForEdit enforces
+	// with the correct "run 'git flow init --shared'" suggestion), so a fresh
+	// clone with a .gitflow but no local init can still edit the shared file.
+	if !shared {
+		initialized, err := config.IsInitialized(repo)
+		if err != nil {
+			return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
+		}
+		if !initialized {
+			return &errors.NotInitializedError{}
+		}
 	}
 
 	// Load current configuration
@@ -936,13 +971,18 @@ func executeConfigDeleteBase(repo *git.Repo, name string, shared bool) error {
 }
 
 func executeConfigDeleteTopic(repo *git.Repo, name string, shared bool) error {
-	// Validate that git-flow is initialized
-	initialized, err := config.IsInitialized(repo)
-	if err != nil {
-		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
-	}
-	if !initialized {
-		return &errors.NotInitializedError{}
+	// Validate that git-flow is initialized. Only gate LOCAL edits: for --shared
+	// the target is the .gitflow file (whose existence loadConfigForEdit enforces
+	// with the correct "run 'git flow init --shared'" suggestion), so a fresh
+	// clone with a .gitflow but no local init can still edit the shared file.
+	if !shared {
+		initialized, err := config.IsInitialized(repo)
+		if err != nil {
+			return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
+		}
+		if !initialized {
+			return &errors.NotInitializedError{}
+		}
 	}
 
 	// Load current configuration

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -62,7 +62,8 @@ Examples:
 		downstreamStrategy, _ := cmd.Flags().GetString("downstream-strategy")
 		autoUpdate, _ := cmd.Flags().GetBool("auto-update")
 
-		ConfigAddBaseCommand(name, parent, upstreamStrategy, downstreamStrategy, autoUpdate)
+		shared, _ := cmd.Flags().GetBool("shared")
+		ConfigAddBaseCommand(name, parent, upstreamStrategy, downstreamStrategy, autoUpdate, shared)
 	},
 }
 
@@ -89,7 +90,8 @@ Examples:
 		downstreamStrategy, _ := cmd.Flags().GetString("downstream-strategy")
 		tag, _ := cmd.Flags().GetBool("tag")
 
-		ConfigAddTopicCommand(name, parent, prefix, startingPoint, upstreamStrategy, downstreamStrategy, tag)
+		shared, _ := cmd.Flags().GetBool("shared")
+		ConfigAddTopicCommand(name, parent, prefix, startingPoint, upstreamStrategy, downstreamStrategy, tag, shared)
 	},
 }
 
@@ -115,7 +117,8 @@ Examples:
 		downstreamStrategy, _ := cmd.Flags().GetString("downstream-strategy")
 		autoUpdate, _ := cmd.Flags().GetBool("auto-update")
 
-		ConfigEditBaseCommand(name, upstreamStrategy, downstreamStrategy, autoUpdate)
+		shared, _ := cmd.Flags().GetBool("shared")
+		ConfigEditBaseCommand(name, upstreamStrategy, downstreamStrategy, autoUpdate, shared)
 	},
 }
 
@@ -137,7 +140,8 @@ Examples:
 		downstreamStrategy, _ := cmd.Flags().GetString("downstream-strategy")
 		tag, _ := cmd.Flags().GetBool("tag")
 
-		ConfigEditTopicCommand(name, prefix, startingPoint, upstreamStrategy, downstreamStrategy, tag)
+		shared, _ := cmd.Flags().GetBool("shared")
+		ConfigEditTopicCommand(name, prefix, startingPoint, upstreamStrategy, downstreamStrategy, tag, shared)
 	},
 }
 
@@ -162,7 +166,8 @@ Examples:
 		oldName := args[0]
 		newName := args[1]
 
-		ConfigRenameBaseCommand(oldName, newName)
+		shared, _ := cmd.Flags().GetBool("shared")
+		ConfigRenameBaseCommand(oldName, newName, shared)
 	},
 }
 
@@ -181,7 +186,8 @@ Examples:
 		oldName := args[0]
 		newName := args[1]
 
-		ConfigRenameTopicCommand(oldName, newName)
+		shared, _ := cmd.Flags().GetBool("shared")
+		ConfigRenameTopicCommand(oldName, newName, shared)
 	},
 }
 
@@ -206,7 +212,8 @@ Examples:
 	Run: func(cmd *cobra.Command, args []string) {
 		name := args[0]
 
-		ConfigDeleteBaseCommand(name)
+		shared, _ := cmd.Flags().GetBool("shared")
+		ConfigDeleteBaseCommand(name, shared)
 	},
 }
 
@@ -224,7 +231,8 @@ Examples:
 	Run: func(cmd *cobra.Command, args []string) {
 		name := args[0]
 
-		ConfigDeleteTopicCommand(name)
+		shared, _ := cmd.Flags().GetBool("shared")
+		ConfigDeleteTopicCommand(name, shared)
 	},
 }
 
@@ -244,9 +252,9 @@ Example:
 }
 
 // ConfigAddBaseCommand adds a base branch configuration
-func ConfigAddBaseCommand(name, parent, upstreamStrategy, downstreamStrategy string, autoUpdate bool) {
+func ConfigAddBaseCommand(name, parent, upstreamStrategy, downstreamStrategy string, autoUpdate bool, shared bool) {
 	repo := mustOpenRepo()
-	if err := executeConfigAddBase(repo, name, parent, upstreamStrategy, downstreamStrategy, autoUpdate); err != nil {
+	if err := executeConfigAddBase(repo, name, parent, upstreamStrategy, downstreamStrategy, autoUpdate, shared); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -259,9 +267,9 @@ func ConfigAddBaseCommand(name, parent, upstreamStrategy, downstreamStrategy str
 }
 
 // ConfigAddTopicCommand adds a topic branch type configuration
-func ConfigAddTopicCommand(name, parent, prefix, startingPoint, upstreamStrategy, downstreamStrategy string, tag bool) {
+func ConfigAddTopicCommand(name, parent, prefix, startingPoint, upstreamStrategy, downstreamStrategy string, tag bool, shared bool) {
 	repo := mustOpenRepo()
-	if err := executeConfigAddTopic(repo, name, parent, prefix, startingPoint, upstreamStrategy, downstreamStrategy, tag); err != nil {
+	if err := executeConfigAddTopic(repo, name, parent, prefix, startingPoint, upstreamStrategy, downstreamStrategy, tag, shared); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -274,9 +282,9 @@ func ConfigAddTopicCommand(name, parent, prefix, startingPoint, upstreamStrategy
 }
 
 // ConfigEditBaseCommand edits a base branch configuration
-func ConfigEditBaseCommand(name, upstreamStrategy, downstreamStrategy string, autoUpdate bool) {
+func ConfigEditBaseCommand(name, upstreamStrategy, downstreamStrategy string, autoUpdate bool, shared bool) {
 	repo := mustOpenRepo()
-	if err := executeConfigEditBase(repo, name, upstreamStrategy, downstreamStrategy, autoUpdate); err != nil {
+	if err := executeConfigEditBase(repo, name, upstreamStrategy, downstreamStrategy, autoUpdate, shared); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -289,9 +297,9 @@ func ConfigEditBaseCommand(name, upstreamStrategy, downstreamStrategy string, au
 }
 
 // ConfigEditTopicCommand edits a topic branch type configuration
-func ConfigEditTopicCommand(name, prefix, startingPoint, upstreamStrategy, downstreamStrategy string, tag bool) {
+func ConfigEditTopicCommand(name, prefix, startingPoint, upstreamStrategy, downstreamStrategy string, tag bool, shared bool) {
 	repo := mustOpenRepo()
-	if err := executeConfigEditTopic(repo, name, prefix, startingPoint, upstreamStrategy, downstreamStrategy, tag); err != nil {
+	if err := executeConfigEditTopic(repo, name, prefix, startingPoint, upstreamStrategy, downstreamStrategy, tag, shared); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -304,9 +312,9 @@ func ConfigEditTopicCommand(name, prefix, startingPoint, upstreamStrategy, downs
 }
 
 // ConfigRenameBaseCommand renames a base branch
-func ConfigRenameBaseCommand(oldName, newName string) {
+func ConfigRenameBaseCommand(oldName, newName string, shared bool) {
 	repo := mustOpenRepo()
-	if err := executeConfigRenameBase(repo, oldName, newName); err != nil {
+	if err := executeConfigRenameBase(repo, oldName, newName, shared); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -319,9 +327,9 @@ func ConfigRenameBaseCommand(oldName, newName string) {
 }
 
 // ConfigRenameTopicCommand renames a topic branch type
-func ConfigRenameTopicCommand(oldName, newName string) {
+func ConfigRenameTopicCommand(oldName, newName string, shared bool) {
 	repo := mustOpenRepo()
-	if err := executeConfigRenameTopic(repo, oldName, newName); err != nil {
+	if err := executeConfigRenameTopic(repo, oldName, newName, shared); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -334,9 +342,9 @@ func ConfigRenameTopicCommand(oldName, newName string) {
 }
 
 // ConfigDeleteBaseCommand deletes a base branch configuration
-func ConfigDeleteBaseCommand(name string) {
+func ConfigDeleteBaseCommand(name string, shared bool) {
 	repo := mustOpenRepo()
-	if err := executeConfigDeleteBase(repo, name); err != nil {
+	if err := executeConfigDeleteBase(repo, name, shared); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -349,9 +357,9 @@ func ConfigDeleteBaseCommand(name string) {
 }
 
 // ConfigDeleteTopicCommand deletes a topic branch type configuration
-func ConfigDeleteTopicCommand(name string) {
+func ConfigDeleteTopicCommand(name string, shared bool) {
 	repo := mustOpenRepo()
-	if err := executeConfigDeleteTopic(repo, name); err != nil {
+	if err := executeConfigDeleteTopic(repo, name, shared); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -378,7 +386,48 @@ func ConfigListCommand() {
 	}
 }
 
-func executeConfigAddBase(repo *git.Repo, name, parent, upstreamStrategy, downstreamStrategy string, autoUpdate bool) error {
+// loadConfigForEdit loads the configuration a CRUD verb should edit: the .gitflow
+// file when --shared is set (requiring it to exist first), or the repository's
+// local/merged config otherwise.
+func loadConfigForEdit(repo *git.Repo, shared bool) (*config.Config, error) {
+	if shared {
+		if !config.SharedConfigExists(repo) {
+			return nil, &errors.InvalidInputError{Message: "no shared .gitflow file found; run 'git flow init --shared' first"}
+		}
+		return config.LoadSharedConfig(repo)
+	}
+	return config.Load(repo)
+}
+
+// persistConfig writes the edited configuration back. For --shared it rewrites
+// the structured keys into .gitflow and then re-syncs the shared-managed key set
+// into local .git/config; otherwise it writes local config directly.
+func persistConfig(repo *git.Repo, cfg *config.Config, shared bool) error {
+	if shared {
+		if err := config.SaveConfigWithScope(cfg, git.ConfigScopeFile, config.SharedConfigPath(repo)); err != nil {
+			return err
+		}
+		if _, err := config.CopySharedToLocal(repo); err != nil {
+			return err
+		}
+		return nil
+	}
+	return config.SaveConfig(cfg)
+}
+
+// removeBranchSection removes a branch's config section. For --shared it removes
+// the section from .gitflow (local is reconciled by the re-sync in persistConfig,
+// which stale-removes keys no longer present in the shared file); otherwise it
+// removes the section from local config directly.
+func removeBranchSection(repo *git.Repo, shared bool, branchName string) error {
+	section := fmt.Sprintf("gitflow.branch.%s", branchName)
+	if shared {
+		return git.UnsetConfigSectionFile(config.SharedConfigPath(repo), section)
+	}
+	return repo.UnsetConfigSection(section)
+}
+
+func executeConfigAddBase(repo *git.Repo, name, parent, upstreamStrategy, downstreamStrategy string, autoUpdate bool, shared bool) error {
 	// Validate that git-flow is initialized
 	initialized, err := config.IsInitialized(repo)
 	if err != nil {
@@ -394,7 +443,7 @@ func executeConfigAddBase(repo *git.Repo, name, parent, upstreamStrategy, downst
 	}
 
 	// Load current configuration
-	cfg, err := config.Load(repo)
+	cfg, err := loadConfigForEdit(repo, shared)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
@@ -449,7 +498,7 @@ func executeConfigAddBase(repo *git.Repo, name, parent, upstreamStrategy, downst
 	cfg.Branches[name] = branchConfig
 
 	// Save configuration
-	if err := config.SaveConfig(cfg); err != nil {
+	if err := persistConfig(repo, cfg, shared); err != nil {
 		return &errors.GitError{Operation: "save configuration", Err: err}
 	}
 
@@ -466,7 +515,7 @@ func executeConfigAddBase(repo *git.Repo, name, parent, upstreamStrategy, downst
 	return nil
 }
 
-func executeConfigAddTopic(repo *git.Repo, name, parent, prefix, startingPoint, upstreamStrategy, downstreamStrategy string, tag bool) error {
+func executeConfigAddTopic(repo *git.Repo, name, parent, prefix, startingPoint, upstreamStrategy, downstreamStrategy string, tag bool, shared bool) error {
 	// Validate that git-flow is initialized
 	initialized, err := config.IsInitialized(repo)
 	if err != nil {
@@ -482,7 +531,7 @@ func executeConfigAddTopic(repo *git.Repo, name, parent, prefix, startingPoint, 
 	}
 
 	// Load current configuration
-	cfg, err := config.Load(repo)
+	cfg, err := loadConfigForEdit(repo, shared)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
@@ -543,7 +592,7 @@ func executeConfigAddTopic(repo *git.Repo, name, parent, prefix, startingPoint, 
 	cfg.Branches[name] = branchConfig
 
 	// Save configuration
-	if err := config.SaveConfig(cfg); err != nil {
+	if err := persistConfig(repo, cfg, shared); err != nil {
 		return &errors.GitError{Operation: "save configuration", Err: err}
 	}
 
@@ -551,7 +600,7 @@ func executeConfigAddTopic(repo *git.Repo, name, parent, prefix, startingPoint, 
 	return nil
 }
 
-func executeConfigEditBase(repo *git.Repo, name, upstreamStrategy, downstreamStrategy string, autoUpdate bool) error {
+func executeConfigEditBase(repo *git.Repo, name, upstreamStrategy, downstreamStrategy string, autoUpdate bool, shared bool) error {
 	// Validate that git-flow is initialized
 	initialized, err := config.IsInitialized(repo)
 	if err != nil {
@@ -562,7 +611,7 @@ func executeConfigEditBase(repo *git.Repo, name, upstreamStrategy, downstreamStr
 	}
 
 	// Load current configuration
-	cfg, err := config.Load(repo)
+	cfg, err := loadConfigForEdit(repo, shared)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
@@ -602,7 +651,7 @@ func executeConfigEditBase(repo *git.Repo, name, upstreamStrategy, downstreamStr
 	cfg.Branches[name] = branchConfig
 
 	// Save configuration
-	if err := config.SaveConfig(cfg); err != nil {
+	if err := persistConfig(repo, cfg, shared); err != nil {
 		return &errors.GitError{Operation: "save configuration", Err: err}
 	}
 
@@ -610,7 +659,7 @@ func executeConfigEditBase(repo *git.Repo, name, upstreamStrategy, downstreamStr
 	return nil
 }
 
-func executeConfigEditTopic(repo *git.Repo, name, prefix, startingPoint, upstreamStrategy, downstreamStrategy string, tag bool) error {
+func executeConfigEditTopic(repo *git.Repo, name, prefix, startingPoint, upstreamStrategy, downstreamStrategy string, tag bool, shared bool) error {
 	// Validate that git-flow is initialized
 	initialized, err := config.IsInitialized(repo)
 	if err != nil {
@@ -621,7 +670,7 @@ func executeConfigEditTopic(repo *git.Repo, name, prefix, startingPoint, upstrea
 	}
 
 	// Load current configuration
-	cfg, err := config.Load(repo)
+	cfg, err := loadConfigForEdit(repo, shared)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
@@ -672,7 +721,7 @@ func executeConfigEditTopic(repo *git.Repo, name, prefix, startingPoint, upstrea
 	cfg.Branches[name] = branchConfig
 
 	// Save configuration
-	if err := config.SaveConfig(cfg); err != nil {
+	if err := persistConfig(repo, cfg, shared); err != nil {
 		return &errors.GitError{Operation: "save configuration", Err: err}
 	}
 
@@ -680,7 +729,7 @@ func executeConfigEditTopic(repo *git.Repo, name, prefix, startingPoint, upstrea
 	return nil
 }
 
-func executeConfigRenameBase(repo *git.Repo, oldName, newName string) error {
+func executeConfigRenameBase(repo *git.Repo, oldName, newName string, shared bool) error {
 	// Validate that git-flow is initialized
 	initialized, err := config.IsInitialized(repo)
 	if err != nil {
@@ -696,7 +745,7 @@ func executeConfigRenameBase(repo *git.Repo, oldName, newName string) error {
 	}
 
 	// Load current configuration
-	cfg, err := config.Load(repo)
+	cfg, err := loadConfigForEdit(repo, shared)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
@@ -739,7 +788,7 @@ func executeConfigRenameBase(repo *git.Repo, oldName, newName string) error {
 	}
 
 	// Remove old branch config from git config
-	if err := repo.UnsetConfigSection(fmt.Sprintf("gitflow.branch.%s", oldName)); err != nil {
+	if err := removeBranchSection(repo, shared, oldName); err != nil {
 		return &errors.GitError{Operation: fmt.Sprintf("remove old branch config for '%s'", oldName), Err: err}
 	}
 
@@ -760,7 +809,7 @@ func executeConfigRenameBase(repo *git.Repo, oldName, newName string) error {
 	}
 
 	// Save configuration
-	if err := config.SaveConfig(cfg); err != nil {
+	if err := persistConfig(repo, cfg, shared); err != nil {
 		return &errors.GitError{Operation: "save configuration", Err: err}
 	}
 
@@ -768,7 +817,7 @@ func executeConfigRenameBase(repo *git.Repo, oldName, newName string) error {
 	return nil
 }
 
-func executeConfigRenameTopic(repo *git.Repo, oldName, newName string) error {
+func executeConfigRenameTopic(repo *git.Repo, oldName, newName string, shared bool) error {
 	// Validate that git-flow is initialized
 	initialized, err := config.IsInitialized(repo)
 	if err != nil {
@@ -784,7 +833,7 @@ func executeConfigRenameTopic(repo *git.Repo, oldName, newName string) error {
 	}
 
 	// Load current configuration
-	cfg, err := config.Load(repo)
+	cfg, err := loadConfigForEdit(repo, shared)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
@@ -812,7 +861,7 @@ func executeConfigRenameTopic(repo *git.Repo, oldName, newName string) error {
 	// Remove the old branch config section from git config (topic renames
 	// only touch config, not refs), so the old canonical subsection does not
 	// linger after the save writes the new one.
-	if err := repo.UnsetConfigSection(fmt.Sprintf("gitflow.branch.%s", oldName)); err != nil {
+	if err := removeBranchSection(repo, shared, oldName); err != nil {
 		return &errors.GitError{Operation: fmt.Sprintf("remove old branch config for '%s'", oldName), Err: err}
 	}
 
@@ -821,7 +870,7 @@ func executeConfigRenameTopic(repo *git.Repo, oldName, newName string) error {
 	cfg.Branches[newName] = branchConfig
 
 	// Save configuration
-	if err := config.SaveConfig(cfg); err != nil {
+	if err := persistConfig(repo, cfg, shared); err != nil {
 		return &errors.GitError{Operation: "save configuration", Err: err}
 	}
 
@@ -829,7 +878,7 @@ func executeConfigRenameTopic(repo *git.Repo, oldName, newName string) error {
 	return nil
 }
 
-func executeConfigDeleteBase(repo *git.Repo, name string) error {
+func executeConfigDeleteBase(repo *git.Repo, name string, shared bool) error {
 	// Validate that git-flow is initialized
 	initialized, err := config.IsInitialized(repo)
 	if err != nil {
@@ -840,7 +889,7 @@ func executeConfigDeleteBase(repo *git.Repo, name string) error {
 	}
 
 	// Load current configuration
-	cfg, err := config.Load(repo)
+	cfg, err := loadConfigForEdit(repo, shared)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
@@ -869,7 +918,7 @@ func executeConfigDeleteBase(repo *git.Repo, name string) error {
 	}
 
 	// Remove branch config from git config
-	if err := repo.UnsetConfigSection(fmt.Sprintf("gitflow.branch.%s", name)); err != nil {
+	if err := removeBranchSection(repo, shared, name); err != nil {
 		return &errors.GitError{Operation: fmt.Sprintf("remove branch config for '%s'", name), Err: err}
 	}
 
@@ -877,7 +926,7 @@ func executeConfigDeleteBase(repo *git.Repo, name string) error {
 	delete(cfg.Branches, name)
 
 	// Save configuration
-	if err := config.SaveConfig(cfg); err != nil {
+	if err := persistConfig(repo, cfg, shared); err != nil {
 		return &errors.GitError{Operation: "save configuration", Err: err}
 	}
 
@@ -886,7 +935,7 @@ func executeConfigDeleteBase(repo *git.Repo, name string) error {
 	return nil
 }
 
-func executeConfigDeleteTopic(repo *git.Repo, name string) error {
+func executeConfigDeleteTopic(repo *git.Repo, name string, shared bool) error {
 	// Validate that git-flow is initialized
 	initialized, err := config.IsInitialized(repo)
 	if err != nil {
@@ -897,7 +946,7 @@ func executeConfigDeleteTopic(repo *git.Repo, name string) error {
 	}
 
 	// Load current configuration
-	cfg, err := config.Load(repo)
+	cfg, err := loadConfigForEdit(repo, shared)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
 	}
@@ -916,7 +965,7 @@ func executeConfigDeleteTopic(repo *git.Repo, name string) error {
 	}
 
 	// Remove branch config from git config
-	if err := repo.UnsetConfigSection(fmt.Sprintf("gitflow.branch.%s", name)); err != nil {
+	if err := removeBranchSection(repo, shared, name); err != nil {
 		return &errors.GitError{Operation: fmt.Sprintf("remove branch config for '%s'", name), Err: err}
 	}
 
@@ -924,7 +973,7 @@ func executeConfigDeleteTopic(repo *git.Repo, name string) error {
 	delete(cfg.Branches, name)
 
 	// Save configuration
-	if err := config.SaveConfig(cfg); err != nil {
+	if err := persistConfig(repo, cfg, shared); err != nil {
 		return &errors.GitError{Operation: "save configuration", Err: err}
 	}
 
@@ -944,7 +993,7 @@ func executeConfigList(repo *git.Repo) error {
 		return nil
 	}
 
-	// Load current configuration
+	// Load current configuration (list always reads local/merged config)
 	cfg, err := config.Load(repo)
 	if err != nil {
 		return &errors.GitError{Operation: "load configuration", Err: err}
@@ -1052,6 +1101,104 @@ func executeConfigList(repo *git.Repo) error {
 	return nil
 }
 
+var configSyncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Copy the shared .gitflow config into local git config",
+	Args:  cobra.NoArgs,
+	Long: `Copy the shared-managed gitflow.* keys from the committable .gitflow file into
+the repository's local .git/config, overwriting differing values and removing
+local keys no longer present in .gitflow.
+
+Hook/filter path keys are copied only when gitflow.shared.trustHooks is enabled.
+When no .gitflow file is present this is a no-op that exits successfully.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		ConfigSyncCommand()
+	},
+}
+
+var configStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show whether local git config matches the shared .gitflow",
+	Args:  cobra.NoArgs,
+	Long: `Compare the shared-managed gitflow.* keys in local .git/config against the
+committable .gitflow file.
+
+Exits 0 when in sync (or when no .gitflow file is present), and with a non-zero
+validation-error code when the two have drifted, listing the differing keys.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		ConfigStatusCommand()
+	},
+}
+
+// ConfigSyncCommand copies the shared .gitflow config into local config.
+func ConfigSyncCommand() {
+	repo := mustOpenRepo()
+	if err := executeConfigSync(repo); err != nil {
+		var exitCode errors.ExitCode
+		if flowErr, ok := err.(errors.Error); ok {
+			exitCode = flowErr.ExitCode()
+		} else {
+			exitCode = errors.ExitCodeGitError
+		}
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(int(exitCode))
+	}
+}
+
+// ConfigStatusCommand reports drift between local config and .gitflow.
+func ConfigStatusCommand() {
+	repo := mustOpenRepo()
+	if err := executeConfigStatus(repo); err != nil {
+		var exitCode errors.ExitCode
+		if flowErr, ok := err.(errors.Error); ok {
+			exitCode = flowErr.ExitCode()
+		} else {
+			exitCode = errors.ExitCodeGitError
+		}
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(int(exitCode))
+	}
+}
+
+func executeConfigSync(repo *git.Repo) error {
+	if !config.SharedConfigExists(repo) {
+		fmt.Println("No shared .gitflow configuration found; nothing to sync.")
+		return nil
+	}
+	result, err := config.CopySharedToLocal(repo)
+	if err != nil {
+		return err
+	}
+	for _, k := range result.SkippedHookKeys {
+		fmt.Fprintf(os.Stderr, "Warning: skipped shared hook path %q; set gitflow.shared.trustHooks=true to apply it.\n", k)
+	}
+	fmt.Println("Synced local git-flow configuration from .gitflow.")
+	return nil
+}
+
+func executeConfigStatus(repo *git.Repo) error {
+	if !config.SharedConfigExists(repo) {
+		fmt.Println("No shared .gitflow configuration found.")
+		return nil
+	}
+	inSync, diffs, note, err := config.SharedStatus(repo)
+	if err != nil {
+		return err
+	}
+	if note != "" {
+		fmt.Println(note)
+	}
+	if inSync {
+		fmt.Println("Local git-flow configuration is in sync with .gitflow.")
+		return nil
+	}
+	fmt.Println("Local git-flow configuration is out of sync with .gitflow. Differing keys:")
+	for _, k := range diffs {
+		fmt.Printf("  %s\n", k)
+	}
+	return &errors.SharedConfigDriftError{}
+}
+
 // Helper functions
 
 func isValidMergeStrategy(strategy string) bool {
@@ -1098,6 +1245,8 @@ func init() {
 	configCmd.AddCommand(configRenameCmd)
 	configCmd.AddCommand(configDeleteCmd)
 	configCmd.AddCommand(configListCmd)
+	configCmd.AddCommand(configSyncCmd)
+	configCmd.AddCommand(configStatusCmd)
 
 	// Add base/topic subcommands
 	configAddCmd.AddCommand(configAddBaseCmd)
@@ -1130,4 +1279,15 @@ func init() {
 	configEditTopicCmd.Flags().String("upstream-strategy", "", "Merge strategy when merging to parent (merge|rebase|squash)")
 	configEditTopicCmd.Flags().String("downstream-strategy", "", "Merge strategy when updating from parent (merge|rebase)")
 	configEditTopicCmd.Flags().Bool("tag", false, "Create tags on finish")
+
+	// --shared writes to the committable .gitflow file and re-syncs local config,
+	// instead of writing local config only. Available on every CRUD verb.
+	for _, c := range []*cobra.Command{
+		configAddBaseCmd, configAddTopicCmd,
+		configEditBaseCmd, configEditTopicCmd,
+		configRenameBaseCmd, configRenameTopicCmd,
+		configDeleteBaseCmd, configDeleteTopicCmd,
+	} {
+		c.Flags().Bool("shared", false, "Edit the shared .gitflow file and re-sync local config (requires an existing .gitflow)")
+	}
 }

--- a/cmd/firstrun.go
+++ b/cmd/firstrun.go
@@ -29,8 +29,10 @@ func firstRunActivation(cmd *cobra.Command) error {
 	// Never intercept the config command group: config verbs manage git-flow
 	// config explicitly. `config status` must stay read-only (no prompt/copy) and
 	// `config sync` must not be refused by an untrusted-hook auto-init before it
-	// gets a chance to run and skip the hook itself.
-	if cmd.Name() == "config" || (cmd.Parent() != nil && cmd.Parent().Name() == "config") {
+	// gets a chance to run and skip the hook itself. Walk the whole ancestor chain
+	// so nested leaves (`config add topic`, `config edit base`, …) are exempt too,
+	// not just the direct children of `config`.
+	if isConfigCommand(cmd) {
 		return nil
 	}
 
@@ -78,6 +80,19 @@ func firstRunActivation(cmd *cobra.Command) error {
 		fmt.Fprintf(os.Stderr, "Note: this repository has a shared %s configuration that has not been activated.\nRun 'git flow config sync' to activate it, or set gitflow.shared.autoInit=true to activate automatically.\n", config.SharedConfigFileName)
 		return nil
 	}
+}
+
+// isConfigCommand reports whether cmd is the config command or any command
+// nested under it, walking the full parent chain. The config leaves (base/topic
+// under add/edit/rename/delete) sit two levels below config, so a direct-parent
+// check alone would let them slip past the first-run exemption.
+func isConfigCommand(cmd *cobra.Command) bool {
+	for c := cmd; c != nil; c = c.Parent() {
+		if c.Name() == "config" {
+			return true
+		}
+	}
+	return false
 }
 
 // activateAutoInit performs a non-interactive activation. It refuses wholesale

--- a/cmd/firstrun.go
+++ b/cmd/firstrun.go
@@ -1,0 +1,129 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/gittower/git-flow-next/internal/config"
+	"github.com/gittower/git-flow-next/internal/errors"
+	"github.com/gittower/git-flow-next/internal/git"
+	"github.com/spf13/cobra"
+)
+
+// firstRunActivation is the rootCmd PersistentPreRunE. On an otherwise
+// unconfigured repository that carries a committable .gitflow file, it activates
+// the shared config (prompt when interactive, auto-init when
+// gitflow.shared.autoInit=true, hint otherwise) by copying gitflow.* into local
+// .git/config before the invoked command proceeds. It is a no-op for the init
+// command itself, outside a work tree / in a bare repo, when no .gitflow exists,
+// and when the repo is already configured (local wins).
+func firstRunActivation(cmd *cobra.Command) error {
+	// Never intercept the command that configures the repository.
+	if cmd.Name() == "init" {
+		return nil
+	}
+
+	// Outside a git work tree (or a bare repo) there is nothing to activate.
+	repo, err := openRepo()
+	if err != nil {
+		return nil
+	}
+
+	if !config.SharedConfigExists(repo) {
+		return nil
+	}
+
+	unconfigured, err := config.IsUnconfiguredIgnoringShared(repo)
+	if err != nil {
+		// Be conservative: a detection failure must not block ordinary commands.
+		return nil
+	}
+	if !unconfigured {
+		// Already configured locally/globally/system: local config wins, the
+		// shared file is not applied on first run.
+		return nil
+	}
+
+	// The repo is unconfigured and a .gitflow is present. Validate it.
+	valid, err := config.SharedConfigValid(repo)
+	if err != nil {
+		// Malformed / unparsable file: surface a clear error naming .gitflow.
+		return err
+	}
+	if !valid {
+		// Present but missing gitflow.version: not offered as initialized. Print a
+		// hint so the user learns why it was not applied, then let the invoked
+		// command report "not initialized" on its own.
+		fmt.Fprintf(os.Stderr, "Note: a %s file is present but declares no gitflow.version, so it was not applied.\nRun 'git flow init --shared --force' to (re)author it.\n", config.SharedConfigFileName)
+		return nil
+	}
+
+	switch {
+	case config.SharedAutoInit(repo):
+		return activateAutoInit(repo)
+	case firstRunInteractive():
+		return activatePrompt(repo)
+	default:
+		fmt.Fprintf(os.Stderr, "Note: this repository has a shared %s configuration that has not been activated.\nRun 'git flow init' to activate it, or set gitflow.shared.autoInit=true to activate automatically.\n", config.SharedConfigFileName)
+		return nil
+	}
+}
+
+// activateAutoInit performs a non-interactive activation. It refuses wholesale
+// when the shared file declares an untrusted hook path, so an unattended run can
+// never silently adopt executable hook configuration.
+func activateAutoInit(repo *git.Repo) error {
+	hookKeys, err := config.SharedConfigHookPathKeys(repo)
+	if err != nil {
+		return err
+	}
+	if len(hookKeys) > 0 && !config.SharedTrustHooks(repo) {
+		return &errors.InvalidInputError{Message: fmt.Sprintf(
+			"refusing to auto-initialize from %s: it declares an untrusted shared hook path (%s). Set gitflow.shared.trustHooks=true to allow it.",
+			config.SharedConfigFileName, strings.Join(hookKeys, ", "))}
+	}
+	if _, err := config.CopySharedToLocal(repo); err != nil {
+		return err
+	}
+	fmt.Printf("Note: auto-initialized git-flow from the shared %s file.\n", config.SharedConfigFileName)
+	return nil
+}
+
+// activatePrompt asks the user (interactive stdin) whether to activate the shared
+// config. Declining leaves the repo unconfigured; the invoked command then
+// reports "not initialized" itself. Accepting copies the config and warns about
+// any hook path skipped for lack of trust.
+func activatePrompt(repo *git.Repo) error {
+	fmt.Printf("This repository has a shared %s configuration that is not yet active.\nInitialize git-flow from %s now? [y/N]: ", config.SharedConfigFileName, config.SharedConfigFileName)
+
+	reader := bufio.NewReader(os.Stdin)
+	answer, _ := reader.ReadString('\n')
+	answer = strings.ToLower(strings.TrimSpace(answer))
+	if answer != "y" && answer != "yes" {
+		return nil
+	}
+
+	result, err := config.CopySharedToLocal(repo)
+	if err != nil {
+		return err
+	}
+	for _, k := range result.SkippedHookKeys {
+		fmt.Fprintf(os.Stderr, "Warning: skipped shared hook path %q; set gitflow.shared.trustHooks=true to apply it.\n", k)
+	}
+	fmt.Printf("Initialized git-flow from the shared %s file.\n", config.SharedConfigFileName)
+	return nil
+}
+
+// firstRunInteractive reports whether the first-run activation decision should
+// treat stdin as interactive. It honors the test-only GIT_FLOW_ASSUME_INTERACTIVE
+// override (set to "1" to force interactive, since the subprocess test harness
+// cannot allocate a PTY); otherwise it uses the real terminal check, so a pipe or
+// /dev/null counts as non-interactive.
+func firstRunInteractive() bool {
+	if os.Getenv("GIT_FLOW_ASSUME_INTERACTIVE") == "1" {
+		return true
+	}
+	return isTerminal(os.Stdin.Fd())
+}

--- a/cmd/firstrun.go
+++ b/cmd/firstrun.go
@@ -17,11 +17,20 @@ import (
 // the shared config (prompt when interactive, auto-init when
 // gitflow.shared.autoInit=true, hint otherwise) by copying gitflow.* into local
 // .git/config before the invoked command proceeds. It is a no-op for the init
-// command itself, outside a work tree / in a bare repo, when no .gitflow exists,
-// and when the repo is already configured (local wins).
+// command itself and for the config command group, outside a work tree / in a
+// bare repo, when no .gitflow exists, and when the repo is already configured
+// (local wins).
 func firstRunActivation(cmd *cobra.Command) error {
 	// Never intercept the command that configures the repository.
 	if cmd.Name() == "init" {
+		return nil
+	}
+
+	// Never intercept the config command group: config verbs manage git-flow
+	// config explicitly. `config status` must stay read-only (no prompt/copy) and
+	// `config sync` must not be refused by an untrusted-hook auto-init before it
+	// gets a chance to run and skip the hook itself.
+	if cmd.Name() == "config" || (cmd.Parent() != nil && cmd.Parent().Name() == "config") {
 		return nil
 	}
 
@@ -66,7 +75,7 @@ func firstRunActivation(cmd *cobra.Command) error {
 	case firstRunInteractive():
 		return activatePrompt(repo)
 	default:
-		fmt.Fprintf(os.Stderr, "Note: this repository has a shared %s configuration that has not been activated.\nRun 'git flow init' to activate it, or set gitflow.shared.autoInit=true to activate automatically.\n", config.SharedConfigFileName)
+		fmt.Fprintf(os.Stderr, "Note: this repository has a shared %s configuration that has not been activated.\nRun 'git flow config sync' to activate it, or set gitflow.shared.autoInit=true to activate automatically.\n", config.SharedConfigFileName)
 		return nil
 	}
 }
@@ -84,6 +93,9 @@ func activateAutoInit(repo *git.Repo) error {
 			"refusing to auto-initialize from %s: it declares an untrusted shared hook path (%s). Set gitflow.shared.trustHooks=true to allow it.",
 			config.SharedConfigFileName, strings.Join(hookKeys, ", "))}
 	}
+	// No skipped-hook warning here (unlike activatePrompt): auto-init refuses
+	// outright when an untrusted hook path is present and copies it only when
+	// trusted, so it never partially skips a hook.
 	if _, err := config.CopySharedToLocal(repo); err != nil {
 		return err
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -51,13 +51,14 @@ If git-flow-avh configuration exists, it will be imported.`,
 		globalScope, _ := cmd.Flags().GetBool("global")
 		systemScope, _ := cmd.Flags().GetBool("system")
 		fileScope, _ := cmd.Flags().GetString("file")
-		InitCommand(useDefaults, !noCreateBranches, force, preset, custom, mainBranch, developBranch, featurePrefix, bugfixPrefix, releasePrefix, hotfixPrefix, supportPrefix, tagPrefix, localScope, globalScope, systemScope, fileScope)
+		sharedScope, _ := cmd.Flags().GetBool("shared")
+		InitCommand(useDefaults, !noCreateBranches, force, preset, custom, mainBranch, developBranch, featurePrefix, bugfixPrefix, releasePrefix, hotfixPrefix, supportPrefix, tagPrefix, localScope, globalScope, systemScope, fileScope, sharedScope)
 	},
 }
 
 // InitCommand is the implementation of the init command
-func InitCommand(useDefaults, createBranches, force bool, preset string, custom bool, mainBranch, developBranch, featurePrefix, bugfixPrefix, releasePrefix, hotfixPrefix, supportPrefix, tagPrefix string, localScope, globalScope, systemScope bool, fileScope string) {
-	if err := initFlow(useDefaults, createBranches, force, preset, custom, mainBranch, developBranch, featurePrefix, bugfixPrefix, releasePrefix, hotfixPrefix, supportPrefix, tagPrefix, localScope, globalScope, systemScope, fileScope); err != nil {
+func InitCommand(useDefaults, createBranches, force bool, preset string, custom bool, mainBranch, developBranch, featurePrefix, bugfixPrefix, releasePrefix, hotfixPrefix, supportPrefix, tagPrefix string, localScope, globalScope, systemScope bool, fileScope string, sharedScope bool) {
+	if err := initFlow(useDefaults, createBranches, force, preset, custom, mainBranch, developBranch, featurePrefix, bugfixPrefix, releasePrefix, hotfixPrefix, supportPrefix, tagPrefix, localScope, globalScope, systemScope, fileScope, sharedScope); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -70,8 +71,11 @@ func InitCommand(useDefaults, createBranches, force bool, preset string, custom 
 }
 
 // initFlow performs the actual initialization logic and returns any errors
-func initFlow(useDefaults, createBranches, force bool, preset string, custom bool, mainBranch, developBranch, featurePrefix, bugfixPrefix, releasePrefix, hotfixPrefix, supportPrefix, tagPrefix string, localScope, globalScope, systemScope bool, fileScope string) error {
-	// Validate mutual exclusivity of scope flags
+func initFlow(useDefaults, createBranches, force bool, preset string, custom bool, mainBranch, developBranch, featurePrefix, bugfixPrefix, releasePrefix, hotfixPrefix, supportPrefix, tagPrefix string, localScope, globalScope, systemScope bool, fileScope string, sharedScope bool) error {
+	// Validate mutual exclusivity of scope flags. --shared is not a git config
+	// scope; it selects "write structured config to <toplevel>/.gitflow, then
+	// copy gitflow.* into local .git/config", so it cannot be combined with the
+	// single-scope write flags.
 	scopeCount := 0
 	if localScope {
 		scopeCount++
@@ -85,8 +89,11 @@ func initFlow(useDefaults, createBranches, force bool, preset string, custom boo
 	if fileScope != "" {
 		scopeCount++
 	}
+	if sharedScope {
+		scopeCount++
+	}
 	if scopeCount > 1 {
-		return fmt.Errorf("cannot use multiple scope options together; specify only one of --local, --global, --system, or --file")
+		return &errors.InvalidInputError{Message: "cannot use multiple scope options together; specify only one of --shared, --local, --global, --system, or --file"}
 	}
 
 	// Determine config scope
@@ -123,10 +130,24 @@ func initFlow(useDefaults, createBranches, force bool, preset string, custom boo
 		return &errors.GitError{Operation: "check if git repository", Err: fmt.Errorf("not a git repository. Please run 'git init' first")}
 	}
 
-	// Check if git-flow-next is already initialized at the specified scope
-	status, err := config.IsGitFlowNextInitializedWithScope(scope, scopeFile)
-	if err != nil {
-		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
+	// Shared scope has its own "already configured" detection based on the
+	// presence of the committed .gitflow file, not on git config scopes.
+	if sharedScope {
+		if config.SharedConfigExists(repo) && !force {
+			fmt.Fprintln(os.Stderr, "Git-flow is already configured via the shared .gitflow file. Use --force to rewrite it.")
+			return &errors.AlreadyInitializedError{}
+		}
+	}
+
+	// Check if git-flow-next is already initialized at the specified scope. This
+	// standard scope-based detection is skipped for --shared (handled above), so
+	// a local copy left by a previous shared activation does not block re-authoring.
+	var status config.InitializedStatus
+	if !sharedScope {
+		status, err = config.IsGitFlowNextInitializedWithScope(scope, scopeFile)
+		if err != nil {
+			return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
+		}
 	}
 
 	if status.Initialized && !force {
@@ -255,12 +276,37 @@ func initFlow(useDefaults, createBranches, force bool, preset string, custom boo
 		}
 	}
 
-	// Save configuration with the appropriate scope
-	if err := config.SaveConfigWithScope(cfg, scope, scopeFile); err != nil {
-		return &errors.GitError{Operation: "save configuration", Err: err}
-	}
-	if err := config.MarkRepoInitializedWithScope(scope, scopeFile); err != nil {
-		return &errors.GitError{Operation: "mark repository as initialized", Err: err}
+	// Save configuration. --shared authors the structured config into the
+	// committable <toplevel>/.gitflow file and then copies gitflow.* into local
+	// .git/config so every read site (including the direct git-config readers)
+	// sees the shared settings.
+	if sharedScope {
+		sharedPath := config.SharedConfigPath(repo)
+		// A forced re-init removes any existing .gitflow first so the rewrite
+		// cannot leave stale keys behind.
+		if force {
+			if _, statErr := os.Stat(sharedPath); statErr == nil {
+				if err := os.Remove(sharedPath); err != nil {
+					return &errors.GitError{Operation: "remove existing .gitflow", Err: err}
+				}
+			}
+		}
+		if err := config.SaveConfigWithScope(cfg, git.ConfigScopeFile, sharedPath); err != nil {
+			return &errors.GitError{Operation: "save shared configuration", Err: err}
+		}
+		if err := config.MarkRepoInitializedWithScope(git.ConfigScopeFile, sharedPath); err != nil {
+			return &errors.GitError{Operation: "mark shared configuration as initialized", Err: err}
+		}
+		if _, err := config.CopySharedToLocal(repo); err != nil {
+			return &errors.GitError{Operation: "copy shared configuration into local config", Err: err}
+		}
+	} else {
+		if err := config.SaveConfigWithScope(cfg, scope, scopeFile); err != nil {
+			return &errors.GitError{Operation: "save configuration", Err: err}
+		}
+		if err := config.MarkRepoInitializedWithScope(scope, scopeFile); err != nil {
+			return &errors.GitError{Operation: "mark repository as initialized", Err: err}
+		}
 	}
 
 	// Create branches if requested
@@ -712,4 +758,5 @@ func init() {
 	initCmd.Flags().Bool("global", false, "Store configuration in user's global ~/.gitconfig")
 	initCmd.Flags().Bool("system", false, "Store configuration in system-wide /etc/gitconfig")
 	initCmd.Flags().String("file", "", "Store configuration in specified file")
+	initCmd.Flags().Bool("shared", false, "Write a committable .gitflow file at the repo root and copy it into local config (mutually exclusive with the other scope flags)")
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -30,6 +30,7 @@ Configuration scope options control where settings are stored:
   --global            Store in user's ~/.gitconfig
   --system            Store in system-wide /etc/gitconfig
   --file=<path>       Store in specified file
+  --shared            Write a committable .gitflow file and copy it into local config
 
 Use --custom for interactive custom configuration.
 If git-flow-avh configuration exists, it will be imported.`,

--- a/cmd/isterminal_bsd.go
+++ b/cmd/isterminal_bsd.go
@@ -1,0 +1,9 @@
+//go:build darwin || freebsd || netbsd || openbsd || dragonfly
+
+package cmd
+
+import "syscall"
+
+// ioctlReadTermios is the ioctl request that reads terminal attributes on the
+// BSD family (including macOS/Darwin).
+const ioctlReadTermios = syscall.TIOCGETA

--- a/cmd/isterminal_linux.go
+++ b/cmd/isterminal_linux.go
@@ -1,0 +1,8 @@
+//go:build linux
+
+package cmd
+
+import "syscall"
+
+// ioctlReadTermios is the ioctl request that reads terminal attributes on Linux.
+const ioctlReadTermios = syscall.TCGETS

--- a/cmd/isterminal_other.go
+++ b/cmd/isterminal_other.go
@@ -1,0 +1,12 @@
+//go:build !windows && !linux && !darwin && !freebsd && !netbsd && !openbsd && !dragonfly
+
+package cmd
+
+// isTerminal is a conservative fallback for Go targets that neither define a
+// termios read ioctl (linux + the BSDs) nor use the Windows console API — e.g.
+// aix, solaris, illumos, plan9. Without a portable TTY probe we assume stdin is
+// not a terminal, so the first-run activation takes the non-interactive hint
+// path rather than blocking on a prompt.
+func isTerminal(fd uintptr) bool {
+	return false
+}

--- a/cmd/isterminal_unix.go
+++ b/cmd/isterminal_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build linux || darwin || freebsd || netbsd || openbsd || dragonfly
 
 package cmd
 

--- a/cmd/isterminal_unix.go
+++ b/cmd/isterminal_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// isTerminal reports whether the given file descriptor is connected to a
+// terminal (TTY). It issues the terminal-attributes ioctl and treats success as
+// "is a terminal". A pipe or /dev/null (as used by the test harness and in
+// non-interactive invocations) fails the ioctl and is correctly reported as not
+// a terminal — this is what distinguishes the first-run prompt path from the
+// hint path.
+func isTerminal(fd uintptr) bool {
+	var termios syscall.Termios
+	_, _, errno := syscall.Syscall6(syscall.SYS_IOCTL, fd, ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	return errno == 0
+}

--- a/cmd/isterminal_windows.go
+++ b/cmd/isterminal_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package cmd
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var (
+	kernel32           = syscall.NewLazyDLL("kernel32.dll")
+	procGetConsoleMode = kernel32.NewProc("GetConsoleMode")
+)
+
+// isTerminal reports whether the given file descriptor is attached to a Windows
+// console. GetConsoleMode succeeds only for a real console handle, so a pipe or
+// the null device is correctly reported as not a terminal.
+func isTerminal(fd uintptr) bool {
+	var mode uint32
+	r, _, _ := procGetConsoleMode.Call(fd, uintptr(unsafe.Pointer(&mode)))
+	return r != 0
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,12 @@ It provides a set of commands to work with Git branches according to the git-flo
   git flow feature finish my-feature
   git flow release start 1.0.0
   git flow release finish 1.0.0`,
+	// First-run activation of a committable .gitflow file runs before any
+	// command. It is a no-op unless the repo is unconfigured and a valid .gitflow
+	// is present (see firstRunActivation).
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return firstRunActivation(cmd)
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// If no subcommand is provided, print help
 		cmd.Help()

--- a/cmd/topicbranch.go
+++ b/cmd/topicbranch.go
@@ -33,9 +33,21 @@ func RegisterTopicBranchCommands() {
 
 	// Get topic branch types from configuration
 	topicBranchTypes := []string{}
+	seen := map[string]bool{}
 	for branchName, branchConfig := range cfg.Branches {
 		if branchConfig.Type == string(config.BranchTypeTopic) {
 			topicBranchTypes = append(topicBranchTypes, branchName)
+			seen[branchName] = true
+		}
+	}
+
+	// Fold in topic types declared only in a present-but-not-yet-activated
+	// .gitflow, so a custom type defined in the shared file has a working command
+	// on a fresh clone before first-run activation copies it into local config.
+	for _, sharedType := range config.SharedTopicTypes(repo) {
+		if !seen[sharedType] {
+			topicBranchTypes = append(topicBranchTypes, sharedType)
+			seen[sharedType] = true
 		}
 	}
 

--- a/docs/git-flow-config.1.md
+++ b/docs/git-flow-config.1.md
@@ -57,6 +57,19 @@ Branch names are matched **case-insensitively**. The case used when a branch is 
 **delete topic** *name*
 : Delete a topic branch type configuration. Does not affect existing branches of this type.
 
+### Shared Configuration
+
+**sync**
+: Copy the shared-managed **gitflow.*** keys from the committable **.gitflow** file into the repository's local **.git/config**, overwriting differing values and removing local keys no longer present in **.gitflow**. Hook/filter path keys (**gitflow.path.hooks**) are copied only when **gitflow.shared.trustHooks** is enabled. When no **.gitflow** file is present, **sync** is a no-op that exits successfully.
+
+**status**
+: Compare the shared-managed **gitflow.*** keys in local **.git/config** against the **.gitflow** file, listing any that differ. Exits **0** when in sync (or when no **.gitflow** is present) and **6** when they have drifted. Local-only keys (**gitflow.shared.***, runtime **gitflow.branch.<branch>.base**) and an intentionally-skipped untrusted hook path are never reported as drift.
+
+## SHARED OPTION
+
+**--shared**
+: Available on **add**, **edit**, **rename**, and **delete** (both **base** and **topic**). Edit the committable **.gitflow** file instead of local config, then re-sync the shared-managed keys into local **.git/config**. Requires an existing **.gitflow** (created by **git flow init --shared**); without one the command fails and suggests **git flow init --shared**, creating no file. Without **--shared**, CRUD verbs write local config only, which **config status** will then report as drift from **.gitflow**.
+
 ## COMMAND OPTIONS
 
 ### Add Base Branch (`add base`)
@@ -257,6 +270,8 @@ The config command performs validation to ensure:
 
 ## STORAGE
 
+Local configuration is stored in **.git/config** under the **gitflow.*** namespace. With **--shared**, the same keys are additionally written to a committable **.gitflow** file at the repository top level and then copied into local config. See **gitflow-config**(5) for the **.gitflow** format, the shared-managed key set, and first-run activation.
+
 All configuration is stored in **.git/config** under the **gitflow.*** namespace:
 
 ```ini
@@ -295,6 +310,9 @@ All configuration is stored in **.git/config** under the **gitflow.*** namespace
 
 **4**
 : Git operation failed
+
+**6**
+: **config status** detected drift between local config and **.gitflow**
 
 ## SEE ALSO
 

--- a/docs/git-flow-init.1.md
+++ b/docs/git-flow-init.1.md
@@ -6,7 +6,7 @@ git-flow-init - Initialize git-flow in a repository
 
 ## SYNOPSIS
 
-**git-flow init** [**-f**|**--force**] [**--preset**=*preset*] [**--custom**] [**--defaults**] [**--local**|**--global**|**--system**|**--file**=*path*] [*options*]
+**git-flow init** [**-f**|**--force**] [**--preset**=*preset*] [**--custom**] [**--defaults**] [**--shared**|**--local**|**--global**|**--system**|**--file**=*path*] [*options*]
 
 ## DESCRIPTION
 
@@ -42,6 +42,9 @@ Initialize git-flow configuration in the current Git repository. This command se
 ### Configuration Scope Options
 
 These options control where git-flow configuration is stored. Only one scope option may be specified at a time. When no scope option is given, git-flow reads from merged config (local > global > system precedence) and writes to local config.
+
+**--shared**
+: Author the configuration into a committable **.gitflow** file at the repository top level, then copy the **gitflow.*** keys into the repository's local **.git/config**. Committing **.gitflow** lets teammates share one git-flow configuration: on a fresh clone, git-flow offers to activate it (see **gitflow-config**(5), FIRST-RUN ACTIVATION). **--shared** is mutually exclusive with **--local**, **--global**, **--system**, and **--file**. Without **--force**, running **--shared** again when a **.gitflow** already exists fails and leaves the file untouched; with **--force** the file is rewritten and re-copied (removing any stale managed keys from local config).
 
 **--local**
 : Read and write configuration only in the repository's **.git/config** file. This is the default for writes when no scope option is specified.
@@ -214,6 +217,12 @@ git flow init --defaults --local
 Initialize with configuration file:
 ```bash
 git flow init --defaults --file=/path/to/custom-gitflow.config
+```
+
+Initialize a shared, committable configuration:
+```bash
+git flow init --defaults --shared
+git add .gitflow && git commit -m "Add shared git-flow configuration"
 ```
 
 Create local config when global config already exists:

--- a/docs/gitflow-config.5.md
+++ b/docs/gitflow-config.5.md
@@ -785,6 +785,64 @@ git flow config add topic feature develop --prefix=feature/
     fetch = true
 ```
 
+## SHARED CONFIGURATION (.gitflow)
+
+git-flow can store its configuration in a committable **.gitflow** file at the repository top level so a whole team shares one workflow. The file uses the same **git-config** INI format and the same **gitflow.*** keys as **.git/config**:
+
+```ini
+[gitflow]
+    version = 1.0
+    initialized = true
+[gitflow "branch.main"]
+    type = base
+[gitflow "branch.develop"]
+    type = base
+    parent = main
+    autoUpdate = true
+[gitflow "branch.feature"]
+    type = topic
+    parent = develop
+    prefix = feature/
+```
+
+git-flow never reads the **.gitflow** file directly during branch operations. Instead it **copies** the shared-managed keys into the clone's local **.git/config**, so every read site — including the commands that read git config directly — sees the shared values, and native git precedence (local > global > system) still applies.
+
+Create and manage **.gitflow** with:
+
+- **git flow init --shared** — author the file and copy it into local config.
+- **git flow config sync** — re-copy **.gitflow** into local config (overwrite + stale-key removal).
+- **git flow config status** — report drift between local config and **.gitflow** (exit **6** on drift).
+- **git flow config** *add|edit|rename|delete* **... --shared** — edit **.gitflow** and re-sync local.
+
+### Shared-managed key set
+
+A **gitflow.*** key is *shared-managed* — copied between **.gitflow** and local config — unless it is:
+
+- a **gitflow.shared.*** control key (see below), or
+- per-branch runtime metadata **gitflow.branch.<branch>.base** (the start point recorded for a started topic branch).
+
+**gitflow.version** and **gitflow.initialized** are shared-managed. Keys outside the **gitflow.*** namespace (for example **core.*** or **alias.***) are never copied, even if present in **.gitflow**. Copying preserves multi-value keys (such as **gitflow.<type>.publish.push-option**) and their order.
+
+### Control keys
+
+These keys are read from local/global/system config (not from **.gitflow**) and are never copied:
+
+**gitflow.shared.autoInit**
+: When **true**, a fresh clone activates a present, valid **.gitflow** automatically (non-interactively) instead of prompting. Set it globally to opt in for all your clones.
+
+**gitflow.shared.trustHooks**
+: When **true**, the executable hook/filter path key **gitflow.path.hooks** is copied from **.gitflow** like any other key. When unset, that key is treated as absent from the effective shared set: it is neither copied in nor left behind (a previously-copied value is removed on the next sync), and non-interactive auto-init refuses outright when an untrusted shared hook path is present. This prevents a committed file from silently redirecting hook execution.
+
+### First-run activation
+
+When a repository is otherwise unconfigured (no **gitflow.version** and no valid git-flow/git-flow-avh branch configuration, ignoring **gitflow.shared.*** keys) and a valid **.gitflow** (one that declares **gitflow.version**) is present, the next git-flow command activates it:
+
+- **Interactive terminal** — prompts to initialize from **.gitflow**; declining leaves the repository unconfigured.
+- **gitflow.shared.autoInit=true** — copies automatically with a one-line notice (refusing if an untrusted hook path is present).
+- **Non-interactive, autoInit unset** — prints a hint and leaves the repository unconfigured.
+
+Activation never runs for **git flow init** itself, in a bare repository or outside a work tree, or when the repository is already configured (local config wins). A **.gitflow** that lacks **gitflow.version** is not offered as initialized, and an unparsable **.gitflow** produces a clear error naming the file. Linked worktrees share the common **.git/config** and therefore inherit the copy without a separate activation.
+
 ## SEE ALSO
 
 **git-flow**(1), **git-flow-config**(1), **git-flow-init**(1), **git-config**(1), **gitignore**(5)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -219,73 +219,71 @@ func Load(repo *git.Repo) (*Config, error) {
 		return nil, fmt.Errorf("failed to load gitflow branch config: %w", err)
 	}
 
-	// Process branch configurations from command output.
-	//
-	// Branch subsection names (gitflow.branch.<name>) are treated
-	// case-insensitively for identity but their original case is preserved
-	// as canonical (mirrors core.ignorecase semantics). The first-seen
-	// casing of a branch name wins as the canonical key; later properties of
-	// the same branch fold into that entry. The name itself may contain dots
-	// (e.g. gitflow.branch.custom.main.type), so it is reconstructed from all
-	// segments between "gitflow.branch." and the final one. Property names
-	// (the last segment) are legitimately case-insensitive in git config and
-	// are lowercased so the BranchConfig field lookups below match regardless
-	// of stored case.
+	config.Branches = ParseBranchConfigLines(branchLines)
+
+	// If no branches were loaded, use default config
+	if len(config.Branches) == 0 {
+		return DefaultConfig(), nil
+	}
+
+	return config, nil
+}
+
+// ParseBranchConfigLines converts raw `git config --get-regexp gitflow.branch.`
+// output lines into BranchConfig objects keyed by canonical branch name.
+//
+// Branch subsection names (gitflow.branch.<name>) are treated case-insensitively
+// for identity but their original case is preserved as canonical (mirrors
+// core.ignorecase semantics). The first-seen casing of a branch name wins as the
+// canonical key; later properties of the same branch fold into that entry. The
+// name itself may contain dots (e.g. gitflow.branch.custom.main.type), so it is
+// reconstructed from all segments between "gitflow.branch." and the final one.
+// Property names (the last segment) are legitimately case-insensitive in git
+// config and are lowercased so the BranchConfig field lookups match regardless
+// of stored case. Lines that are not branch *definitions* (e.g. the runtime
+// gitflow.branch.<actual>.base key) are still parsed as properties but yield no
+// recognized BranchConfig field.
+func ParseBranchConfigLines(branchLines []string) map[string]BranchConfig {
 	branchMap := make(map[string]map[string]string)
 	// canonicalNames maps a lowercased fold key to the canonical (first-seen)
 	// branch name used as the branchMap key.
 	canonicalNames := make(map[string]string)
 
-	{
-		for _, line := range branchLines {
-			if line == "" {
-				continue
-			}
-
-			parts := strings.SplitN(line, " ", 2)
-			if len(parts) != 2 {
-				continue
-			}
-
-			key := parts[0]
-			value := parts[1]
-
-			// Parse key: gitflow.branch.<branchname>.<property>
-			//
-			// The branch name is a git config subsection and may contain
-			// dots (e.g. gitflow.branch.custom.main.type), so it can span
-			// several dot-separated segments. Git keeps the section
-			// (gitflow) and the variable name (the final segment) dot-free,
-			// so the property is always the last segment and the branch name
-			// is everything between "gitflow.branch." and it.
-			keyParts := strings.Split(key, ".")
-			if len(keyParts) < 4 {
-				continue
-			}
-
-			// Preserve the original branch-name case as canonical, folding
-			// case-insensitively so all properties of the same branch land in
-			// one entry keyed by the first-seen case.
-			rawBranchName := strings.Join(keyParts[2:len(keyParts)-1], ".")
-			foldKey := strings.ToLower(rawBranchName)
-			branchName, ok := canonicalNames[foldKey]
-			if !ok {
-				branchName = rawBranchName
-				canonicalNames[foldKey] = branchName
-			}
-			property := strings.ToLower(keyParts[len(keyParts)-1])
-
-			// Initialize branch map if needed
-			if _, ok := branchMap[branchName]; !ok {
-				branchMap[branchName] = make(map[string]string)
-			}
-
-			// Add property to branch map
-			branchMap[branchName][property] = value
+	for _, line := range branchLines {
+		if line == "" {
+			continue
 		}
+
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		key := parts[0]
+		value := parts[1]
+
+		// Parse key: gitflow.branch.<branchname>.<property>
+		keyParts := strings.Split(key, ".")
+		if len(keyParts) < 4 {
+			continue
+		}
+
+		rawBranchName := strings.Join(keyParts[2:len(keyParts)-1], ".")
+		foldKey := strings.ToLower(rawBranchName)
+		branchName, ok := canonicalNames[foldKey]
+		if !ok {
+			branchName = rawBranchName
+			canonicalNames[foldKey] = branchName
+		}
+		property := strings.ToLower(keyParts[len(keyParts)-1])
+
+		if _, ok := branchMap[branchName]; !ok {
+			branchMap[branchName] = make(map[string]string)
+		}
+		branchMap[branchName][property] = value
 	}
 
-	// Convert branch map to BranchConfig objects
+	branches := make(map[string]BranchConfig)
 	for branchName, properties := range branchMap {
 		branchConfig := BranchConfig{
 			Type:               properties["type"],
@@ -296,29 +294,20 @@ func Load(repo *git.Repo) (*Config, error) {
 			Prefix:             properties["prefix"],
 		}
 
-		// Handle boolean properties
 		if autoUpdate, ok := properties["autoupdate"]; ok {
 			branchConfig.AutoUpdate = autoUpdate == "true"
 		}
 		if tag, ok := properties["tag"]; ok {
 			branchConfig.Tag = tag == "true"
 		}
-
-		// Handle tag prefix
 		if tagPrefix, ok := properties["tagprefix"]; ok {
 			branchConfig.TagPrefix = tagPrefix
 		}
 
-		// Add branch config to config
-		config.Branches[branchName] = branchConfig
+		branches[branchName] = branchConfig
 	}
 
-	// If no branches were loaded, use default config
-	if len(config.Branches) == 0 {
-		return DefaultConfig(), nil
-	}
-
-	return config, nil
+	return branches
 }
 
 // IsInitialized checks if git-flow is initialized in the repository

--- a/internal/config/shared.go
+++ b/internal/config/shared.go
@@ -271,9 +271,10 @@ func SharedStatus(repo *git.Repo) (inSync bool, diffs []string, note string, err
 		if !IsSharedManagedKey(e.key) {
 			continue
 		}
-		if isHookPathKey(e.key) && !trust {
-			continue
-		}
+		// Do NOT filter an untrusted hook path out of the local map: the file
+		// (expected) map is filtered, so a hook path lingering in local config
+		// after trust was revoked surfaces here as drift — matching what the next
+		// sync would remove. The never-copied case (no local hook) stays in sync.
 		localValues[e.key] = append(localValues[e.key], e.value)
 	}
 

--- a/internal/config/shared.go
+++ b/internal/config/shared.go
@@ -1,0 +1,395 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/gittower/git-flow-next/internal/git"
+)
+
+// SharedConfigFileName is the name of the committable shared-config file that
+// lives at the repository work-tree root.
+const SharedConfigFileName = ".gitflow"
+
+// SharedConfigPath returns the absolute path to the repository's .gitflow file.
+func SharedConfigPath(repo *git.Repo) string {
+	return filepath.Join(repo.WorkTree(), SharedConfigFileName)
+}
+
+// SharedConfigExists reports whether a .gitflow file is present at the repo root.
+func SharedConfigExists(repo *git.Repo) bool {
+	info, err := os.Stat(SharedConfigPath(repo))
+	return err == nil && !info.IsDir()
+}
+
+// configEntry is a single parsed git-config line (key + value), preserving
+// multi-value order across a slice of entries.
+type configEntry struct {
+	key   string
+	value string
+}
+
+// parseConfigEntries turns `git config --get-regexp` output lines into ordered
+// (key, value) pairs, dropping blank lines. Git prints one line per value, so a
+// multi-value key appears as several consecutive entries in file order.
+func parseConfigEntries(lines []string) []configEntry {
+	var entries []configEntry
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, " ", 2)
+		value := ""
+		if len(parts) == 2 {
+			value = parts[1]
+		}
+		entries = append(entries, configEntry{key: parts[0], value: value})
+	}
+	return entries
+}
+
+// IsSharedManagedKey reports whether a gitflow.* key participates in the
+// shared-managed set that is copied between .gitflow and local .git/config.
+//
+// A key is shared-managed iff it is under gitflow. AND is not a gitflow.shared.*
+// control key AND is not per-branch runtime metadata (gitflow.branch.<name>.base,
+// written by Repo.SetBaseBranch). gitflow.version and gitflow.initialized are
+// shared-managed. Everything outside gitflow.* (core.*, alias.*, …) is not.
+func IsSharedManagedKey(key string) bool {
+	k := strings.ToLower(key)
+	if !strings.HasPrefix(k, "gitflow.") {
+		return false
+	}
+	if strings.HasPrefix(k, "gitflow.shared.") {
+		return false
+	}
+	// Per-branch runtime metadata: gitflow.branch.<actual-branch>.base. The
+	// branch name may contain dots, so match on the ".base" suffix — no real
+	// branch *definition* uses a ".base" property (definitions use type/parent/
+	// prefix/strategies).
+	if strings.HasPrefix(k, "gitflow.branch.") && strings.HasSuffix(k, ".base") {
+		return false
+	}
+	return true
+}
+
+// isHookPathKey reports whether a key points at an executable hook/filter path
+// that must not be copied from a committed .gitflow unless explicitly trusted.
+func isHookPathKey(key string) bool {
+	return strings.EqualFold(key, "gitflow.path.hooks")
+}
+
+// SharedTrustHooks reports whether gitflow.shared.trustHooks is set true in the
+// repository's merged git config.
+func SharedTrustHooks(repo *git.Repo) bool {
+	v, err := repo.GetConfig("gitflow.shared.trustHooks")
+	return err == nil && v == "true"
+}
+
+// SharedAutoInit reports whether gitflow.shared.autoInit is set true in the
+// repository's merged git config.
+func SharedAutoInit(repo *git.Repo) bool {
+	v, err := repo.GetConfig("gitflow.shared.autoInit")
+	return err == nil && v == "true"
+}
+
+// SharedConfigValid parses the .gitflow file and reports whether it is a valid
+// shared config: it must parse AND declare a non-empty gitflow.version. A parse
+// failure is returned as an error naming the file.
+func SharedConfigValid(repo *git.Repo) (bool, error) {
+	entries, err := readSharedEntriesRaw(repo)
+	if err != nil {
+		return false, err
+	}
+	for _, e := range entries {
+		if strings.EqualFold(e.key, "gitflow.version") && e.value != "" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// readSharedEntriesRaw returns every gitflow.* entry in the .gitflow file, in
+// order, or a parse error naming the file.
+func readSharedEntriesRaw(repo *git.Repo) ([]configEntry, error) {
+	path := SharedConfigPath(repo)
+	lines, err := git.GetConfigFileRegexpLines(path, "^gitflow\\.")
+	if err != nil {
+		return nil, fmt.Errorf("shared config file %s is invalid or unparsable: %w", path, err)
+	}
+	return parseConfigEntries(lines), nil
+}
+
+// readSharedManagedEntries returns the ordered shared-managed entries from the
+// .gitflow file (filtered by IsSharedManagedKey), or a parse error naming the
+// file.
+func readSharedManagedEntries(repo *git.Repo) ([]configEntry, error) {
+	entries, err := readSharedEntriesRaw(repo)
+	if err != nil {
+		return nil, err
+	}
+	var out []configEntry
+	for _, e := range entries {
+		if IsSharedManagedKey(e.key) {
+			out = append(out, e)
+		}
+	}
+	return out, nil
+}
+
+// SharedConfigHookPathKeys returns the distinct hook/filter path keys present in
+// the .gitflow file (e.g. gitflow.path.hooks). Used to refuse non-interactive
+// auto-init when an untrusted shared hook path is present.
+func SharedConfigHookPathKeys(repo *git.Repo) ([]string, error) {
+	entries, err := readSharedManagedEntries(repo)
+	if err != nil {
+		return nil, err
+	}
+	var keys []string
+	seen := map[string]bool{}
+	for _, e := range entries {
+		if isHookPathKey(e.key) && !seen[e.key] {
+			seen[e.key] = true
+			keys = append(keys, e.key)
+		}
+	}
+	return keys, nil
+}
+
+// CopyResult reports the outcome of a shared -> local copy.
+type CopyResult struct {
+	// SkippedHookKeys lists hook/filter path keys present in .gitflow that were
+	// not copied because gitflow.shared.trustHooks was not enabled.
+	SkippedHookKeys []string
+}
+
+// CopySharedToLocal copies the shared-managed gitflow.* keys from the repo's
+// .gitflow file into its local .git/config: it overwrites differing values,
+// reproduces multi-value order, and removes local shared-managed keys that are
+// absent from the effective shared set (stale removal). Hook/filter path keys are
+// copied only when gitflow.shared.trustHooks is enabled; otherwise they are
+// skipped (and stale-removed from local if previously copied) and reported in
+// CopyResult.SkippedHookKeys. Non-shared-managed keys (gitflow.shared.*, runtime
+// .base keys, and anything outside gitflow.*) are never touched.
+func CopySharedToLocal(repo *git.Repo) (CopyResult, error) {
+	var result CopyResult
+
+	entries, err := readSharedManagedEntries(repo)
+	if err != nil {
+		return result, err
+	}
+	trust := SharedTrustHooks(repo)
+
+	// Partition into effective (to copy) vs skipped hook keys, preserving order.
+	var effectiveOrder []string
+	effectiveValues := map[string][]string{}
+	skippedSeen := map[string]bool{}
+	for _, e := range entries {
+		if isHookPathKey(e.key) && !trust {
+			if !skippedSeen[e.key] {
+				skippedSeen[e.key] = true
+				result.SkippedHookKeys = append(result.SkippedHookKeys, e.key)
+			}
+			continue
+		}
+		if _, ok := effectiveValues[e.key]; !ok {
+			effectiveOrder = append(effectiveOrder, e.key)
+		}
+		effectiveValues[e.key] = append(effectiveValues[e.key], e.value)
+	}
+
+	// Apply each effective key: unset-all then add the values in order. This
+	// overwrites a differing local value and reproduces multi-value order.
+	for _, key := range effectiveOrder {
+		if err := repo.UnsetAllConfigIfPresent(key); err != nil {
+			return result, err
+		}
+		for _, v := range effectiveValues[key] {
+			if err := repo.AddConfig(key, v); err != nil {
+				return result, err
+			}
+		}
+	}
+
+	// Stale removal: drop local shared-managed keys not in the effective set.
+	localLines, err := repo.GetConfigLocalRegexpLines("^gitflow\\.")
+	if err != nil {
+		return result, err
+	}
+	removedSeen := map[string]bool{}
+	for _, e := range parseConfigEntries(localLines) {
+		if !IsSharedManagedKey(e.key) {
+			continue
+		}
+		if _, keep := effectiveValues[e.key]; keep {
+			continue
+		}
+		if removedSeen[e.key] {
+			continue
+		}
+		removedSeen[e.key] = true
+		if err := repo.UnsetAllConfigIfPresent(e.key); err != nil {
+			return result, err
+		}
+	}
+
+	return result, nil
+}
+
+// SharedStatus compares the shared-managed keys in the repo's local config
+// against its .gitflow file, applying the same hook-trust filter as the copy.
+// It returns whether the two are in sync, a sorted list of drifting keys, an
+// optional security note describing an intentionally-skipped untrusted hook path
+// (which is NOT counted as drift), and any parse error naming the file.
+func SharedStatus(repo *git.Repo) (inSync bool, diffs []string, note string, err error) {
+	fileEntries, err := readSharedManagedEntries(repo)
+	if err != nil {
+		return false, nil, "", err
+	}
+	trust := SharedTrustHooks(repo)
+
+	fileValues := map[string][]string{}
+	for _, e := range fileEntries {
+		if isHookPathKey(e.key) && !trust {
+			if note == "" {
+				note = fmt.Sprintf("shared hook path %q is present in .gitflow but skipped (set gitflow.shared.trustHooks=true to apply it)", e.key)
+			}
+			continue
+		}
+		fileValues[e.key] = append(fileValues[e.key], e.value)
+	}
+
+	localLines, err := repo.GetConfigLocalRegexpLines("^gitflow\\.")
+	if err != nil {
+		return false, nil, "", err
+	}
+	localValues := map[string][]string{}
+	for _, e := range parseConfigEntries(localLines) {
+		if !IsSharedManagedKey(e.key) {
+			continue
+		}
+		if isHookPathKey(e.key) && !trust {
+			continue
+		}
+		localValues[e.key] = append(localValues[e.key], e.value)
+	}
+
+	keySet := map[string]bool{}
+	for k := range fileValues {
+		keySet[k] = true
+	}
+	for k := range localValues {
+		keySet[k] = true
+	}
+	var keys []string
+	for k := range keySet {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		if !equalStringSlice(fileValues[k], localValues[k]) {
+			diffs = append(diffs, k)
+		}
+	}
+
+	return len(diffs) == 0, diffs, note, nil
+}
+
+// equalStringSlice reports whether two string slices are equal element-for-
+// element and in the same order (order-sensitive, for multi-value comparison).
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// IsUnconfiguredIgnoringShared reports whether the repository has no effective
+// git-flow configuration, deliberately ignoring gitflow.shared.* control keys.
+//
+// The repo counts as configured (returns false) if merged git config has a
+// non-empty gitflow.version, valid git-flow-avh config, or any git-flow-next
+// branch *definition* (a gitflow.branch.<name>.type key). A stray command key
+// (e.g. gitflow.feature.start.fetch) or a shared-control key alone does not count
+// as configuration, so the repo still reads as unconfigured (returns true).
+func IsUnconfiguredIgnoringShared(repo *git.Repo) (bool, error) {
+	if v, err := repo.GetConfig("gitflow.version"); err == nil && v != "" {
+		return false, nil
+	}
+	if CheckGitFlowAVHConfig(repo) {
+		return false, nil
+	}
+	lines, err := repo.GetConfigRegexpLines("^gitflow\\.branch\\.")
+	if err != nil {
+		return false, err
+	}
+	for _, e := range parseConfigEntries(lines) {
+		if strings.HasSuffix(strings.ToLower(e.key), ".type") {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// LoadSharedConfig loads the structured git-flow configuration from the .gitflow
+// file itself (not from git config). Used by the `config … --shared` CRUD verbs,
+// which edit the shared file and then re-sync it into local.
+func LoadSharedConfig(repo *git.Repo) (*Config, error) {
+	path := SharedConfigPath(repo)
+	allLines, err := git.GetConfigFileRegexpLines(path, "^gitflow\\.")
+	if err != nil {
+		return nil, fmt.Errorf("shared config file %s is invalid or unparsable: %w", path, err)
+	}
+
+	cfg := &Config{
+		Version:       "1.0",
+		Remote:        "origin",
+		CommandConfig: make(map[string]string),
+		Branches:      make(map[string]BranchConfig),
+	}
+	for _, e := range parseConfigEntries(allLines) {
+		cfg.CommandConfig[e.key] = e.value
+		if strings.EqualFold(e.key, "gitflow.version") && e.value != "" {
+			cfg.Version = e.value
+		}
+		if strings.EqualFold(e.key, "gitflow.origin") && e.value != "" {
+			cfg.Remote = e.value
+		}
+	}
+
+	branchLines, err := git.GetConfigFileRegexpLines(path, "^gitflow\\.branch\\.")
+	if err != nil {
+		return nil, fmt.Errorf("shared config file %s is invalid or unparsable: %w", path, err)
+	}
+	cfg.Branches = ParseBranchConfigLines(branchLines)
+	return cfg, nil
+}
+
+// SharedTopicTypes returns the names of topic branch types declared in the
+// repository's .gitflow file, or nil when the file is absent, unparsable, or
+// declares none. It is tolerant of errors so it can be called during command
+// registration on a fresh clone before activation.
+func SharedTopicTypes(repo *git.Repo) []string {
+	if !SharedConfigExists(repo) {
+		return nil
+	}
+	cfg, err := LoadSharedConfig(repo)
+	if err != nil {
+		return nil
+	}
+	var types []string
+	for name, branch := range cfg.Branches {
+		if branch.Type == string(BranchTypeTopic) {
+			types = append(types, name)
+		}
+	}
+	return types
+}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -50,6 +50,34 @@ func (e *EmptyBranchNameError) ExitCode() ExitCode {
 	return ExitCodeInvalidInput
 }
 
+// InvalidInputError indicates invalid user input with a custom message. It is a
+// typed error so callers get ExitCodeInvalidInput (2) instead of the default
+// git-error code.
+type InvalidInputError struct {
+	Message string
+}
+
+func (e *InvalidInputError) Error() string {
+	return e.Message
+}
+
+func (e *InvalidInputError) ExitCode() ExitCode {
+	return ExitCodeInvalidInput
+}
+
+// SharedConfigDriftError indicates that local git-flow config has drifted from
+// the committed .gitflow file. It carries the drift exit code (validation error)
+// so `config status` can signal drift distinctly from "not initialized".
+type SharedConfigDriftError struct{}
+
+func (e *SharedConfigDriftError) Error() string {
+	return "local git-flow configuration is out of sync with .gitflow (run 'git flow config sync')"
+}
+
+func (e *SharedConfigDriftError) ExitCode() ExitCode {
+	return ExitCodeValidationError
+}
+
 // InvalidBranchTypeError indicates an unknown branch type
 type InvalidBranchTypeError struct {
 	BranchType string

--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -147,6 +147,98 @@ func (r *Repo) GetConfigRegexpLines(pattern string) ([]string, error) {
 	return strings.Split(string(output), "\n"), nil
 }
 
+// GetConfigLocalRegexpLines returns the raw output lines of `git config --local
+// --get-regexp <pattern>` for the repository's local config only (.git/config),
+// or an empty slice when nothing matches. Multi-value keys yield one line per
+// value, in file order. Used by the shared-config copy/status logic, which must
+// distinguish local keys from merged (global/system) ones.
+func (r *Repo) GetConfigLocalRegexpLines(pattern string) ([]string, error) {
+	output, err := r.gitCmd("config", "--local", "--get-regexp", pattern).Output()
+	if err != nil {
+		if strings.Contains(err.Error(), "exit status 1") {
+			return []string{}, nil
+		}
+		return nil, fmt.Errorf("failed to get local git config matching %s: %w", pattern, err)
+	}
+	return strings.Split(string(output), "\n"), nil
+}
+
+// AddConfig adds a value to a (possibly multi-value) Git config key in local
+// scope with `git config --add`. Unlike SetConfig it never replaces existing
+// values, so callers can reproduce an ordered multi-value list by unsetting then
+// adding each value in order.
+func (r *Repo) AddConfig(key, value string) error {
+	if _, err := r.gitCmd("config", "--add", key, value).Output(); err != nil {
+		return fmt.Errorf("failed to add git config %s: %w", key, err)
+	}
+	return nil
+}
+
+// UnsetAllConfigIfPresent removes all values of a key from local config with
+// `git config --local --unset-all`, treating an absent key (exit 5) as a no-op.
+// This is the multi-value-safe counterpart to UnsetConfigIfPresent.
+func (r *Repo) UnsetAllConfigIfPresent(key string) error {
+	_, err := r.gitCmd("config", "--local", "--unset-all", key).Output()
+	if err != nil {
+		// exit 5 = key does not exist in the given scope: nothing to remove.
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 5 {
+			return nil
+		}
+		return fmt.Errorf("failed to unset-all git config %s: %w", key, err)
+	}
+	return nil
+}
+
+// GetConfigFileRegexpLines returns the raw output lines of `git config --file
+// <filePath> --get-regexp <pattern>`, or an empty slice when nothing matches.
+// A non-"no match" failure (e.g. an unparsable file) is returned as an error so
+// callers can surface a clear message naming the file. Multi-value keys yield one
+// line per value, in file order.
+func GetConfigFileRegexpLines(filePath, pattern string) ([]string, error) {
+	output, err := gitCommand("", "config", "--file", filePath, "--get-regexp", pattern).Output()
+	if err != nil {
+		// exit 1 = no matching keys (a valid, possibly empty result).
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return []string{}, nil
+		}
+		return nil, fmt.Errorf("failed to read git config from %s: %w", filePath, err)
+	}
+	return strings.Split(string(output), "\n"), nil
+}
+
+// GetConfigFileAllValues returns all values for a key from a file-scoped config,
+// in order, or an empty slice when unset.
+func GetConfigFileAllValues(filePath, key string) ([]string, error) {
+	output, err := gitCommand("", "config", "--file", filePath, "--get-all", key).Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return []string{}, nil
+		}
+		return nil, fmt.Errorf("failed to read git config %s from %s: %w", key, filePath, err)
+	}
+	var values []string
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if line != "" {
+			values = append(values, line)
+		}
+	}
+	return values, nil
+}
+
+// UnsetConfigSectionFile removes an entire section from a file-scoped config with
+// `git config --file <filePath> --remove-section <section>`, treating a missing
+// section (exit 128) as a no-op.
+func UnsetConfigSectionFile(filePath, section string) error {
+	_, err := gitCommand("", "config", "--file", filePath, "--remove-section", section).Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 128 {
+			return nil
+		}
+		return fmt.Errorf("failed to remove section %s from %s: %w", section, filePath, err)
+	}
+	return nil
+}
+
 // UnsetConfig unsets a Git config value
 func (r *Repo) UnsetConfig(key string) error {
 	if _, err := r.gitCmd("config", "--unset", key).Output(); err != nil {

--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -155,7 +155,8 @@ func (r *Repo) GetConfigRegexpLines(pattern string) ([]string, error) {
 func (r *Repo) GetConfigLocalRegexpLines(pattern string) ([]string, error) {
 	output, err := r.gitCmd("config", "--local", "--get-regexp", pattern).Output()
 	if err != nil {
-		if strings.Contains(err.Error(), "exit status 1") {
+		// exit 1 = no matching keys (a valid, possibly empty result).
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
 			return []string{}, nil
 		}
 		return nil, fmt.Errorf("failed to get local git config matching %s: %w", pattern, err)
@@ -168,7 +169,7 @@ func (r *Repo) GetConfigLocalRegexpLines(pattern string) ([]string, error) {
 // values, so callers can reproduce an ordered multi-value list by unsetting then
 // adding each value in order.
 func (r *Repo) AddConfig(key, value string) error {
-	if _, err := r.gitCmd("config", "--add", key, value).Output(); err != nil {
+	if _, err := r.gitCmd("config", "--local", "--add", key, value).Output(); err != nil {
 		return fmt.Errorf("failed to add git config %s: %w", key, err)
 	}
 	return nil

--- a/test/cmd/config_shared_crud_test.go
+++ b/test/cmd/config_shared_crud_test.go
@@ -223,6 +223,40 @@ func TestConfigEditTopicSharedFreshCloneNoLocalInit(t *testing.T) {
 	}
 }
 
+// TestConfigNestedLeafFreshCloneNoActivation guards the first-run exemption for
+// NESTED config leaves: `config add topic` sits two levels below `config`, so a
+// direct-parent-only exemption would let first-run activation fire for it. On a
+// fresh clone that has autoInit=true set locally, a wrongly-fired activation
+// would auto-copy the shared config and print an "auto-initialized" notice
+// before the command runs. The config verb must stay exempt: no notice, and the
+// edit targets .gitflow directly.
+// Steps:
+// 1. Fresh clone carrying a committed .gitflow, no local gitflow.* keys, autoInit=true local
+// 2. Runs 'config add topic qa develop --shared'
+// 3. Verifies no auto-init notice, success, and gitflow.branch.qa lands in .gitflow
+func TestConfigNestedLeafFreshCloneNoActivation(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupFreshCloneWithShared(t, testutil.AuthorSharedConfig(t))
+	defer testutil.CleanupTestRepo(t, dir)
+
+	// autoInit is a local control key, so it survives ClearLocalGitflowConfig's
+	// job here: if activation wrongly fired it would take the auto-init branch.
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.shared.autoInit", "true"); err != nil {
+		t.Fatalf("failed to set autoInit: %v", err)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "add", "topic", "qa", "develop", "--shared")
+	if err != nil {
+		t.Fatalf("config add topic --shared on fresh clone failed: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "auto-initialized") {
+		t.Errorf("expected no first-run activation for a nested config command, got: %s", out)
+	}
+	if v := testutil.SharedConfigValue(t, dir, "gitflow.branch.qa.type"); v != "topic" {
+		t.Errorf("expected .gitflow qa.type=topic, got %q", v)
+	}
+}
+
 // TestConfigAddBaseSharedAddsBaseAndSyncs covers scenario 30base-a: config add
 // base --shared adds a base branch to .gitflow, re-syncs local, and creates the branch.
 // Steps:

--- a/test/cmd/config_shared_crud_test.go
+++ b/test/cmd/config_shared_crud_test.go
@@ -1,0 +1,314 @@
+package cmd_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// TestConfigEditTopicSharedUpdatesFileAndLocal covers scenario 26: config edit
+// topic --shared updates .gitflow, re-syncs local, and the new prefix takes effect.
+// Steps:
+// 1. init --shared --defaults
+// 2. Runs 'config edit topic feature --shared --prefix feat/', then 'feature start x'
+// 3. Verifies .gitflow and local prefix are feat/ and feat/x is created
+func TestConfigEditTopicSharedUpdatesFileAndLocal(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "config", "edit", "topic", "feature", "--shared", "--prefix", "feat/"); err != nil {
+		t.Fatalf("config edit topic --shared failed: %v\n%s", err, out)
+	}
+	if v := testutil.SharedConfigValue(t, dir, "gitflow.branch.feature.prefix"); v != "feat/" {
+		t.Errorf("expected .gitflow feature.prefix=feat/, got %q", v)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.feature.prefix"); v != "feat/" {
+		t.Errorf("expected local feature.prefix=feat/, got %q", v)
+	}
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "start", "x"); err != nil {
+		t.Fatalf("feature start failed: %v\n%s", err, out)
+	}
+	if !testutil.BranchExists(t, dir, "feat/x") {
+		t.Error("expected feat/x to be created with the new prefix")
+	}
+}
+
+// TestConfigAddTopicSharedAddsTypeAndSyncs covers scenario 27: config add topic
+// --shared adds a type to .gitflow, re-syncs local, and the new type works.
+// Steps:
+// 1. init --shared --defaults
+// 2. Runs 'config add topic qa develop --shared', then 'qa start x'
+// 3. Verifies .gitflow and local carry gitflow.branch.qa.* and qa/x is created
+func TestConfigAddTopicSharedAddsTypeAndSyncs(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "config", "add", "topic", "qa", "develop", "--shared"); err != nil {
+		t.Fatalf("config add topic --shared failed: %v\n%s", err, out)
+	}
+	if v := testutil.SharedConfigValue(t, dir, "gitflow.branch.qa.type"); v != "topic" {
+		t.Errorf("expected .gitflow qa.type=topic, got %q", v)
+	}
+	if !testutil.GitConfigHasPrefix(t, dir, "gitflow.branch.qa.") {
+		t.Error("expected local re-synced with gitflow.branch.qa.*")
+	}
+	if out, err := testutil.RunGitFlow(t, dir, "qa", "start", "x"); err != nil {
+		t.Fatalf("qa start failed: %v\n%s", err, out)
+	}
+	if !testutil.BranchExists(t, dir, "qa/x") {
+		t.Error("expected qa/x to be created")
+	}
+}
+
+// TestConfigRenameTopicSharedFileOnly covers scenario 28a: config rename topic
+// --shared edits only .gitflow + re-syncs; a local-only control key is preserved
+// and a local-only shared-managed key is stale-removed (not pushed up).
+// Steps:
+// 1. init --shared --defaults, set local-only gitflow.shared.autoInit and gitflow.feature.start.fetch
+// 2. Runs 'config rename topic feature feat --shared'
+// 3. Verifies .gitflow renamed feature->feat, local synced, autoInit preserved, start.fetch removed and not in .gitflow
+func TestConfigRenameTopicSharedFileOnly(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.shared.autoInit", "true"); err != nil {
+		t.Fatalf("set autoInit: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.feature.start.fetch", "true"); err != nil {
+		t.Fatalf("set local start.fetch: %v", err)
+	}
+
+	if out, err := testutil.RunGitFlow(t, dir, "config", "rename", "topic", "feature", "feat", "--shared"); err != nil {
+		t.Fatalf("config rename topic --shared failed: %v\n%s", err, out)
+	}
+
+	if !testutil.SharedConfigHasPrefix(t, dir, "gitflow.branch.feat.") {
+		t.Error("expected .gitflow to have gitflow.branch.feat.*")
+	}
+	if testutil.SharedConfigHasPrefix(t, dir, "gitflow.branch.feature.") {
+		t.Error("expected .gitflow to no longer have gitflow.branch.feature.*")
+	}
+	if !testutil.GitConfigHasPrefix(t, dir, "gitflow.branch.feat.") {
+		t.Error("expected local re-synced with gitflow.branch.feat.*")
+	}
+	if testutil.GitConfigHasPrefix(t, dir, "gitflow.branch.feature.") {
+		t.Error("expected local gitflow.branch.feature.* removed by re-sync")
+	}
+	// Control key: never shared-managed, preserved locally, not written to .gitflow.
+	if v := testutil.GitConfigValue(t, dir, "gitflow.shared.autoInit"); v != "true" {
+		t.Errorf("expected local autoInit preserved, got %q", v)
+	}
+	if testutil.SharedConfigValue(t, dir, "gitflow.shared.autoInit") != "" {
+		t.Error("expected gitflow.shared.autoInit NOT written into .gitflow")
+	}
+	// Local-only shared-managed key: stale-removed and never pushed up.
+	if testutil.GitConfigExists(t, dir, "gitflow.feature.start.fetch") {
+		t.Error("expected local-only gitflow.feature.start.fetch removed by re-sync")
+	}
+	if testutil.SharedConfigValue(t, dir, "gitflow.feature.start.fetch") != "" {
+		t.Error("expected gitflow.feature.start.fetch NOT pushed up into .gitflow")
+	}
+}
+
+// TestConfigDeleteTopicSharedFileOnly covers scenario 28b: config delete topic
+// --shared removes the section from .gitflow and re-syncs local.
+// Steps:
+// 1. init --shared --defaults, add a qa topic via --shared
+// 2. Runs 'config delete topic qa --shared'
+// 3. Verifies qa.* gone from both .gitflow and local, feature defaults remain in both
+func TestConfigDeleteTopicSharedFileOnly(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	if out, err := testutil.RunGitFlow(t, dir, "config", "add", "topic", "qa", "develop", "--shared"); err != nil {
+		t.Fatalf("config add topic qa --shared failed: %v\n%s", err, out)
+	}
+
+	if out, err := testutil.RunGitFlow(t, dir, "config", "delete", "topic", "qa", "--shared"); err != nil {
+		t.Fatalf("config delete topic qa --shared failed: %v\n%s", err, out)
+	}
+	if testutil.SharedConfigHasPrefix(t, dir, "gitflow.branch.qa.") {
+		t.Error("expected .gitflow to no longer have gitflow.branch.qa.*")
+	}
+	if testutil.GitConfigHasPrefix(t, dir, "gitflow.branch.qa.") {
+		t.Error("expected local to no longer have gitflow.branch.qa.*")
+	}
+	if testutil.SharedConfigValue(t, dir, "gitflow.branch.feature.type") != "topic" {
+		t.Error("expected feature defaults to remain in .gitflow")
+	}
+	if testutil.GitConfigValue(t, dir, "gitflow.branch.feature.type") != "topic" {
+		t.Error("expected feature defaults to remain in local")
+	}
+}
+
+// TestConfigEditLocalOnlyCausesDrift covers scenario 29: config edit WITHOUT
+// --shared writes local only; status then reports drift.
+// Steps:
+// 1. init --shared --defaults
+// 2. Runs 'config edit topic feature --prefix feat/' (no --shared), then 'config status'
+// 3. Verifies .gitflow unchanged, local is feat/, and status reports drift with exit 6
+func TestConfigEditLocalOnlyCausesDrift(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "config", "edit", "topic", "feature", "--prefix", "feat/"); err != nil {
+		t.Fatalf("config edit topic (local) failed: %v\n%s", err, out)
+	}
+	if v := testutil.SharedConfigValue(t, dir, "gitflow.branch.feature.prefix"); v != "feature/" {
+		t.Errorf("expected .gitflow feature.prefix unchanged (feature/), got %q", v)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.feature.prefix"); v != "feat/" {
+		t.Errorf("expected local feature.prefix=feat/, got %q", v)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "status")
+	if err == nil {
+		t.Fatalf("expected drift after a local-only edit, got success\n%s", out)
+	}
+	assertExitCode(t, err, 6)
+}
+
+// TestConfigAddTopicSharedWithoutFileErrors covers scenario 30: config add topic
+// --shared without a .gitflow errors, suggests init --shared, and creates no file.
+// Steps:
+// 1. init --defaults (local only, no .gitflow)
+// 2. Runs 'config add topic qa develop --shared'
+// 3. Verifies non-zero exit, a message suggesting init --shared, and no .gitflow created
+func TestConfigAddTopicSharedWithoutFileErrors(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("init --defaults failed: %v\n%s", err, out)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "add", "topic", "qa", "develop", "--shared")
+	if err == nil {
+		t.Fatalf("expected --shared without .gitflow to fail, got success\n%s", out)
+	}
+	if !strings.Contains(out, "init --shared") {
+		t.Errorf("expected a message suggesting 'git flow init --shared', got: %s", out)
+	}
+	if _, statErr := os.Stat(testutil.SharedConfigPath(dir)); statErr == nil {
+		t.Error("expected no .gitflow to be created")
+	}
+}
+
+// TestConfigAddBaseSharedAddsBaseAndSyncs covers scenario 30base-a: config add
+// base --shared adds a base branch to .gitflow, re-syncs local, and creates the branch.
+// Steps:
+// 1. init --shared --defaults
+// 2. Runs 'config add base staging main --shared'
+// 3. Verifies .gitflow and local carry gitflow.branch.staging.* (parent=main) and staging exists
+func TestConfigAddBaseSharedAddsBaseAndSyncs(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "config", "add", "base", "staging", "main", "--shared"); err != nil {
+		t.Fatalf("config add base --shared failed: %v\n%s", err, out)
+	}
+	if v := testutil.SharedConfigValue(t, dir, "gitflow.branch.staging.type"); v != "base" {
+		t.Errorf("expected .gitflow staging.type=base, got %q", v)
+	}
+	if v := testutil.SharedConfigValue(t, dir, "gitflow.branch.staging.parent"); v != "main" {
+		t.Errorf("expected .gitflow staging.parent=main, got %q", v)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.staging.parent"); v != "main" {
+		t.Errorf("expected local staging.parent=main, got %q", v)
+	}
+	if !testutil.BranchExists(t, dir, "staging") {
+		t.Error("expected the staging branch to be created")
+	}
+}
+
+// TestConfigEditBaseSharedUpdatesFileAndLocal covers scenario 30base-b: config
+// edit base --shared updates .gitflow and re-syncs local.
+// Steps:
+// 1. init --shared --defaults (develop has autoUpdate)
+// 2. Runs 'config edit base develop --auto-update=false --shared'
+// 3. Verifies develop.autoUpdate=false in both .gitflow and local
+func TestConfigEditBaseSharedUpdatesFileAndLocal(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "config", "edit", "base", "develop", "--auto-update=false", "--shared"); err != nil {
+		t.Fatalf("config edit base --shared failed: %v\n%s", err, out)
+	}
+	if v := testutil.SharedConfigValue(t, dir, "gitflow.branch.develop.autoUpdate"); v != "false" {
+		t.Errorf("expected .gitflow develop.autoUpdate=false, got %q", v)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.develop.autoupdate"); v != "false" {
+		t.Errorf("expected local develop.autoUpdate=false, got %q", v)
+	}
+}
+
+// TestConfigRenameBaseSharedFileOnly covers scenario 30base-c: config rename base
+// --shared renames the section in .gitflow and re-syncs local.
+// Steps:
+// 1. init --shared --defaults, add a staging base via --shared
+// 2. Runs 'config rename base staging stage --shared'
+// 3. Verifies .gitflow and local have stage.* and not staging.*
+func TestConfigRenameBaseSharedFileOnly(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	if out, err := testutil.RunGitFlow(t, dir, "config", "add", "base", "staging", "main", "--shared"); err != nil {
+		t.Fatalf("config add base staging --shared failed: %v\n%s", err, out)
+	}
+
+	if out, err := testutil.RunGitFlow(t, dir, "config", "rename", "base", "staging", "stage", "--shared"); err != nil {
+		t.Fatalf("config rename base --shared failed: %v\n%s", err, out)
+	}
+	if !testutil.SharedConfigHasPrefix(t, dir, "gitflow.branch.stage.") {
+		t.Error("expected .gitflow to have gitflow.branch.stage.*")
+	}
+	if testutil.SharedConfigHasPrefix(t, dir, "gitflow.branch.staging.") {
+		t.Error("expected .gitflow to no longer have gitflow.branch.staging.*")
+	}
+	if !testutil.GitConfigHasPrefix(t, dir, "gitflow.branch.stage.") {
+		t.Error("expected local to have gitflow.branch.stage.*")
+	}
+	if testutil.GitConfigHasPrefix(t, dir, "gitflow.branch.staging.") {
+		t.Error("expected local to no longer have gitflow.branch.staging.*")
+	}
+}
+
+// TestConfigDeleteBaseSharedFileOnly covers scenario 30base-d: config delete base
+// --shared removes the section from .gitflow and re-syncs local.
+// Steps:
+// 1. init --shared --defaults, add a staging base via --shared
+// 2. Runs 'config delete base staging --shared'
+// 3. Verifies staging.* gone from both, and core bases main/develop remain in both
+func TestConfigDeleteBaseSharedFileOnly(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	if out, err := testutil.RunGitFlow(t, dir, "config", "add", "base", "staging", "main", "--shared"); err != nil {
+		t.Fatalf("config add base staging --shared failed: %v\n%s", err, out)
+	}
+
+	if out, err := testutil.RunGitFlow(t, dir, "config", "delete", "base", "staging", "--shared"); err != nil {
+		t.Fatalf("config delete base --shared failed: %v\n%s", err, out)
+	}
+	if testutil.SharedConfigHasPrefix(t, dir, "gitflow.branch.staging.") {
+		t.Error("expected .gitflow to no longer have gitflow.branch.staging.*")
+	}
+	if testutil.GitConfigHasPrefix(t, dir, "gitflow.branch.staging.") {
+		t.Error("expected local to no longer have gitflow.branch.staging.*")
+	}
+	for _, base := range []string{"main", "develop"} {
+		if testutil.SharedConfigValue(t, dir, "gitflow.branch."+base+".type") != "base" {
+			t.Errorf("expected core base %q to remain in .gitflow", base)
+		}
+		if testutil.GitConfigValue(t, dir, "gitflow.branch."+base+".type") != "base" {
+			t.Errorf("expected core base %q to remain in local", base)
+		}
+	}
+}

--- a/test/cmd/config_shared_crud_test.go
+++ b/test/cmd/config_shared_crud_test.go
@@ -199,6 +199,30 @@ func TestConfigAddTopicSharedWithoutFileErrors(t *testing.T) {
 	}
 }
 
+// TestConfigEditTopicSharedFreshCloneNoLocalInit covers Imp-4: shared CRUD must
+// not be gated on local git-flow init. On a FRESH CLONE (committed .gitflow with a
+// feature type, NO local init), 'config edit topic feature --shared --prefix=feat/'
+// must succeed, update .gitflow, and re-sync local.
+// Steps:
+// 1. Fresh clone carrying a committed .gitflow, no local gitflow.* keys
+// 2. Runs 'config edit topic feature --shared --prefix=feat/'
+// 3. Verifies success, .gitflow feature.prefix=feat/, and local re-synced to feat/
+func TestConfigEditTopicSharedFreshCloneNoLocalInit(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupFreshCloneWithShared(t, testutil.AuthorSharedConfig(t))
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "config", "edit", "topic", "feature", "--shared", "--prefix=feat/"); err != nil {
+		t.Fatalf("expected shared edit to succeed without local init, got: %v\n%s", err, out)
+	}
+	if v := testutil.SharedConfigValue(t, dir, "gitflow.branch.feature.prefix"); v != "feat/" {
+		t.Errorf("expected .gitflow feature.prefix=feat/, got %q", v)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.feature.prefix"); v != "feat/" {
+		t.Errorf("expected local re-synced feature.prefix=feat/, got %q", v)
+	}
+}
+
 // TestConfigAddBaseSharedAddsBaseAndSyncs covers scenario 30base-a: config add
 // base --shared adds a base branch to .gitflow, re-syncs local, and creates the branch.
 // Steps:

--- a/test/cmd/config_sync_status_test.go
+++ b/test/cmd/config_sync_status_test.go
@@ -41,13 +41,45 @@ func TestConfigSyncAddsMissingLocalValue(t *testing.T) {
 	}
 }
 
-// TestConfigSyncRemovesStaleKeys covers scenario 20: sync removes a stale branch
-// type and a dropped multi-value entry.
+// TestConfigSyncRemovesStaleBranchType covers scenario 20a: sync removes a stale
+// branch type that is absent from .gitflow. (One behavior: stale branch-type
+// section removal on sync.)
 // Steps:
-// 1. init --shared --defaults, add a push-option [a,b] and a qa type to both file and local
-// 2. Edits .gitflow to remove the qa type and drop the b push-option value
-// 3. Runs 'git flow config sync' and verifies qa.* is gone and push-option is [a] only
-func TestConfigSyncRemovesStaleKeys(t *testing.T) {
+// 1. init --shared --defaults, add a custom qa type to .gitflow+local via config add topic --shared
+// 2. Removes the qa section from .gitflow
+// 3. Runs 'git flow config sync' and verifies qa.* is gone while feature defaults remain
+func TestConfigSyncRemovesStaleBranchType(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "config", "add", "topic", "qa", "develop", "--shared"); err != nil {
+		t.Fatalf("config add topic qa --shared failed: %v\n%s", err, out)
+	}
+
+	sharedPath := testutil.SharedConfigPath(dir)
+	if _, err := testutil.RunGit(t, dir, "config", "--file", sharedPath, "--remove-section", "gitflow.branch.qa"); err != nil {
+		t.Fatalf("remove qa section: %v", err)
+	}
+
+	if out, err := testutil.RunGitFlow(t, dir, "config", "sync"); err != nil {
+		t.Fatalf("config sync failed: %v\n%s", err, out)
+	}
+	if testutil.GitConfigHasPrefix(t, dir, "gitflow.branch.qa.") {
+		t.Error("expected stale local gitflow.branch.qa.* to be removed")
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.feature.prefix"); v != "feature/" {
+		t.Errorf("expected feature defaults to remain, got feature.prefix=%q", v)
+	}
+}
+
+// TestConfigSyncRemovesDroppedMultiValue covers scenario 20b: sync removes a
+// dropped multi-value entry (multi-value shrink).
+// Steps:
+// 1. init --shared --defaults, set push-option [a,b] in .gitflow and sync so local has [a,b]
+// 2. Drops b from .gitflow, leaving [a]
+// 3. Runs 'git flow config sync' and verifies local push-option is [a] only
+func TestConfigSyncRemovesDroppedMultiValue(t *testing.T) {
 	t.Parallel()
 	dir := initSharedDefaults(t)
 	defer testutil.CleanupTestRepo(t, dir)
@@ -59,17 +91,11 @@ func TestConfigSyncRemovesStaleKeys(t *testing.T) {
 	if _, err := testutil.RunGit(t, dir, "config", "--file", sharedPath, "--add", "gitflow.feature.publish.push-option", "b"); err != nil {
 		t.Fatalf("add push-option b: %v", err)
 	}
-	if out, err := testutil.RunGitFlow(t, dir, "config", "add", "topic", "qa", "develop", "--shared"); err != nil {
-		t.Fatalf("config add topic qa --shared failed: %v\n%s", err, out)
-	}
 	if out, err := testutil.RunGitFlow(t, dir, "config", "sync"); err != nil {
 		t.Fatalf("initial sync failed: %v\n%s", err, out)
 	}
 
-	// Shrink .gitflow: drop the qa type and the b push-option value.
-	if _, err := testutil.RunGit(t, dir, "config", "--file", sharedPath, "--remove-section", "gitflow.branch.qa"); err != nil {
-		t.Fatalf("remove qa section: %v", err)
-	}
+	// Drop b from .gitflow, leaving [a].
 	if _, err := testutil.RunGit(t, dir, "config", "--file", sharedPath, "--unset-all", "gitflow.feature.publish.push-option"); err != nil {
 		t.Fatalf("unset push-option: %v", err)
 	}
@@ -79,9 +105,6 @@ func TestConfigSyncRemovesStaleKeys(t *testing.T) {
 
 	if out, err := testutil.RunGitFlow(t, dir, "config", "sync"); err != nil {
 		t.Fatalf("config sync failed: %v\n%s", err, out)
-	}
-	if testutil.GitConfigHasPrefix(t, dir, "gitflow.branch.qa.") {
-		t.Error("expected stale local gitflow.branch.qa.* to be removed")
 	}
 	local := testutil.GitConfigAll(t, dir, "gitflow.feature.publish.push-option")
 	if len(local) != 1 || local[0] != "a" {
@@ -351,6 +374,40 @@ func TestSharedFileMalformedClearErrorSync(t *testing.T) {
 	}
 	if testutil.GitConfigHasPrefix(t, dir, "gitflow.branch.") {
 		t.Error("expected no partial gitflow.branch.* mutation on malformed-file sync")
+	}
+}
+
+// TestSharedFileMalformedClearErrorStatus covers scenario 35c: a malformed
+// .gitflow fails at config status with a clear error naming the file, and is NOT
+// misreported as in-sync (exit 0) nor as ordinary drift (ExitCodeValidationError)
+// — a parse failure is a distinct, clearly-named error.
+// Steps:
+// 1. init --defaults first (so the first-run hook no-ops), THEN write an unparsable .gitflow
+// 2. Runs 'git flow config status'
+// 3. Verifies non-zero exit, an error naming .gitflow, a non-drift exit code, and no local gitflow.* mutation
+func TestSharedFileMalformedClearErrorStatus(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("init --defaults failed: %v\n%s", err, out)
+	}
+	if err := os.WriteFile(testutil.SharedConfigPath(dir), []byte("[gitflow\nbroken = = =\n"), 0644); err != nil {
+		t.Fatalf("write malformed .gitflow: %v", err)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "status")
+	if err == nil {
+		t.Fatalf("expected config status to fail on malformed .gitflow, not report in-sync\n%s", out)
+	}
+	if ee, ok := err.(*testutil.ExitError); ok && ee.ExitCode == int(errors.ExitCodeValidationError) {
+		t.Errorf("expected a distinct parse-error exit code, not ordinary drift (%d): %s", int(errors.ExitCodeValidationError), out)
+	}
+	if !strings.Contains(out, ".gitflow") {
+		t.Errorf("expected error naming .gitflow, got: %s", out)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.feature.prefix"); v != "feature/" {
+		t.Errorf("expected local gitflow.* unchanged (feature.prefix=feature/), got %q", v)
 	}
 }
 

--- a/test/cmd/config_sync_status_test.go
+++ b/test/cmd/config_sync_status_test.go
@@ -466,6 +466,109 @@ func TestConfigStatusUntrustedHookNotDrift(t *testing.T) {
 	}
 }
 
+// TestConfigStatusFreshCloneReadOnlyReportsDrift covers Imp-1: config status on a
+// FRESH CLONE (committed .gitflow, no local gitflow.* keys) with
+// gitflow.shared.autoInit=true must stay read-only — it must NOT auto-activate —
+// and must report drift because local lacks the shared keys.
+// Steps:
+// 1. Fresh clone carrying a committed .gitflow, set local gitflow.shared.autoInit=true
+// 2. Runs 'git flow config status'
+// 3. Verifies no activation (no gitflow.branch.* copied, no activation notice) and drift, exit 6
+func TestConfigStatusFreshCloneReadOnlyReportsDrift(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupFreshCloneWithShared(t, testutil.AuthorSharedConfig(t))
+	defer testutil.CleanupTestRepo(t, dir)
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.shared.autoInit", "true"); err != nil {
+		t.Fatalf("set autoInit: %v", err)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "status")
+	if err == nil {
+		t.Fatalf("expected config status to report drift on a fresh clone, got success\n%s", out)
+	}
+	assertExitCode(t, err, errors.ExitCodeValidationError)
+	// Read-only: config status must not have auto-activated despite autoInit=true.
+	if testutil.GitConfigHasPrefix(t, dir, "gitflow.branch.") {
+		t.Error("expected config status to NOT copy any gitflow.branch.* keys (must be read-only)")
+	}
+	if strings.Contains(out, "auto-initialized") {
+		t.Errorf("expected no activation notice from config status, got: %s", out)
+	}
+}
+
+// TestConfigSyncFreshCloneUntrustedHookSucceeds covers Imp-1: config sync on a
+// fresh clone with gitflow.shared.autoInit=true AND an untrusted hook path in
+// .gitflow must SUCCEED (not be refused by activation) — it copies the non-hook
+// keys and skips the untrusted hook. Before the fix, activateAutoInit refused
+// before sync could run.
+// Steps:
+// 1. Fresh clone with a committed .gitflow that ALSO declares gitflow.path.hooks; set local autoInit=true
+// 2. Runs 'git flow config sync'
+// 3. Verifies exit 0, a normal key (feature.prefix) synced, the hook NOT copied, and a skipped-hook warning
+func TestConfigSyncFreshCloneUntrustedHookSucceeds(t *testing.T) {
+	t.Parallel()
+	// Author a .gitflow that includes an untrusted hook path, then drop it into a
+	// fresh clone (no local init).
+	shared := testutil.AuthorSharedConfig(t)
+	dir := testutil.SetupFreshCloneWithShared(t, shared)
+	defer testutil.CleanupTestRepo(t, dir)
+	testutil.SharedConfigSet(t, dir, "gitflow.path.hooks", "/some/hooks")
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.shared.autoInit", "true"); err != nil {
+		t.Fatalf("set autoInit: %v", err)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "sync")
+	if err != nil {
+		t.Fatalf("expected config sync to succeed despite untrusted hook, got: %v\n%s", err, out)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.feature.prefix"); v != "feature/" {
+		t.Errorf("expected non-hook keys synced (feature.prefix=feature/), got %q", v)
+	}
+	if testutil.GitConfigExists(t, dir, "gitflow.path.hooks") {
+		t.Error("expected untrusted gitflow.path.hooks NOT copied to local")
+	}
+	if !strings.Contains(out, "gitflow.shared.trustHooks") {
+		t.Errorf("expected a skipped-hook warning naming gitflow.shared.trustHooks, got: %s", out)
+	}
+}
+
+// TestConfigStatusStaleHookAfterTrustRevokedIsDrift covers Imp-3: after a trusted
+// hook path is copied to local and trust is then revoked, config status must
+// report the stale local hook as drift (the file/expected map filters it out, the
+// local map does not).
+// Steps:
+// 1. init --shared --defaults, add gitflow.path.hooks, set trustHooks=true, sync (copies the hook to local)
+// 2. Unset trustHooks, then run 'git flow config status'
+// 3. Verifies OUT OF SYNC naming gitflow.path.hooks, exit 6
+func TestConfigStatusStaleHookAfterTrustRevokedIsDrift(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	testutil.SharedConfigSet(t, dir, "gitflow.path.hooks", "/some/hooks")
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.shared.trustHooks", "true"); err != nil {
+		t.Fatalf("set trustHooks: %v", err)
+	}
+	if out, err := testutil.RunGitFlow(t, dir, "config", "sync"); err != nil {
+		t.Fatalf("sync (trusted) failed: %v\n%s", err, out)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.path.hooks"); v != "/some/hooks" {
+		t.Fatalf("precondition: expected hook copied to local when trusted, got %q", v)
+	}
+
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "--unset", "gitflow.shared.trustHooks"); err != nil {
+		t.Fatalf("unset trustHooks: %v", err)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "status")
+	if err == nil {
+		t.Fatalf("expected drift for a stale local hook after trust revoked, got success\n%s", out)
+	}
+	assertExitCode(t, err, errors.ExitCodeValidationError)
+	if !strings.Contains(out, "gitflow.path.hooks") {
+		t.Errorf("expected drift to name gitflow.path.hooks, got: %s", out)
+	}
+}
+
 // TestSharedSyncRemovesHookPathAfterTrustRevoked covers scenario 17d: revoking
 // trustHooks removes a previously-copied hook path on the next sync.
 // Steps:

--- a/test/cmd/config_sync_status_test.go
+++ b/test/cmd/config_sync_status_test.go
@@ -1,0 +1,449 @@
+package cmd_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gittower/git-flow-next/internal/errors"
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// initSharedDefaults sets up a repo initialized via `git flow init --shared
+// --defaults` (local config already matches .gitflow) and returns its directory.
+func initSharedDefaults(t *testing.T) string {
+	t.Helper()
+	dir := testutil.SetupTestRepo(t)
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--shared", "--defaults"); err != nil {
+		testutil.CleanupTestRepo(t, dir)
+		t.Fatalf("init --shared failed: %v\n%s", err, out)
+	}
+	return dir
+}
+
+// TestConfigSyncAddsMissingLocalValue covers scenario 19: sync pulls a value
+// present in .gitflow but absent locally.
+// Steps:
+// 1. init --shared --defaults, then add gitflow.feature.start.fetch=true only to .gitflow
+// 2. Runs 'git flow config sync'
+// 3. Verifies local gitflow.feature.start.fetch=true
+func TestConfigSyncAddsMissingLocalValue(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	testutil.SharedConfigSet(t, dir, "gitflow.feature.start.fetch", "true")
+
+	if out, err := testutil.RunGitFlow(t, dir, "config", "sync"); err != nil {
+		t.Fatalf("config sync failed: %v\n%s", err, out)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.feature.start.fetch"); v != "true" {
+		t.Errorf("expected local start.fetch=true after sync, got %q", v)
+	}
+}
+
+// TestConfigSyncRemovesStaleKeys covers scenario 20: sync removes a stale branch
+// type and a dropped multi-value entry.
+// Steps:
+// 1. init --shared --defaults, add a push-option [a,b] and a qa type to both file and local
+// 2. Edits .gitflow to remove the qa type and drop the b push-option value
+// 3. Runs 'git flow config sync' and verifies qa.* is gone and push-option is [a] only
+func TestConfigSyncRemovesStaleKeys(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	sharedPath := testutil.SharedConfigPath(dir)
+	if _, err := testutil.RunGit(t, dir, "config", "--file", sharedPath, "--add", "gitflow.feature.publish.push-option", "a"); err != nil {
+		t.Fatalf("add push-option a: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "--file", sharedPath, "--add", "gitflow.feature.publish.push-option", "b"); err != nil {
+		t.Fatalf("add push-option b: %v", err)
+	}
+	if out, err := testutil.RunGitFlow(t, dir, "config", "add", "topic", "qa", "develop", "--shared"); err != nil {
+		t.Fatalf("config add topic qa --shared failed: %v\n%s", err, out)
+	}
+	if out, err := testutil.RunGitFlow(t, dir, "config", "sync"); err != nil {
+		t.Fatalf("initial sync failed: %v\n%s", err, out)
+	}
+
+	// Shrink .gitflow: drop the qa type and the b push-option value.
+	if _, err := testutil.RunGit(t, dir, "config", "--file", sharedPath, "--remove-section", "gitflow.branch.qa"); err != nil {
+		t.Fatalf("remove qa section: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "--file", sharedPath, "--unset-all", "gitflow.feature.publish.push-option"); err != nil {
+		t.Fatalf("unset push-option: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "--file", sharedPath, "--add", "gitflow.feature.publish.push-option", "a"); err != nil {
+		t.Fatalf("re-add push-option a: %v", err)
+	}
+
+	if out, err := testutil.RunGitFlow(t, dir, "config", "sync"); err != nil {
+		t.Fatalf("config sync failed: %v\n%s", err, out)
+	}
+	if testutil.GitConfigHasPrefix(t, dir, "gitflow.branch.qa.") {
+		t.Error("expected stale local gitflow.branch.qa.* to be removed")
+	}
+	local := testutil.GitConfigAll(t, dir, "gitflow.feature.publish.push-option")
+	if len(local) != 1 || local[0] != "a" {
+		t.Errorf("expected local push-option [a] after shrink, got %v", local)
+	}
+}
+
+// TestConfigSyncOverwritesLocalValue covers scenario 21: sync overwrites a
+// locally-differing shared-managed value.
+// Steps:
+// 1. init --shared --defaults, then set local feature.prefix=local/ (file still feature/)
+// 2. Runs 'git flow config sync'
+// 3. Verifies local feature.prefix is overwritten back to feature/
+func TestConfigSyncOverwritesLocalValue(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.branch.feature.prefix", "local/"); err != nil {
+		t.Fatalf("set local prefix: %v", err)
+	}
+
+	if out, err := testutil.RunGitFlow(t, dir, "config", "sync"); err != nil {
+		t.Fatalf("config sync failed: %v\n%s", err, out)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.feature.prefix"); v != "feature/" {
+		t.Errorf("expected local feature.prefix overwritten to feature/, got %q", v)
+	}
+}
+
+// TestConfigSyncPreservesLocalOnlyKeys covers scenario 22: sync preserves
+// local-only keys (autoInit control key and runtime branch metadata).
+// Steps:
+// 1. init --shared --defaults, set local gitflow.shared.autoInit=true, start feature/foo (writes a .base key)
+// 2. Runs 'git flow config sync'
+// 3. Verifies autoInit and the runtime feature/foo.base key both survive
+func TestConfigSyncPreservesLocalOnlyKeys(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.shared.autoInit", "true"); err != nil {
+		t.Fatalf("set autoInit: %v", err)
+	}
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "start", "foo"); err != nil {
+		t.Fatalf("feature start foo failed: %v\n%s", err, out)
+	}
+
+	if out, err := testutil.RunGitFlow(t, dir, "config", "sync"); err != nil {
+		t.Fatalf("config sync failed: %v\n%s", err, out)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.shared.autoInit"); v != "true" {
+		t.Errorf("expected local autoInit preserved, got %q", v)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.feature/foo.base"); v == "" {
+		t.Error("expected runtime gitflow.branch.feature/foo.base preserved after sync")
+	}
+}
+
+// TestConfigStatusInSyncExitsZero covers scenario 23: status when in sync exits 0.
+// Steps:
+// 1. init --shared --defaults (local already matches .gitflow)
+// 2. Runs 'git flow config status'
+// 3. Verifies it reports in sync and exits 0
+func TestConfigStatusInSyncExitsZero(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "status")
+	if err != nil {
+		t.Fatalf("expected config status to exit 0 when in sync, got err: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "in sync") {
+		t.Errorf("expected 'in sync' in output, got: %s", out)
+	}
+}
+
+// TestConfigStatusDriftExitsNonZero covers scenario 24: status when out of sync
+// names the differing key, exits 6, and does not flag local-only keys as drift.
+// Steps:
+// 1. init --shared --defaults, set .gitflow feature.prefix=feat/, add local-only autoInit and a runtime base key
+// 2. Runs 'git flow config status'
+// 3. Verifies out-of-sync, names feature.prefix, exit 6, and local-only keys not reported
+func TestConfigStatusDriftExitsNonZero(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	testutil.SharedConfigSet(t, dir, "gitflow.branch.feature.prefix", "feat/")
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.shared.autoInit", "true"); err != nil {
+		t.Fatalf("set autoInit: %v", err)
+	}
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "start", "foo"); err != nil {
+		t.Fatalf("feature start foo failed: %v\n%s", err, out)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "status")
+	if err == nil {
+		t.Fatalf("expected config status to fail on drift, got success\n%s", out)
+	}
+	assertExitCode(t, err, errors.ExitCodeValidationError)
+	if !strings.Contains(out, "gitflow.branch.feature.prefix") {
+		t.Errorf("expected drift to name gitflow.branch.feature.prefix, got: %s", out)
+	}
+	if strings.Contains(out, "autoInit") || strings.Contains(out, "feature/foo.base") {
+		t.Errorf("expected local-only keys not reported as drift, got: %s", out)
+	}
+}
+
+// TestConfigStatusDriftMissingLocalKey covers scenario 24b: status drift for a
+// shared-managed key present in .gitflow but missing locally.
+// Steps:
+// 1. init --shared --defaults, add gitflow.feature.start.fetch=true only to .gitflow
+// 2. Runs 'git flow config status'
+// 3. Verifies out-of-sync, names start.fetch, exit 6
+func TestConfigStatusDriftMissingLocalKey(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	testutil.SharedConfigSet(t, dir, "gitflow.feature.start.fetch", "true")
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "status")
+	if err == nil {
+		t.Fatalf("expected drift for shared-only key, got success\n%s", out)
+	}
+	assertExitCode(t, err, errors.ExitCodeValidationError)
+	if !strings.Contains(out, "gitflow.feature.start.fetch") {
+		t.Errorf("expected drift to name gitflow.feature.start.fetch, got: %s", out)
+	}
+}
+
+// TestConfigStatusDriftStaleLocalKey covers scenario 24c: status drift for a
+// stale shared-managed key present locally but absent from .gitflow.
+// Steps:
+// 1. init --shared --defaults, set a managed key locally that is not in .gitflow
+// 2. Runs 'git flow config status'
+// 3. Verifies out-of-sync, names the stale key, exit 6
+func TestConfigStatusDriftStaleLocalKey(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.branch.oldtype.type", "topic"); err != nil {
+		t.Fatalf("set stale local key: %v", err)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "status")
+	if err == nil {
+		t.Fatalf("expected drift for stale local key, got success\n%s", out)
+	}
+	assertExitCode(t, err, errors.ExitCodeValidationError)
+	if !strings.Contains(out, "gitflow.branch.oldtype.type") {
+		t.Errorf("expected drift to name gitflow.branch.oldtype.type, got: %s", out)
+	}
+}
+
+// TestConfigStatusDriftReorderedMultiValue covers scenario 24d: status drift for
+// a reordered multi-value publish.push-option.
+// Steps:
+// 1. init --shared --defaults, set .gitflow push-option [a,b] and sync, then set local to [b,a]
+// 2. Runs 'git flow config status'
+// 3. Verifies out-of-sync (order-sensitive), names push-option, exit 6
+func TestConfigStatusDriftReorderedMultiValue(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	sharedPath := testutil.SharedConfigPath(dir)
+	if _, err := testutil.RunGit(t, dir, "config", "--file", sharedPath, "--add", "gitflow.feature.publish.push-option", "a"); err != nil {
+		t.Fatalf("add file push-option a: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "--file", sharedPath, "--add", "gitflow.feature.publish.push-option", "b"); err != nil {
+		t.Fatalf("add file push-option b: %v", err)
+	}
+	if out, err := testutil.RunGitFlow(t, dir, "config", "sync"); err != nil {
+		t.Fatalf("sync failed: %v\n%s", err, out)
+	}
+	// Reverse the local order to [b, a].
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "--unset-all", "gitflow.feature.publish.push-option"); err != nil {
+		t.Fatalf("unset local push-option: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "--add", "gitflow.feature.publish.push-option", "b"); err != nil {
+		t.Fatalf("add local push-option b: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "--add", "gitflow.feature.publish.push-option", "a"); err != nil {
+		t.Fatalf("add local push-option a: %v", err)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "status")
+	if err == nil {
+		t.Fatalf("expected drift for reordered multi-value, got success\n%s", out)
+	}
+	assertExitCode(t, err, errors.ExitCodeValidationError)
+	if !strings.Contains(out, "gitflow.feature.publish.push-option") {
+		t.Errorf("expected drift to name gitflow.feature.publish.push-option, got: %s", out)
+	}
+}
+
+// TestConfigStatusNoSharedConfig covers scenario 25a: with no .gitflow, status
+// reports "no shared config", exits 0, and does not mutate anything.
+// Steps:
+// 1. init --defaults (local only, no .gitflow)
+// 2. Runs 'git flow config status'
+// 3. Verifies "no shared config", exit 0, no .gitflow created
+func TestConfigStatusNoSharedConfig(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("init --defaults failed: %v\n%s", err, out)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "status")
+	if err != nil {
+		t.Fatalf("expected config status to exit 0 with no shared config, got: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "No shared") {
+		t.Errorf("expected a 'no shared config' message, got: %s", out)
+	}
+	if _, statErr := os.Stat(testutil.SharedConfigPath(dir)); statErr == nil {
+		t.Error("expected no .gitflow to be created by config status")
+	}
+}
+
+// TestConfigSyncNoSharedConfig covers scenario 25b: with no .gitflow, sync reports
+// "no shared config", exits 0, and does not mutate anything.
+// Steps:
+// 1. init --defaults (local only, no .gitflow)
+// 2. Runs 'git flow config sync'
+// 3. Verifies "no shared config", exit 0, no .gitflow created
+func TestConfigSyncNoSharedConfig(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("init --defaults failed: %v\n%s", err, out)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "sync")
+	if err != nil {
+		t.Fatalf("expected config sync to exit 0 with no shared config, got: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "No shared") {
+		t.Errorf("expected a 'no shared config' message, got: %s", out)
+	}
+	if _, statErr := os.Stat(testutil.SharedConfigPath(dir)); statErr == nil {
+		t.Error("expected no .gitflow to be created by config sync")
+	}
+}
+
+// TestSharedFileMalformedClearErrorSync covers scenario 35b: a malformed .gitflow
+// fails at config sync with a clear error naming the file.
+// Steps:
+// 1. Writes an unparsable .gitflow in a fresh repo
+// 2. Runs 'git flow config sync'
+// 3. Verifies non-zero exit, an error naming .gitflow, and no partial local mutation
+func TestSharedFileMalformedClearErrorSync(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	if err := os.WriteFile(testutil.SharedConfigPath(dir), []byte("[gitflow\nbroken = = =\n"), 0644); err != nil {
+		t.Fatalf("write malformed .gitflow: %v", err)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "sync")
+	if err == nil {
+		t.Fatalf("expected config sync to fail on malformed .gitflow, got success\n%s", out)
+	}
+	if !strings.Contains(out, ".gitflow") {
+		t.Errorf("expected error naming .gitflow, got: %s", out)
+	}
+	if testutil.GitConfigHasPrefix(t, dir, "gitflow.branch.") {
+		t.Error("expected no partial gitflow.branch.* mutation on malformed-file sync")
+	}
+}
+
+// TestConfigSyncSkipsUntrustedHookPath covers scenario 37: config sync applies the
+// hook-trust filter, not only first-run.
+// Steps:
+// 1. init --shared --defaults, add gitflow.path.hooks only to .gitflow, trust unset
+// 2. Runs 'git flow config sync'
+// 3. Verifies local did not gain the hook path, a warning printed, other keys synced
+func TestConfigSyncSkipsUntrustedHookPath(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	testutil.SharedConfigSet(t, dir, "gitflow.path.hooks", "/some/hooks")
+	testutil.SharedConfigSet(t, dir, "gitflow.feature.start.fetch", "true")
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "sync")
+	if err != nil {
+		t.Fatalf("config sync failed: %v\n%s", err, out)
+	}
+	if testutil.GitConfigExists(t, dir, "gitflow.path.hooks") {
+		t.Error("expected local to NOT gain gitflow.path.hooks when untrusted")
+	}
+	if !strings.Contains(out, "gitflow.shared.trustHooks") {
+		t.Errorf("expected a warning naming gitflow.shared.trustHooks, got: %s", out)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.feature.start.fetch"); v != "true" {
+		t.Errorf("expected other keys synced (start.fetch=true), got %q", v)
+	}
+}
+
+// TestConfigStatusUntrustedHookNotDrift covers scenario 37b: status does not flag
+// an intentionally-skipped untrusted hook path as drift.
+// Steps:
+// 1. init --shared --defaults, add gitflow.path.hooks only to .gitflow, trust unset, sync (skips it)
+// 2. Runs 'git flow config status'
+// 3. Verifies IN SYNC, exit 0, and a security note (not a drift key)
+func TestConfigStatusUntrustedHookNotDrift(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	testutil.SharedConfigSet(t, dir, "gitflow.path.hooks", "/some/hooks")
+	if out, err := testutil.RunGitFlow(t, dir, "config", "sync"); err != nil {
+		t.Fatalf("config sync failed: %v\n%s", err, out)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "status")
+	if err != nil {
+		t.Fatalf("expected status to exit 0 (skipped hook is not drift), got: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "in sync") {
+		t.Errorf("expected 'in sync', got: %s", out)
+	}
+	if !strings.Contains(out, "gitflow.path.hooks") {
+		t.Errorf("expected a security note mentioning gitflow.path.hooks, got: %s", out)
+	}
+}
+
+// TestSharedSyncRemovesHookPathAfterTrustRevoked covers scenario 17d: revoking
+// trustHooks removes a previously-copied hook path on the next sync.
+// Steps:
+// 1. init --shared --defaults, add gitflow.path.hooks, set trustHooks=true, sync (copies it)
+// 2. Unset trustHooks and run 'git flow config sync' again
+// 3. Verifies the hook path is removed locally, other keys remain, a warning printed
+func TestSharedSyncRemovesHookPathAfterTrustRevoked(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	testutil.SharedConfigSet(t, dir, "gitflow.path.hooks", "/some/hooks")
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.shared.trustHooks", "true"); err != nil {
+		t.Fatalf("set trustHooks: %v", err)
+	}
+	if out, err := testutil.RunGitFlow(t, dir, "config", "sync"); err != nil {
+		t.Fatalf("first sync failed: %v\n%s", err, out)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.path.hooks"); v != "/some/hooks" {
+		t.Fatalf("precondition: expected hook path copied when trusted, got %q", v)
+	}
+
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "--unset", "gitflow.shared.trustHooks"); err != nil {
+		t.Fatalf("unset trustHooks: %v", err)
+	}
+	out, err := testutil.RunGitFlow(t, dir, "config", "sync")
+	if err != nil {
+		t.Fatalf("second sync failed: %v\n%s", err, out)
+	}
+	if testutil.GitConfigExists(t, dir, "gitflow.path.hooks") {
+		t.Error("expected local gitflow.path.hooks removed after trust revoked")
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.feature.prefix"); v != "feature/" {
+		t.Errorf("expected other keys to remain, got feature.prefix=%q", v)
+	}
+	if !strings.Contains(out, "gitflow.shared.trustHooks") {
+		t.Errorf("expected a warning naming gitflow.shared.trustHooks, got: %s", out)
+	}
+}

--- a/test/cmd/init_shared_test.go
+++ b/test/cmd/init_shared_test.go
@@ -1,0 +1,179 @@
+package cmd_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gittower/git-flow-next/internal/errors"
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// TestInitSharedCreatesFileAndCopiesLocal covers scenario 1: init --shared
+// --defaults creates .gitflow and copies the keys into local config.
+// Steps:
+// 1. Sets up a fresh repository with no git-flow config
+// 2. Runs 'git flow init --shared --defaults'
+// 3. Verifies .gitflow exists with version and default branch types
+// 4. Verifies local .git/config carries the same gitflow.* keys
+// 5. Verifies 'git flow overview' immediately lists the default topic types
+func TestInitSharedCreatesFileAndCopiesLocal(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--shared", "--defaults"); err != nil {
+		t.Fatalf("init --shared failed: %v\n%s", err, out)
+	}
+
+	if _, err := os.Stat(testutil.SharedConfigPath(dir)); err != nil {
+		t.Fatalf("expected .gitflow to exist: %v", err)
+	}
+	if v := testutil.SharedConfigValue(t, dir, "gitflow.version"); v == "" {
+		t.Error("expected .gitflow to declare gitflow.version")
+	}
+	if v := testutil.SharedConfigValue(t, dir, "gitflow.branch.feature.type"); v != "topic" {
+		t.Errorf("expected .gitflow feature.type=topic, got %q", v)
+	}
+	if v := testutil.SharedConfigValue(t, dir, "gitflow.branch.feature.prefix"); v != "feature/" {
+		t.Errorf("expected .gitflow feature.prefix=feature/, got %q", v)
+	}
+
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.feature.prefix"); v != "feature/" {
+		t.Errorf("expected local feature.prefix=feature/, got %q", v)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "overview")
+	if err != nil {
+		t.Fatalf("overview failed: %v\n%s", err, out)
+	}
+	for _, want := range []string{"feature", "release", "hotfix"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected overview to list %q, got: %s", want, out)
+		}
+	}
+}
+
+// TestInitSharedWritesAtToplevelFromSubdir covers scenario 2: init --shared from
+// a subdirectory writes .gitflow at the repository toplevel.
+// Steps:
+// 1. Sets up a repository and creates a sub/ directory
+// 2. Runs 'git flow init --shared --defaults' from sub/
+// 3. Verifies <repo>/.gitflow exists and <repo>/sub/.gitflow does not
+func TestInitSharedWritesAtToplevelFromSubdir(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	subDir := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatalf("failed to create sub dir: %v", err)
+	}
+
+	if out, err := testutil.RunGitFlow(t, subDir, "init", "--shared", "--defaults"); err != nil {
+		t.Fatalf("init --shared from subdir failed: %v\n%s", err, out)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, ".gitflow")); err != nil {
+		t.Errorf("expected .gitflow at toplevel: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(subDir, ".gitflow")); err == nil {
+		t.Error("expected no .gitflow in the subdirectory")
+	}
+}
+
+// TestInitSharedRejectsOtherScopeFlags covers scenario 3: --shared is mutually
+// exclusive with the other scope flags.
+// Steps:
+// 1. Sets up a fresh repository
+// 2. Runs 'git flow init --shared --local --defaults'
+// 3. Verifies exit code ExitCodeInvalidInput, an error naming --shared, and no .gitflow
+func TestInitSharedRejectsOtherScopeFlags(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	out, err := testutil.RunGitFlow(t, dir, "init", "--shared", "--local", "--defaults")
+	if err == nil {
+		t.Fatalf("expected error for mutually exclusive scope flags, got success\n%s", out)
+	}
+	if ee, ok := err.(*testutil.ExitError); ok {
+		if ee.ExitCode != int(errors.ExitCodeInvalidInput) {
+			t.Errorf("expected exit code %d, got %d", errors.ExitCodeInvalidInput, ee.ExitCode)
+		}
+	} else {
+		t.Fatalf("expected ExitError, got %T", err)
+	}
+	if !strings.Contains(out, "--shared") {
+		t.Errorf("expected error to name --shared, got: %s", out)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".gitflow")); err == nil {
+		t.Error("expected no .gitflow to be created on a rejected invocation")
+	}
+}
+
+// TestInitSharedExistingFileWithoutForceNoOp covers scenario 4: with an existing
+// .gitflow, init --shared without --force is a no-op.
+// Steps:
+// 1. Runs init --shared --defaults, then edits .gitflow feature.prefix to a sentinel
+// 2. Captures the current local feature.prefix
+// 3. Runs 'git flow init --shared --defaults' again (no --force)
+// 4. Verifies non-zero exit, .gitflow still has the sentinel, local prefix unchanged
+func TestInitSharedExistingFileWithoutForceNoOp(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--shared", "--defaults"); err != nil {
+		t.Fatalf("init --shared failed: %v\n%s", err, out)
+	}
+	testutil.SharedConfigSet(t, dir, "gitflow.branch.feature.prefix", "sentinel/")
+	localBefore := testutil.GitConfigValue(t, dir, "gitflow.branch.feature.prefix")
+
+	out, err := testutil.RunGitFlow(t, dir, "init", "--shared", "--defaults")
+	if err == nil {
+		t.Fatalf("expected error for existing .gitflow without --force, got success\n%s", out)
+	}
+
+	if v := testutil.SharedConfigValue(t, dir, "gitflow.branch.feature.prefix"); v != "sentinel/" {
+		t.Errorf("expected .gitflow feature.prefix to stay sentinel/, got %q", v)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.feature.prefix"); v != localBefore {
+		t.Errorf("expected local feature.prefix unchanged (%q), got %q", localBefore, v)
+	}
+}
+
+// TestInitSharedForceRewritesAndRecopies covers scenario 5: init --shared --force
+// rewrites .gitflow, re-copies into local, and stale-removes an old managed key.
+// Steps:
+// 1. Runs init --shared --defaults, sets a sentinel prefix in .gitflow, adds a stale local key
+// 2. Runs 'git flow init --shared --defaults --force'
+// 3. Verifies .gitflow feature.prefix is back to feature/, local matches, stale key removed
+func TestInitSharedForceRewritesAndRecopies(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--shared", "--defaults"); err != nil {
+		t.Fatalf("init --shared failed: %v\n%s", err, out)
+	}
+	testutil.SharedConfigSet(t, dir, "gitflow.branch.feature.prefix", "sentinel/")
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.branch.oldtype.type", "topic"); err != nil {
+		t.Fatalf("failed to seed stale local key: %v", err)
+	}
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--shared", "--defaults", "--force"); err != nil {
+		t.Fatalf("init --shared --force failed: %v\n%s", err, out)
+	}
+
+	if v := testutil.SharedConfigValue(t, dir, "gitflow.branch.feature.prefix"); v != "feature/" {
+		t.Errorf("expected .gitflow feature.prefix rewritten to feature/, got %q", v)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.feature.prefix"); v != "feature/" {
+		t.Errorf("expected local feature.prefix re-copied to feature/, got %q", v)
+	}
+	if testutil.GitConfigExists(t, dir, "gitflow.branch.oldtype.type") {
+		t.Error("expected stale local gitflow.branch.oldtype.type to be removed on force re-copy")
+	}
+}

--- a/test/cmd/shared_activation_test.go
+++ b/test/cmd/shared_activation_test.go
@@ -1,0 +1,341 @@
+package cmd_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gittower/git-flow-next/internal/errors"
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// TestFirstRunPromptAcceptActivates covers scenario 6: an interactive first-run
+// prompt that is accepted activates the shared config and proceeds.
+// Steps:
+// 1. Builds a fresh-clone fixture that carries a committed .gitflow but no local config
+// 2. Runs 'feature start my-thing' with interactive stdin answering "y"
+// 3. Verifies the prompt mentions .gitflow, local config was copied, and the branch exists
+func TestFirstRunPromptAcceptActivates(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupFreshCloneWithShared(t, testutil.AuthorSharedConfig(t))
+	defer testutil.CleanupTestRepo(t, dir)
+
+	out, err := testutil.RunGitFlowInteractive(t, dir, "y\n", "feature", "start", "my-thing")
+	if err != nil {
+		t.Fatalf("feature start after accept failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, ".gitflow") {
+		t.Errorf("expected prompt to mention .gitflow, got: %s", out)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.feature.prefix"); v != "feature/" {
+		t.Errorf("expected local feature.prefix copied to feature/, got %q", v)
+	}
+	if !testutil.BranchExists(t, dir, "feature/my-thing") {
+		t.Error("expected feature/my-thing to be created")
+	}
+}
+
+// TestFirstRunPromptDeclineNoCopy covers scenario 7: an interactive first-run
+// prompt that is declined performs no copy and the command fails as uninitialized.
+// Steps:
+// 1. Builds a fresh-clone fixture with a committed .gitflow
+// 2. Runs 'feature start my-thing' with interactive stdin answering "n"
+// 3. Verifies no gitflow.* keys were written, no branch created, exit code 1
+func TestFirstRunPromptDeclineNoCopy(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupFreshCloneWithShared(t, testutil.AuthorSharedConfig(t))
+	defer testutil.CleanupTestRepo(t, dir)
+
+	out, err := testutil.RunGitFlowInteractive(t, dir, "n\n", "feature", "start", "my-thing")
+	if err == nil {
+		t.Fatalf("expected declined first-run to fail, got success\n%s", out)
+	}
+	assertExitCode(t, err, errors.ExitCodeNotInitialized)
+	if testutil.GitConfigHasPrefix(t, dir, "gitflow.") {
+		t.Error("expected no gitflow.* keys in local config after decline")
+	}
+	if testutil.BranchExists(t, dir, "feature/my-thing") {
+		t.Error("expected no branch to be created after decline")
+	}
+}
+
+// TestFirstRunNonInteractiveHintNoMutation covers scenario 8: a non-interactive
+// run with autoInit unset only hints and mutates nothing.
+// Steps:
+// 1. Builds a fresh-clone fixture with a committed .gitflow, autoInit unset
+// 2. Runs 'feature start my-thing' non-interactively (stdin not a TTY)
+// 3. Verifies a hint naming .gitflow, no gitflow.* keys, no branch, exit code 1
+func TestFirstRunNonInteractiveHintNoMutation(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupFreshCloneWithShared(t, testutil.AuthorSharedConfig(t))
+	defer testutil.CleanupTestRepo(t, dir)
+
+	out, err := testutil.RunGitFlow(t, dir, "feature", "start", "my-thing")
+	if err == nil {
+		t.Fatalf("expected non-interactive uninitialized run to fail, got success\n%s", out)
+	}
+	assertExitCode(t, err, errors.ExitCodeNotInitialized)
+	if !strings.Contains(out, ".gitflow") {
+		t.Errorf("expected a hint naming .gitflow, got: %s", out)
+	}
+	if testutil.GitConfigHasPrefix(t, dir, "gitflow.") {
+		t.Error("expected no gitflow.* keys in local config after a hint-only run")
+	}
+	if testutil.BranchExists(t, dir, "feature/my-thing") {
+		t.Error("expected no branch to be created after a hint-only run")
+	}
+}
+
+// TestFirstRunAutoInitActivatesWithNotice covers scenario 9: with
+// gitflow.shared.autoInit=true, a non-interactive run auto-copies with a notice.
+// Steps:
+// 1. Builds a fresh-clone fixture and sets gitflow.shared.autoInit=true locally
+// 2. Runs 'feature start my-thing' non-interactively
+// 3. Verifies a one-line auto-init notice, local config copied, and the branch exists
+func TestFirstRunAutoInitActivatesWithNotice(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupFreshCloneWithShared(t, testutil.AuthorSharedConfig(t))
+	defer testutil.CleanupTestRepo(t, dir)
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.shared.autoInit", "true"); err != nil {
+		t.Fatalf("failed to set autoInit: %v", err)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "feature", "start", "my-thing")
+	if err != nil {
+		t.Fatalf("auto-init feature start failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "auto-initialized") || !strings.Contains(out, ".gitflow") {
+		t.Errorf("expected an auto-init notice naming .gitflow, got: %s", out)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.feature.prefix"); v != "feature/" {
+		t.Errorf("expected local feature.prefix copied, got %q", v)
+	}
+	if !testutil.BranchExists(t, dir, "feature/my-thing") {
+		t.Error("expected feature/my-thing to be created")
+	}
+}
+
+// TestFirstRunLocalConfigPresentNoPrompt covers scenario 10: an already
+// locally-configured repo with a .gitflow present does not prompt; local wins.
+// Steps:
+// 1. Runs 'init --defaults' (local config, no .gitflow), then drops in a .gitflow with feat/
+// 2. Runs 'feature start my-thing'
+// 3. Verifies no prompt/notice, the LOCAL prefix feature/ is used, and local prefix unchanged
+func TestFirstRunLocalConfigPresentNoPrompt(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("init --defaults failed: %v\n%s", err, out)
+	}
+	// A .gitflow that disagrees with local (feat/ vs feature/), left unsynced.
+	testutil.SharedConfigSet(t, dir, "gitflow.version", "1.0")
+	testutil.SharedConfigSet(t, dir, "gitflow.branch.feature.type", "topic")
+	testutil.SharedConfigSet(t, dir, "gitflow.branch.feature.prefix", "feat/")
+
+	out, err := testutil.RunGitFlow(t, dir, "feature", "start", "my-thing")
+	if err != nil {
+		t.Fatalf("feature start failed: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "not yet active") || strings.Contains(out, "auto-initialized") {
+		t.Errorf("expected no first-run prompt/notice, got: %s", out)
+	}
+	if !testutil.BranchExists(t, dir, "feature/my-thing") {
+		t.Error("expected feature/my-thing (local prefix) to be created")
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.feature.prefix"); v != "feature/" {
+		t.Errorf("expected local feature.prefix to stay feature/, got %q", v)
+	}
+}
+
+// TestFirstRunAutoInitOnlyStillUnconfigured covers scenario 11: a repo whose only
+// git-flow key is gitflow.shared.autoInit still reads as unconfigured and activates.
+// Steps:
+// 1. Builds a fresh-clone fixture and sets only gitflow.shared.autoInit=true locally
+// 2. Runs 'feature start my-thing'
+// 3. Verifies activation occurred (config copied) and the branch was created
+func TestFirstRunAutoInitOnlyStillUnconfigured(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupFreshCloneWithShared(t, testutil.AuthorSharedConfig(t))
+	defer testutil.CleanupTestRepo(t, dir)
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.shared.autoInit", "true"); err != nil {
+		t.Fatalf("failed to set autoInit: %v", err)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "feature", "start", "my-thing")
+	if err != nil {
+		t.Fatalf("feature start failed: %v\n%s", err, out)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.feature.type"); v != "topic" {
+		t.Errorf("expected activation to copy feature.type, got %q", v)
+	}
+	if !testutil.BranchExists(t, dir, "feature/my-thing") {
+		t.Error("expected feature/my-thing to be created")
+	}
+}
+
+// TestNoSharedFileBehavesAsToday covers scenario 32: a repo with no .gitflow that
+// was init'd --local behaves exactly as before, with no first-run side effects.
+// Steps:
+// 1. Runs 'init --local --defaults' (no .gitflow)
+// 2. Runs 'feature start x'
+// 3. Verifies no prompt/hint/notice about .gitflow and the branch is created
+func TestNoSharedFileBehavesAsToday(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--local", "--defaults"); err != nil {
+		t.Fatalf("init --local failed: %v\n%s", err, out)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "feature", "start", "x")
+	if err != nil {
+		t.Fatalf("feature start failed: %v\n%s", err, out)
+	}
+	if strings.Contains(out, ".gitflow") {
+		t.Errorf("expected no .gitflow text in output, got: %s", out)
+	}
+	if !testutil.BranchExists(t, dir, "feature/x") {
+		t.Error("expected feature/x to be created")
+	}
+}
+
+// TestBareRepoNoSharedDetection covers scenario 33: in a bare repository the
+// first-run hook is a no-op and version still works.
+// Steps:
+// 1. Creates a bare repository
+// 2. Runs 'git flow version' in it
+// 3. Verifies exit 0, normal version output, and no .gitflow text or panic
+func TestBareRepoNoSharedDetection(t *testing.T) {
+	t.Parallel()
+	bareDir, err := os.MkdirTemp("", "git-flow-test-bare-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer testutil.CleanupTestRepo(t, bareDir)
+	if _, err := testutil.RunGit(t, bareDir, "init", "--bare", "--initial-branch=main"); err != nil {
+		t.Fatalf("failed to init bare repo: %v", err)
+	}
+
+	out, err := testutil.RunGitFlow(t, bareDir, "version")
+	if err != nil {
+		t.Fatalf("version in bare repo failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "git-flow-next version") {
+		t.Errorf("expected version output, got: %s", out)
+	}
+	if strings.Contains(out, ".gitflow") {
+		t.Errorf("expected no .gitflow text in bare-repo version output, got: %s", out)
+	}
+}
+
+// TestSharedFileMissingVersionNotOffered covers scenario 34: a .gitflow missing
+// gitflow.version is not a valid shared config and is not activated.
+// Steps:
+// 1. Creates a repo with a .gitflow that has branch keys but no gitflow.version
+// 2. Runs 'feature start x' non-interactively with autoInit unset
+// 3. Verifies no activation, no branch, exit 1, and a hint that version is missing
+func TestSharedFileMissingVersionNotOffered(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	if _, err := testutil.RunGit(t, dir, "branch", "develop"); err != nil {
+		t.Fatalf("failed to create develop: %v", err)
+	}
+	testutil.SharedConfigSet(t, dir, "gitflow.branch.feature.type", "topic")
+	testutil.SharedConfigSet(t, dir, "gitflow.branch.feature.prefix", "feature/")
+
+	out, err := testutil.RunGitFlow(t, dir, "feature", "start", "x")
+	if err == nil {
+		t.Fatalf("expected failure for version-less .gitflow, got success\n%s", out)
+	}
+	assertExitCode(t, err, errors.ExitCodeNotInitialized)
+	if testutil.GitConfigHasPrefix(t, dir, "gitflow.") {
+		t.Error("expected no gitflow.* keys copied for a version-less .gitflow")
+	}
+	if testutil.BranchExists(t, dir, "feature/x") {
+		t.Error("expected no branch created for a version-less .gitflow")
+	}
+	if !strings.Contains(out, "gitflow.version") {
+		t.Errorf("expected a hint mentioning gitflow.version, got: %s", out)
+	}
+}
+
+// TestSharedFileMalformedClearErrorFirstRun covers scenario 35: a malformed
+// .gitflow fails first-run activation with a clear error naming the file.
+// Steps:
+// 1. Writes an unparsable .gitflow and sets gitflow.shared.autoInit=true locally
+// 2. Runs 'feature start x' (drives the first-run activation path)
+// 3. Verifies non-zero exit, an error naming .gitflow, no branch, and no partial copy
+func TestSharedFileMalformedClearErrorFirstRun(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	if err := os.WriteFile(testutil.SharedConfigPath(dir), []byte("[gitflow\nbroken = = =\n"), 0644); err != nil {
+		t.Fatalf("failed to write malformed .gitflow: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.shared.autoInit", "true"); err != nil {
+		t.Fatalf("failed to set autoInit: %v", err)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "feature", "start", "x")
+	if err == nil {
+		t.Fatalf("expected failure for malformed .gitflow, got success\n%s", out)
+	}
+	if !strings.Contains(out, ".gitflow") {
+		t.Errorf("expected error naming .gitflow, got: %s", out)
+	}
+	if testutil.BranchExists(t, dir, "feature/x") {
+		t.Error("expected no branch created on malformed-file failure")
+	}
+	if testutil.GitConfigHasPrefix(t, dir, "gitflow.branch.") {
+		t.Error("expected no partial gitflow.branch.* keys copied on malformed-file failure")
+	}
+}
+
+// TestFirstRunSkipsInitCommand covers scenario 36: the first-run hook does not
+// fire for 'git flow init' itself.
+// Steps:
+// 1. Creates a repo with a present valid .gitflow, autoInit unset, non-interactive
+// 2. Runs 'git flow init --defaults' (plain, no --shared)
+// 3. Verifies init writes local config normally and .gitflow is untouched
+func TestFirstRunSkipsInitCommand(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	if _, err := testutil.RunGit(t, dir, "branch", "develop"); err != nil {
+		t.Fatalf("failed to create develop: %v", err)
+	}
+	testutil.SharedConfigSet(t, dir, "gitflow.version", "1.0")
+	testutil.SharedConfigSet(t, dir, "gitflow.branch.feature.type", "topic")
+	testutil.SharedConfigSet(t, dir, "gitflow.branch.feature.prefix", "shared/")
+
+	out, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("init --defaults failed: %v\n%s", err, out)
+	}
+	// Local config came from init --defaults, not from the shared file.
+	if v := testutil.GitConfigValue(t, dir, "gitflow.version"); v == "" {
+		t.Error("expected init --defaults to write local gitflow.version")
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.feature.prefix"); v != "feature/" {
+		t.Errorf("expected local feature.prefix from init defaults (feature/), got %q", v)
+	}
+	// The shared file was not rewritten by the plain init.
+	if v := testutil.SharedConfigValue(t, dir, "gitflow.branch.feature.prefix"); v != "shared/" {
+		t.Errorf("expected .gitflow feature.prefix untouched (shared/), got %q", v)
+	}
+}
+
+// assertExitCode fails the test unless err is a testutil.ExitError carrying the
+// expected exit code.
+func assertExitCode(t *testing.T, err error, want errors.ExitCode) {
+	t.Helper()
+	ee, ok := err.(*testutil.ExitError)
+	if !ok {
+		t.Fatalf("expected *testutil.ExitError, got %T (%v)", err, err)
+	}
+	if ee.ExitCode != int(want) {
+		t.Errorf("expected exit code %d, got %d", int(want), ee.ExitCode)
+	}
+}

--- a/test/cmd/shared_copy_test.go
+++ b/test/cmd/shared_copy_test.go
@@ -1,0 +1,358 @@
+package cmd_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// advanceRemoteMain clones the given bare remote into a throwaway working copy,
+// adds a commit on main, pushes it, and returns the new commit SHA. Used to make
+// the primary repo's origin/main tracking ref provably stale before a fetch.
+func advanceRemoteMain(t *testing.T, remoteDir string) string {
+	t.Helper()
+	parent, err := os.MkdirTemp("", "git-flow-test-advance-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(parent) })
+	if _, err := testutil.RunGit(t, parent, "clone", remoteDir, "work"); err != nil {
+		t.Fatalf("failed to clone remote: %v", err)
+	}
+	work := filepath.Join(parent, "work")
+	testutil.ConfigureGitIdentity(t, work)
+	if err := testutil.WriteFile(t, work, "advance.txt", "content"); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, work, "add", "advance.txt"); err != nil {
+		t.Fatalf("failed to add file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, work, "commit", "-m", "advance main"); err != nil {
+		t.Fatalf("failed to commit: %v", err)
+	}
+	sha, err := testutil.RunGit(t, work, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("failed to resolve HEAD: %v", err)
+	}
+	if _, err := testutil.RunGit(t, work, "push", "origin", "main"); err != nil {
+		t.Fatalf("failed to push main: %v", err)
+	}
+	return strings.TrimSpace(sha)
+}
+
+// TestSharedBranchTypeRunnableAfterActivation covers scenario 12: a
+// .gitflow-defined branch type is registered and runnable after activation.
+// Steps:
+// 1. Builds a fresh-clone fixture with autoInit=true
+// 2. Runs 'feature start x'
+// 3. Verifies feature/x was created and local feature.prefix=feature/
+func TestSharedBranchTypeRunnableAfterActivation(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupFreshCloneWithShared(t, testutil.AuthorSharedConfig(t))
+	defer testutil.CleanupTestRepo(t, dir)
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.shared.autoInit", "true"); err != nil {
+		t.Fatalf("failed to set autoInit: %v", err)
+	}
+
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "start", "x"); err != nil {
+		t.Fatalf("feature start failed: %v\n%s", err, out)
+	}
+	if !testutil.BranchExists(t, dir, "feature/x") {
+		t.Error("expected feature/x to be created")
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.feature.prefix"); v != "feature/" {
+		t.Errorf("expected local feature.prefix=feature/, got %q", v)
+	}
+}
+
+// TestSharedStartFetchDirectReadSite covers scenario 13: gitflow.feature.start.fetch
+// declared only in .gitflow triggers a fetch (direct read site in cmd/start.go).
+// Steps:
+// 1. Builds a repo+remote, authors a .gitflow with start.fetch=true, clears local config, autoInit=true
+// 2. Advances origin/main from a second clone to a known SHA the primary has not fetched
+// 3. Runs 'feature start x' and verifies origin/main advanced to that SHA and a fetch notice printed
+func TestSharedStartFetchDirectReadSite(t *testing.T) {
+	t.Parallel()
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if err := os.WriteFile(testutil.SharedConfigPath(dir), testutil.AuthorSharedConfig(t), 0644); err != nil {
+		t.Fatalf("failed to write .gitflow: %v", err)
+	}
+	testutil.SharedConfigSet(t, dir, "gitflow.feature.start.fetch", "true")
+	testutil.ClearLocalGitflowConfig(t, dir)
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.shared.autoInit", "true"); err != nil {
+		t.Fatalf("failed to set autoInit: %v", err)
+	}
+
+	wantSHA := advanceRemoteMain(t, remoteDir)
+	before, _ := testutil.RunGit(t, dir, "rev-parse", "refs/remotes/origin/main")
+	if strings.TrimSpace(before) == wantSHA {
+		t.Fatalf("precondition failed: origin/main already at wantSHA before fetch")
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "feature", "start", "x")
+	if err != nil {
+		t.Fatalf("feature start failed: %v\n%s", err, out)
+	}
+	after, err := testutil.RunGit(t, dir, "rev-parse", "refs/remotes/origin/main")
+	if err != nil {
+		t.Fatalf("failed to resolve origin/main: %v", err)
+	}
+	if strings.TrimSpace(after) != wantSHA {
+		t.Errorf("expected origin/main to advance to %s after fetch, got %s", wantSHA, strings.TrimSpace(after))
+	}
+	if !strings.Contains(out, "Fetching") {
+		t.Errorf("expected a fetch notice in output, got: %s", out)
+	}
+}
+
+// TestSharedDeleteForceAndRemoteDirectReadSite covers scenario 14:
+// gitflow.feature.delete.force and gitflow.branch.feature.deleteRemote declared
+// only in .gitflow are honored (direct reads in cmd/delete.go).
+// Steps:
+// 1. Builds a repo+remote, authors a .gitflow with delete.force=true and deleteRemote=true, autoInit=true
+// 2. Starts feature/x, commits a unique (unmerged) change, and publishes it to origin
+// 3. Runs 'feature delete x' (no flags) and verifies the local and remote branches are gone
+func TestSharedDeleteForceAndRemoteDirectReadSite(t *testing.T) {
+	t.Parallel()
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if err := os.WriteFile(testutil.SharedConfigPath(dir), testutil.AuthorSharedConfig(t), 0644); err != nil {
+		t.Fatalf("failed to write .gitflow: %v", err)
+	}
+	testutil.SharedConfigSet(t, dir, "gitflow.feature.delete.force", "true")
+	testutil.SharedConfigSet(t, dir, "gitflow.branch.feature.deleteRemote", "true")
+	testutil.ClearLocalGitflowConfig(t, dir)
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.shared.autoInit", "true"); err != nil {
+		t.Fatalf("failed to set autoInit: %v", err)
+	}
+
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "start", "x"); err != nil {
+		t.Fatalf("feature start failed: %v\n%s", err, out)
+	}
+	if err := testutil.WriteFile(t, dir, "unmerged.txt", "unique"); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "add", "unmerged.txt"); err != nil {
+		t.Fatalf("failed to add file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "unique change"); err != nil {
+		t.Fatalf("failed to commit: %v", err)
+	}
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "publish", "x"); err != nil {
+		t.Fatalf("feature publish failed: %v\n%s", err, out)
+	}
+
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "delete", "x"); err != nil {
+		t.Fatalf("feature delete failed: %v\n%s", err, out)
+	}
+	if testutil.BranchExists(t, dir, "feature/x") {
+		t.Error("expected local feature/x to be deleted (force honored from shared config)")
+	}
+	lsRemote, err := testutil.RunGit(t, dir, "ls-remote", "--heads", "origin", "refs/heads/feature/x")
+	if err != nil {
+		t.Fatalf("ls-remote failed: %v", err)
+	}
+	if strings.TrimSpace(lsRemote) != "" {
+		t.Errorf("expected remote feature/x to be deleted, got: %s", lsRemote)
+	}
+}
+
+// TestSharedPublishPushOptionMultiValueDirectReadSite covers scenario 15: a
+// multi-value gitflow.feature.publish.push-option in .gitflow survives the copy
+// and is transmitted in order (direct read in cmd/publish.go).
+// Steps:
+// 1. Builds a repo+remote with a push-option-capturing hook, authors .gitflow with two options, autoInit=true
+// 2. Starts feature/x (activating) and publishes it
+// 3. Verifies both options arrived in order and local get-all preserves order
+func TestSharedPublishPushOptionMultiValueDirectReadSite(t *testing.T) {
+	t.Parallel()
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	readOptions := installPushOptionHook(t, remoteDir)
+
+	if err := os.WriteFile(testutil.SharedConfigPath(dir), testutil.AuthorSharedConfig(t), 0644); err != nil {
+		t.Fatalf("failed to write .gitflow: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "--file", testutil.SharedConfigPath(dir), "--add", "gitflow.feature.publish.push-option", "opt-a"); err != nil {
+		t.Fatalf("failed to add push-option opt-a: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "--file", testutil.SharedConfigPath(dir), "--add", "gitflow.feature.publish.push-option", "opt-b"); err != nil {
+		t.Fatalf("failed to add push-option opt-b: %v", err)
+	}
+	testutil.ClearLocalGitflowConfig(t, dir)
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.shared.autoInit", "true"); err != nil {
+		t.Fatalf("failed to set autoInit: %v", err)
+	}
+
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "start", "x"); err != nil {
+		t.Fatalf("feature start failed: %v\n%s", err, out)
+	}
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "publish", "x"); err != nil {
+		t.Fatalf("feature publish failed: %v\n%s", err, out)
+	}
+
+	count, options := readOptions()
+	if count != 2 || len(options) != 2 || options[0] != "opt-a" || options[1] != "opt-b" {
+		t.Errorf("expected push options [opt-a opt-b] in order, got count=%d options=%v", count, options)
+	}
+	local := testutil.GitConfigAll(t, dir, "gitflow.feature.publish.push-option")
+	if len(local) != 2 || local[0] != "opt-a" || local[1] != "opt-b" {
+		t.Errorf("expected local push-option [opt-a opt-b] in order, got %v", local)
+	}
+}
+
+// TestSharedNonGitflowKeysNotCopied covers scenario 16: non-gitflow keys in
+// .gitflow are never copied into local config.
+// Steps:
+// 1. Builds a fresh-clone fixture whose .gitflow also declares core.sshCommand and alias.x, autoInit=true
+// 2. Runs 'feature start x' (activates)
+// 3. Verifies local config has neither core.sshCommand nor alias.x, but gitflow.* is present
+func TestSharedNonGitflowKeysNotCopied(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupFreshCloneWithShared(t, testutil.AuthorSharedConfig(t))
+	defer testutil.CleanupTestRepo(t, dir)
+	testutil.SharedConfigSet(t, dir, "core.sshCommand", "echo pwned")
+	testutil.SharedConfigSet(t, dir, "alias.x", "!sh -c evil")
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.shared.autoInit", "true"); err != nil {
+		t.Fatalf("failed to set autoInit: %v", err)
+	}
+
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "start", "x"); err != nil {
+		t.Fatalf("feature start failed: %v\n%s", err, out)
+	}
+	if testutil.GitConfigExists(t, dir, "core.sshCommand") {
+		t.Error("expected core.sshCommand NOT copied into local config")
+	}
+	if testutil.GitConfigExists(t, dir, "alias.x") {
+		t.Error("expected alias.x NOT copied into local config")
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.feature.type"); v != "topic" {
+		t.Errorf("expected gitflow.* copied, got feature.type=%q", v)
+	}
+}
+
+// TestSharedHookPathSkippedWhenUntrustedInteractive covers scenario 17a: with an
+// untrusted hook path, an interactive accept skips that one key with a warning
+// but copies the rest and proceeds.
+// Steps:
+// 1. Builds a fresh-clone fixture whose .gitflow sets gitflow.path.hooks, trust/autoInit unset
+// 2. Runs 'feature start x' interactively answering "y"
+// 3. Verifies the hook path was not copied, the rest was, a warning naming trustHooks printed, branch created
+func TestSharedHookPathSkippedWhenUntrustedInteractive(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupFreshCloneWithShared(t, testutil.AuthorSharedConfig(t))
+	defer testutil.CleanupTestRepo(t, dir)
+	testutil.SharedConfigSet(t, dir, "gitflow.path.hooks", "/some/hooks")
+
+	out, err := testutil.RunGitFlowInteractive(t, dir, "y\n", "feature", "start", "x")
+	if err != nil {
+		t.Fatalf("feature start after accept failed: %v\n%s", err, out)
+	}
+	if testutil.GitConfigExists(t, dir, "gitflow.path.hooks") {
+		t.Error("expected gitflow.path.hooks NOT copied when untrusted")
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.feature.prefix"); v != "feature/" {
+		t.Errorf("expected the rest of gitflow.* copied, got feature.prefix=%q", v)
+	}
+	if !strings.Contains(out, "gitflow.shared.trustHooks") {
+		t.Errorf("expected a warning naming gitflow.shared.trustHooks, got: %s", out)
+	}
+	if !testutil.BranchExists(t, dir, "feature/x") {
+		t.Error("expected feature/x to be created despite the skipped hook path")
+	}
+}
+
+// TestSharedHookPathCopiedWhenTrusted covers scenario 17b: with
+// gitflow.shared.trustHooks=true the hook path is copied.
+// Steps:
+// 1. Builds a fresh-clone fixture whose .gitflow sets gitflow.path.hooks, trustHooks=true, autoInit=true
+// 2. Runs 'feature start x' (activates)
+// 3. Verifies local config contains gitflow.path.hooks=/some/hooks
+func TestSharedHookPathCopiedWhenTrusted(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupFreshCloneWithShared(t, testutil.AuthorSharedConfig(t))
+	defer testutil.CleanupTestRepo(t, dir)
+	testutil.SharedConfigSet(t, dir, "gitflow.path.hooks", "/some/hooks")
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.shared.trustHooks", "true"); err != nil {
+		t.Fatalf("failed to set trustHooks: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.shared.autoInit", "true"); err != nil {
+		t.Fatalf("failed to set autoInit: %v", err)
+	}
+
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "start", "x"); err != nil {
+		t.Fatalf("feature start failed: %v\n%s", err, out)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.path.hooks"); v != "/some/hooks" {
+		t.Errorf("expected local gitflow.path.hooks=/some/hooks when trusted, got %q", v)
+	}
+}
+
+// TestSharedAutoInitRefusesUntrustedHookPath covers scenario 17c: non-interactive
+// auto-init with an untrusted hook path refuses wholesale.
+// Steps:
+// 1. Builds a fresh-clone fixture whose .gitflow sets gitflow.path.hooks, autoInit=true, trust unset
+// 2. Runs 'feature start x' non-interactively
+// 3. Verifies failure naming trustHooks, no gitflow.branch.* copied, and the autoInit control key untouched
+func TestSharedAutoInitRefusesUntrustedHookPath(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupFreshCloneWithShared(t, testutil.AuthorSharedConfig(t))
+	defer testutil.CleanupTestRepo(t, dir)
+	testutil.SharedConfigSet(t, dir, "gitflow.path.hooks", "/some/hooks")
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.shared.autoInit", "true"); err != nil {
+		t.Fatalf("failed to set autoInit: %v", err)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "feature", "start", "x")
+	if err == nil {
+		t.Fatalf("expected auto-init to refuse an untrusted hook path, got success\n%s", out)
+	}
+	if !strings.Contains(out, "gitflow.shared.trustHooks") {
+		t.Errorf("expected the error to name gitflow.shared.trustHooks, got: %s", out)
+	}
+	if testutil.GitConfigHasPrefix(t, dir, "gitflow.branch.") {
+		t.Error("expected no gitflow.branch.* copied when auto-init refuses")
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.shared.autoInit"); v != "true" {
+		t.Errorf("expected the pre-existing autoInit control key preserved, got %q", v)
+	}
+}
+
+// TestSharedCustomDottedTypeAvailableBeforeActivation covers scenario 18: a custom
+// dotted-name topic type from .gitflow is usable on a fresh clone before activation.
+// Steps:
+// 1. Builds a fresh-clone fixture whose .gitflow defines a custom topic type qa.Release, autoInit=true
+// 2. Runs 'git flow qa.Release start x' as the first command
+// 3. Verifies the command is recognized and the dotted-name branch is created
+func TestSharedCustomDottedTypeAvailableBeforeActivation(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupFreshCloneWithShared(t, testutil.AuthorSharedConfig(t))
+	defer testutil.CleanupTestRepo(t, dir)
+	testutil.SharedConfigSet(t, dir, "gitflow.branch.qa.Release.type", "topic")
+	testutil.SharedConfigSet(t, dir, "gitflow.branch.qa.Release.parent", "develop")
+	testutil.SharedConfigSet(t, dir, "gitflow.branch.qa.Release.prefix", "qa.Release/")
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.shared.autoInit", "true"); err != nil {
+		t.Fatalf("failed to set autoInit: %v", err)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "qa.Release", "start", "x")
+	if err != nil {
+		t.Fatalf("qa.Release start failed: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "unknown command") {
+		t.Errorf("expected qa.Release command to be recognized, got: %s", out)
+	}
+	if !testutil.BranchExists(t, dir, "qa.Release/x") {
+		t.Error("expected qa.Release/x branch to be created with its dotted name preserved")
+	}
+}

--- a/test/cmd/shared_copy_test.go
+++ b/test/cmd/shared_copy_test.go
@@ -111,14 +111,53 @@ func TestSharedStartFetchDirectReadSite(t *testing.T) {
 	}
 }
 
-// TestSharedDeleteForceAndRemoteDirectReadSite covers scenario 14:
-// gitflow.feature.delete.force and gitflow.branch.feature.deleteRemote declared
-// only in .gitflow are honored (direct reads in cmd/delete.go).
+// TestSharedDeleteForceDirectReadSite covers scenario 14a:
+// gitflow.feature.delete.force declared only in .gitflow is honored (direct read
+// in cmd/delete.go), so an unmerged feature branch is force-deleted even without
+// --force on the CLI. (One behavior: force honored from shared config.)
 // Steps:
-// 1. Builds a repo+remote, authors a .gitflow with delete.force=true and deleteRemote=true, autoInit=true
-// 2. Starts feature/x, commits a unique (unmerged) change, and publishes it to origin
-// 3. Runs 'feature delete x' (no flags) and verifies the local and remote branches are gone
-func TestSharedDeleteForceAndRemoteDirectReadSite(t *testing.T) {
+// 1. Builds a fresh-clone fixture whose .gitflow sets delete.force=true (no deleteRemote), autoInit=true
+// 2. Starts feature/x and commits a unique (provably unmerged) change on it
+// 3. Runs 'feature delete x' (no --force) and verifies the local branch is gone
+func TestSharedDeleteForceDirectReadSite(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupFreshCloneWithShared(t, testutil.AuthorSharedConfig(t))
+	defer testutil.CleanupTestRepo(t, dir)
+	testutil.SharedConfigSet(t, dir, "gitflow.feature.delete.force", "true")
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.shared.autoInit", "true"); err != nil {
+		t.Fatalf("failed to set autoInit: %v", err)
+	}
+
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "start", "x"); err != nil {
+		t.Fatalf("feature start failed: %v\n%s", err, out)
+	}
+	if err := testutil.WriteFile(t, dir, "unmerged.txt", "unique"); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "add", "unmerged.txt"); err != nil {
+		t.Fatalf("failed to add file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "unique change"); err != nil {
+		t.Fatalf("failed to commit: %v", err)
+	}
+
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "delete", "x"); err != nil {
+		t.Fatalf("feature delete failed: %v\n%s", err, out)
+	}
+	if testutil.BranchExists(t, dir, "feature/x") {
+		t.Error("expected local feature/x to be deleted (force honored from shared config)")
+	}
+}
+
+// TestSharedDeleteRemoteDirectReadSite covers scenario 14b:
+// gitflow.branch.feature.deleteRemote declared only in .gitflow is honored
+// (direct read in cmd/delete.go). delete.force is present only so the unmerged
+// branch delete proceeds; the asserted behavior is REMOTE deletion.
+// Steps:
+// 1. Builds a repo+remote, authors a .gitflow with deleteRemote=true and delete.force=true, autoInit=true
+// 2. Starts feature/x, commits a unique change, and publishes it so refs/heads/feature/x exists on origin
+// 3. Runs 'feature delete x' (no flags) and verifies the remote branch is gone
+func TestSharedDeleteRemoteDirectReadSite(t *testing.T) {
 	t.Parallel()
 	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
 	defer testutil.CleanupTestRepo(t, dir)
@@ -127,8 +166,8 @@ func TestSharedDeleteForceAndRemoteDirectReadSite(t *testing.T) {
 	if err := os.WriteFile(testutil.SharedConfigPath(dir), testutil.AuthorSharedConfig(t), 0644); err != nil {
 		t.Fatalf("failed to write .gitflow: %v", err)
 	}
-	testutil.SharedConfigSet(t, dir, "gitflow.feature.delete.force", "true")
 	testutil.SharedConfigSet(t, dir, "gitflow.branch.feature.deleteRemote", "true")
+	testutil.SharedConfigSet(t, dir, "gitflow.feature.delete.force", "true")
 	testutil.ClearLocalGitflowConfig(t, dir)
 	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.shared.autoInit", "true"); err != nil {
 		t.Fatalf("failed to set autoInit: %v", err)
@@ -152,9 +191,6 @@ func TestSharedDeleteForceAndRemoteDirectReadSite(t *testing.T) {
 
 	if out, err := testutil.RunGitFlow(t, dir, "feature", "delete", "x"); err != nil {
 		t.Fatalf("feature delete failed: %v\n%s", err, out)
-	}
-	if testutil.BranchExists(t, dir, "feature/x") {
-		t.Error("expected local feature/x to be deleted (force honored from shared config)")
 	}
 	lsRemote, err := testutil.RunGit(t, dir, "ls-remote", "--heads", "origin", "refs/heads/feature/x")
 	if err != nil {

--- a/test/cmd/shared_worktree_test.go
+++ b/test/cmd/shared_worktree_test.go
@@ -1,0 +1,47 @@
+package cmd_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// TestSharedWorktreeInheritsConfig covers scenario 31: a linked worktree inherits
+// the copied config from the common .git/config, with no separate activation.
+// Steps:
+// 1. init --shared --defaults in the main clone (local now carries the copy)
+// 2. Adds a linked worktree on a new branch off main
+// 3. Runs 'feature start x' from the worktree
+// 4. Verifies no first-run prompt/notice and that feature/x exists from the worktree
+func TestSharedWorktreeInheritsConfig(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	wtPath, err := os.MkdirTemp("", "git-flow-test-wt-*")
+	if err != nil {
+		t.Fatalf("failed to create worktree temp dir: %v", err)
+	}
+	// git worktree add requires the destination not to pre-exist as a populated dir.
+	os.RemoveAll(wtPath)
+	if out, err := testutil.RunGit(t, dir, "worktree", "add", "-b", "wt-test", wtPath, "main"); err != nil {
+		t.Fatalf("git worktree add failed: %v\n%s", err, out)
+	}
+	t.Cleanup(func() {
+		_, _ = testutil.RunGit(t, dir, "worktree", "remove", "--force", wtPath)
+		os.RemoveAll(wtPath)
+	})
+
+	out, err := testutil.RunGitFlow(t, wtPath, "feature", "start", "x")
+	if err != nil {
+		t.Fatalf("feature start from worktree failed: %v\n%s", err, out)
+	}
+	if strings.Contains(out, ".gitflow") {
+		t.Errorf("expected no first-run .gitflow prompt/notice from the worktree, got: %s", out)
+	}
+	if !testutil.BranchExists(t, wtPath, "feature/x") {
+		t.Error("expected feature/x to exist when created from the worktree")
+	}
+}

--- a/test/internal/config/shared_test.go
+++ b/test/internal/config/shared_test.go
@@ -1,0 +1,284 @@
+package config_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/gittower/git-flow-next/internal/config"
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// setSharedConfig writes a key into the repository's .gitflow file via
+// `git config --file`.
+func setSharedConfig(t *testing.T, dir, key, value string) {
+	t.Helper()
+	cmd := exec.Command("git", "config", "--file", config.SharedConfigFileName, key, value)
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to set shared config %s: %v", key, err)
+	}
+}
+
+// localConfigValue returns a single value from local git config, and whether the
+// key is present.
+func localConfigValue(t *testing.T, dir, key string) (string, bool) {
+	t.Helper()
+	cmd := exec.Command("git", "config", "--local", "--get", key)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(string(out)), true
+}
+
+// TestSharedManagedKeyPredicate covers scenario 38: the shared-managed key
+// predicate classifies keys correctly (pure function, table-driven per the
+// TESTING_GUIDELINES exception).
+// Steps:
+// 1. Enumerates representative keys with their expected managed classification
+// 2. Calls config.IsSharedManagedKey on each
+// 3. Verifies control keys and runtime .base keys are excluded, real config included
+func TestSharedManagedKeyPredicate(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		key     string
+		managed bool
+	}{
+		{"gitflow.branch.feature.prefix", true},
+		{"gitflow.feature.publish.push-option", true},
+		{"gitflow.version", true},
+		{"gitflow.initialized", true},
+		{"gitflow.shared.autoInit", false},
+		{"gitflow.shared.trustHooks", false},
+		{"gitflow.branch.feature/foo.base", false},
+		{"core.sshCommand", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.key, func(t *testing.T) {
+			if got := config.IsSharedManagedKey(tc.key); got != tc.managed {
+				t.Errorf("IsSharedManagedKey(%q) = %v, want %v", tc.key, got, tc.managed)
+			}
+		})
+	}
+}
+
+// TestCopySharedToLocalStaleRemovalPreservesLocalOnly covers scenario 39:
+// CopySharedToLocal removes stale managed keys but preserves local-only keys.
+// Steps:
+// 1. Seeds local with a stale managed key, a shared-control key, and a runtime base key
+// 2. Writes a .gitflow with feature defaults (no "old" branch)
+// 3. Calls config.CopySharedToLocal
+// 4. Verifies old.* is gone, feature.* copied, and the local-only keys preserved
+func TestCopySharedToLocalStaleRemovalPreservesLocalOnly(t *testing.T) {
+	t.Parallel()
+	dir := setupTestRepo(t)
+	defer cleanupTestRepo(t, dir)
+
+	setConfig(t, dir, "gitflow.branch.old.type", "topic")
+	setConfig(t, dir, "gitflow.shared.autoInit", "true")
+	setConfig(t, dir, "gitflow.branch.feature/foo.base", "develop")
+
+	setSharedConfig(t, dir, "gitflow.version", "1.0")
+	setSharedConfig(t, dir, "gitflow.branch.feature.type", "topic")
+	setSharedConfig(t, dir, "gitflow.branch.feature.prefix", "feature/")
+
+	if _, err := config.CopySharedToLocal(openRepo(t, dir)); err != nil {
+		t.Fatalf("CopySharedToLocal failed: %v", err)
+	}
+
+	if _, ok := localConfigValue(t, dir, "gitflow.branch.old.type"); ok {
+		t.Error("expected stale gitflow.branch.old.type to be removed from local")
+	}
+	if v, _ := localConfigValue(t, dir, "gitflow.branch.feature.prefix"); v != "feature/" {
+		t.Errorf("expected local feature.prefix=feature/, got %q", v)
+	}
+	if v, _ := localConfigValue(t, dir, "gitflow.shared.autoInit"); v != "true" {
+		t.Errorf("expected local gitflow.shared.autoInit preserved as true, got %q", v)
+	}
+	if v, _ := localConfigValue(t, dir, "gitflow.branch.feature/foo.base"); v != "develop" {
+		t.Errorf("expected runtime gitflow.branch.feature/foo.base preserved as develop, got %q", v)
+	}
+}
+
+// TestCopySharedToLocalIgnoresExcludedKeysInFile covers scenario 39b:
+// CopySharedToLocal never copies excluded keys that appear inside .gitflow and
+// never overwrites their local counterparts.
+// Steps:
+// 1. Seeds local counterparts for each excluded key with differing values
+// 2. Writes a .gitflow that (wrongly) contains excluded keys plus feature defaults
+// 3. Calls config.CopySharedToLocal
+// 4. Verifies excluded keys are inert (not copied / not overwritten) and defaults copied
+func TestCopySharedToLocalIgnoresExcludedKeysInFile(t *testing.T) {
+	t.Parallel()
+	dir := setupTestRepo(t)
+	defer cleanupTestRepo(t, dir)
+
+	setConfig(t, dir, "gitflow.shared.autoInit", "false")
+	setConfig(t, dir, "gitflow.branch.feature/foo.base", "develop")
+
+	setSharedConfig(t, dir, "gitflow.version", "1.0")
+	setSharedConfig(t, dir, "gitflow.shared.autoInit", "true")
+	setSharedConfig(t, dir, "gitflow.shared.trustHooks", "true")
+	setSharedConfig(t, dir, "gitflow.branch.feature/foo.base", "main")
+	setSharedConfig(t, dir, "gitflow.branch.feature.type", "topic")
+	setSharedConfig(t, dir, "gitflow.branch.feature.prefix", "feature/")
+
+	if _, err := config.CopySharedToLocal(openRepo(t, dir)); err != nil {
+		t.Fatalf("CopySharedToLocal failed: %v", err)
+	}
+
+	if v, _ := localConfigValue(t, dir, "gitflow.shared.autoInit"); v != "false" {
+		t.Errorf("expected local gitflow.shared.autoInit untouched (false), got %q", v)
+	}
+	if v, _ := localConfigValue(t, dir, "gitflow.branch.feature/foo.base"); v != "develop" {
+		t.Errorf("expected local runtime base untouched (develop), got %q", v)
+	}
+	if _, ok := localConfigValue(t, dir, "gitflow.shared.trustHooks"); ok {
+		t.Error("expected local gitflow.shared.trustHooks NOT created from .gitflow")
+	}
+	if v, _ := localConfigValue(t, dir, "gitflow.branch.feature.prefix"); v != "feature/" {
+		t.Errorf("expected local feature.prefix copied as feature/, got %q", v)
+	}
+}
+
+// TestIsUnconfiguredFreshRepo covers scenario 40a: a fresh repo with no gitflow.*
+// reads as unconfigured.
+// Steps:
+// 1. Creates a fresh repository with no git-flow config
+// 2. Calls config.IsUnconfiguredIgnoringShared
+// 3. Verifies it reports unconfigured (true)
+func TestIsUnconfiguredFreshRepo(t *testing.T) {
+	t.Parallel()
+	dir := setupTestRepo(t)
+	defer cleanupTestRepo(t, dir)
+
+	unconfigured, err := config.IsUnconfiguredIgnoringShared(openRepo(t, dir))
+	if err != nil {
+		t.Fatalf("IsUnconfiguredIgnoringShared failed: %v", err)
+	}
+	if !unconfigured {
+		t.Error("expected fresh repo to read as unconfigured")
+	}
+}
+
+// TestIsUnconfiguredSharedControlOnly covers scenario 40b: a repo carrying only
+// gitflow.shared.* control keys still reads as unconfigured.
+// Steps:
+// 1. Sets only gitflow.shared.autoInit and gitflow.shared.trustHooks
+// 2. Calls config.IsUnconfiguredIgnoringShared
+// 3. Verifies it reports unconfigured (shared-control keys are ignored)
+func TestIsUnconfiguredSharedControlOnly(t *testing.T) {
+	t.Parallel()
+	dir := setupTestRepo(t)
+	defer cleanupTestRepo(t, dir)
+
+	setConfig(t, dir, "gitflow.shared.autoInit", "true")
+	setConfig(t, dir, "gitflow.shared.trustHooks", "true")
+
+	unconfigured, err := config.IsUnconfiguredIgnoringShared(openRepo(t, dir))
+	if err != nil {
+		t.Fatalf("IsUnconfiguredIgnoringShared failed: %v", err)
+	}
+	if !unconfigured {
+		t.Error("expected shared-control-only repo to read as unconfigured")
+	}
+}
+
+// TestIsUnconfiguredCommandOnlyKey covers scenario 40c: a repo with only a
+// command-scoped gitflow.* key (no version, no branch definitions) still reads as
+// unconfigured.
+// Steps:
+// 1. Sets only gitflow.feature.start.fetch=true
+// 2. Calls config.IsUnconfiguredIgnoringShared
+// 3. Verifies it reports unconfigured (a stray command key is not branch config)
+func TestIsUnconfiguredCommandOnlyKey(t *testing.T) {
+	t.Parallel()
+	dir := setupTestRepo(t)
+	defer cleanupTestRepo(t, dir)
+
+	setConfig(t, dir, "gitflow.feature.start.fetch", "true")
+
+	unconfigured, err := config.IsUnconfiguredIgnoringShared(openRepo(t, dir))
+	if err != nil {
+		t.Fatalf("IsUnconfiguredIgnoringShared failed: %v", err)
+	}
+	if !unconfigured {
+		t.Error("expected command-only-key repo to read as unconfigured")
+	}
+}
+
+// TestIsUnconfiguredAfterGitFlowInit covers scenario 40d: a repo initialized by
+// git-flow-next reads as configured.
+// Steps:
+// 1. Initializes git-flow with defaults via the binary
+// 2. Calls config.IsUnconfiguredIgnoringShared
+// 3. Verifies it reports configured (false)
+func TestIsUnconfiguredAfterGitFlowInit(t *testing.T) {
+	t.Parallel()
+	dir := setupTestRepo(t)
+	defer cleanupTestRepo(t, dir)
+
+	cmd := exec.Command(testutil.GitFlowPath(), "init", "--defaults")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git flow init failed: %v\n%s", err, out)
+	}
+
+	unconfigured, err := config.IsUnconfiguredIgnoringShared(openRepo(t, dir))
+	if err != nil {
+		t.Fatalf("IsUnconfiguredIgnoringShared failed: %v", err)
+	}
+	if unconfigured {
+		t.Error("expected git-flow-initialized repo to read as configured")
+	}
+}
+
+// TestIsUnconfiguredAvhOnlyNoVersion covers scenario 40e: AVH-only config with no
+// gitflow.version reads as configured.
+// Steps:
+// 1. Sets git-flow-avh style keys (gitflow.branch.master, gitflow.prefix.feature) and no version
+// 2. Calls config.IsUnconfiguredIgnoringShared
+// 3. Verifies it reports configured (AVH branch config counts as configuration)
+func TestIsUnconfiguredAvhOnlyNoVersion(t *testing.T) {
+	t.Parallel()
+	dir := setupTestRepo(t)
+	defer cleanupTestRepo(t, dir)
+
+	setConfig(t, dir, "gitflow.branch.master", "master")
+	setConfig(t, dir, "gitflow.branch.develop", "develop")
+	setConfig(t, dir, "gitflow.prefix.feature", "feature/")
+
+	unconfigured, err := config.IsUnconfiguredIgnoringShared(openRepo(t, dir))
+	if err != nil {
+		t.Fatalf("IsUnconfiguredIgnoringShared failed: %v", err)
+	}
+	if unconfigured {
+		t.Error("expected AVH-only repo to read as configured")
+	}
+}
+
+// TestIsUnconfiguredBranchDefsNoVersion covers scenario 40f: valid
+// git-flow-next branch definitions without gitflow.version read as configured.
+// Steps:
+// 1. Sets gitflow.branch.feature.type/parent/prefix but no gitflow.version
+// 2. Calls config.IsUnconfiguredIgnoringShared
+// 3. Verifies it reports configured (branch definitions alone are enough)
+func TestIsUnconfiguredBranchDefsNoVersion(t *testing.T) {
+	t.Parallel()
+	dir := setupTestRepo(t)
+	defer cleanupTestRepo(t, dir)
+
+	setConfig(t, dir, "gitflow.branch.feature.type", "topic")
+	setConfig(t, dir, "gitflow.branch.feature.parent", "develop")
+	setConfig(t, dir, "gitflow.branch.feature.prefix", "feature/")
+
+	unconfigured, err := config.IsUnconfiguredIgnoringShared(openRepo(t, dir))
+	if err != nil {
+		t.Fatalf("IsUnconfiguredIgnoringShared failed: %v", err)
+	}
+	if unconfigured {
+		t.Error("expected repo with branch definitions to read as configured")
+	}
+}

--- a/test/internal/config/shared_test.go
+++ b/test/internal/config/shared_test.go
@@ -1,7 +1,6 @@
 package config_test
 
 import (
-	"os/exec"
 	"strings"
 	"testing"
 
@@ -13,9 +12,7 @@ import (
 // `git config --file`.
 func setSharedConfig(t *testing.T, dir, key, value string) {
 	t.Helper()
-	cmd := exec.Command("git", "config", "--file", config.SharedConfigFileName, key, value)
-	cmd.Dir = dir
-	if err := cmd.Run(); err != nil {
+	if _, err := testutil.RunGit(t, dir, "config", "--file", config.SharedConfigFileName, key, value); err != nil {
 		t.Fatalf("Failed to set shared config %s: %v", key, err)
 	}
 }
@@ -24,13 +21,11 @@ func setSharedConfig(t *testing.T, dir, key, value string) {
 // key is present.
 func localConfigValue(t *testing.T, dir, key string) (string, bool) {
 	t.Helper()
-	cmd := exec.Command("git", "config", "--local", "--get", key)
-	cmd.Dir = dir
-	out, err := cmd.Output()
+	out, err := testutil.RunGit(t, dir, "config", "--local", "--get", key)
 	if err != nil {
 		return "", false
 	}
-	return strings.TrimSpace(string(out)), true
+	return strings.TrimSpace(out), true
 }
 
 // TestSharedManagedKeyPredicate covers scenario 38: the shared-managed key
@@ -220,9 +215,7 @@ func TestIsUnconfiguredAfterGitFlowInit(t *testing.T) {
 	dir := setupTestRepo(t)
 	defer cleanupTestRepo(t, dir)
 
-	cmd := exec.Command(testutil.GitFlowPath(), "init", "--defaults")
-	cmd.Dir = dir
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
 		t.Fatalf("git flow init failed: %v\n%s", err, out)
 	}
 

--- a/test/testutil/git.go
+++ b/test/testutil/git.go
@@ -156,6 +156,197 @@ func RunGitFlowWithInput(t *testing.T, dir string, input string, args ...string)
 	return string(output), nil
 }
 
+// RunGitFlowInteractive runs a git-flow command with the given stdin input and
+// forces the first-run interactivity seam ON via GIT_FLOW_ASSUME_INTERACTIVE=1.
+// The subprocess test harness cannot allocate a PTY, so git-flow's real
+// term.IsTerminal check would always report non-interactive; this test-only env
+// var makes the first-run activation decision treat stdin as interactive and
+// read the answer from the piped input. Use it for the prompt scenarios (accept
+// "y\n" / decline "n\n"); use RunGitFlow (env unset) to exercise the
+// non-interactive hint path.
+func RunGitFlowInteractive(t *testing.T, dir string, input string, args ...string) (string, error) {
+	cmd := exec.Command(gitFlowPath, args...)
+	cmd.Dir = dir
+	cmd.Stdin = strings.NewReader(input)
+	cmd.Env = append(os.Environ(), "GIT_EDITOR=:", "GIT_FLOW_ASSUME_INTERACTIVE=1")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return string(output), &ExitError{
+				ExitCode: exitErr.ExitCode(),
+				Err:      fmt.Errorf("%s", output),
+			}
+		}
+		return string(output), err
+	}
+	return string(output), nil
+}
+
+// SharedConfigPath returns the path to the committable .gitflow file at the root
+// of the given repository directory.
+func SharedConfigPath(dir string) string {
+	return filepath.Join(dir, ".gitflow")
+}
+
+// GitConfigValue returns a single git config value from the repository's LOCAL
+// scope (.git/config), or the empty string when the key is unset. Reading from
+// local scope (not merged) is what the shared-copy tests need: they verify keys
+// actually landed in .git/config.
+func GitConfigValue(t *testing.T, dir, key string) string {
+	out, err := RunGit(t, dir, "config", "--local", "--get", key)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(out)
+}
+
+// GitConfigExists reports whether a key is present in the repository's LOCAL
+// git config.
+func GitConfigExists(t *testing.T, dir, key string) bool {
+	_, err := RunGit(t, dir, "config", "--local", "--get", key)
+	return err == nil
+}
+
+// GitConfigAll returns all values for a (possibly multi-value) key from the
+// repository's LOCAL git config, in file order. Returns nil when unset.
+func GitConfigAll(t *testing.T, dir, key string) []string {
+	out, err := RunGit(t, dir, "config", "--local", "--get-all", key)
+	if err != nil {
+		return nil
+	}
+	var vals []string
+	for _, l := range strings.Split(strings.TrimSpace(out), "\n") {
+		if l != "" {
+			vals = append(vals, l)
+		}
+	}
+	return vals
+}
+
+// GitConfigHasPrefix reports whether the repository's LOCAL git config contains
+// any key whose name starts with the given prefix (e.g. "gitflow.branch.qa.").
+func GitConfigHasPrefix(t *testing.T, dir, prefix string) bool {
+	out, err := RunGit(t, dir, "config", "--local", "--get-regexp", "^"+prefix)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(out) != ""
+}
+
+// SharedConfigValue returns a single value from the .gitflow file, or empty when
+// unset.
+func SharedConfigValue(t *testing.T, dir, key string) string {
+	out, err := RunGit(t, dir, "config", "--file", SharedConfigPath(dir), "--get", key)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(out)
+}
+
+// SharedConfigAll returns all values for a key from the .gitflow file, in order.
+func SharedConfigAll(t *testing.T, dir, key string) []string {
+	out, err := RunGit(t, dir, "config", "--file", SharedConfigPath(dir), "--get-all", key)
+	if err != nil {
+		return nil
+	}
+	var vals []string
+	for _, l := range strings.Split(strings.TrimSpace(out), "\n") {
+		if l != "" {
+			vals = append(vals, l)
+		}
+	}
+	return vals
+}
+
+// SharedConfigSet sets a key in the .gitflow file via `git config --file`.
+func SharedConfigSet(t *testing.T, dir, key, value string) {
+	t.Helper()
+	if _, err := RunGit(t, dir, "config", "--file", SharedConfigPath(dir), key, value); err != nil {
+		t.Fatalf("Failed to set %s in .gitflow: %v", key, err)
+	}
+}
+
+// SharedConfigHasPrefix reports whether the .gitflow file contains any key whose
+// name starts with the given prefix.
+func SharedConfigHasPrefix(t *testing.T, dir, prefix string) bool {
+	out, err := RunGit(t, dir, "config", "--file", SharedConfigPath(dir), "--get-regexp", "^"+prefix)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(out) != ""
+}
+
+// AuthorSharedConfig runs `git flow init --shared --defaults` (plus any extra
+// args) in a throwaway repository and returns the raw bytes of the resulting
+// .gitflow file. Callers copy this into a fresh clone via SetupFreshCloneWithShared.
+func AuthorSharedConfig(t *testing.T, extraArgs ...string) []byte {
+	t.Helper()
+	src := SetupTestRepo(t)
+	defer CleanupTestRepo(t, src)
+	args := append([]string{"init", "--shared", "--defaults"}, extraArgs...)
+	if out, err := RunGitFlow(t, src, args...); err != nil {
+		t.Fatalf("Failed to author shared config: %v\nOutput: %s", err, out)
+	}
+	data, err := os.ReadFile(SharedConfigPath(src))
+	if err != nil {
+		t.Fatalf("Failed to read authored .gitflow: %v", err)
+	}
+	return data
+}
+
+// SetupFreshCloneWithShared creates a fresh repository that contains a committed
+// .gitflow file (with the given content) but NO local gitflow.* keys, simulating
+// a fresh clone of a repository that carries a committed .gitflow before its
+// first-run activation. Like a real clone of a defaults repo, it also has a
+// develop branch (the non-trunk base of the default configuration) so topic
+// branches that start from develop can be created after activation.
+func SetupFreshCloneWithShared(t *testing.T, gitflowContent []byte) string {
+	t.Helper()
+	dir := SetupTestRepo(t)
+	if err := os.WriteFile(SharedConfigPath(dir), gitflowContent, 0644); err != nil {
+		t.Fatalf("Failed to write .gitflow: %v", err)
+	}
+	if _, err := RunGit(t, dir, "add", ".gitflow"); err != nil {
+		t.Fatalf("Failed to stage .gitflow: %v", err)
+	}
+	if _, err := RunGit(t, dir, "commit", "-m", "Add committed .gitflow"); err != nil {
+		t.Fatalf("Failed to commit .gitflow: %v", err)
+	}
+	// A real clone of a git-flow-defaults repository has develop as well as main.
+	// Branch develop AFTER committing .gitflow so both branches carry the file;
+	// this keeps the work tree switchable when a test edits the (tracked) .gitflow.
+	if _, err := RunGit(t, dir, "branch", "develop"); err != nil {
+		t.Fatalf("Failed to create develop branch: %v", err)
+	}
+	return dir
+}
+
+// ClearLocalGitflowConfig removes every gitflow.* key from the repository's LOCAL
+// git config, leaving other scopes and any .gitflow file untouched. It is used to
+// return a repository that ran `git flow init` to a real "fresh clone" state
+// (branches present, but no local git-flow configuration).
+func ClearLocalGitflowConfig(t *testing.T, dir string) {
+	t.Helper()
+	out, err := RunGit(t, dir, "config", "--local", "--get-regexp", "^gitflow\\.")
+	if err != nil {
+		// No gitflow.* keys present: nothing to clear.
+		return
+	}
+	seen := map[string]bool{}
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if line == "" {
+			continue
+		}
+		key := strings.SplitN(line, " ", 2)[0]
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		// --unset-all removes multi-value keys too; ignore "not found".
+		_, _ = RunGit(t, dir, "config", "--local", "--unset-all", key)
+	}
+}
+
 // SetupTestRepo creates a temporary Git repository for testing
 func SetupTestRepo(t *testing.T) string {
 	// Create temporary directory

--- a/test/testutil/git.go
+++ b/test/testutil/git.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -342,8 +343,17 @@ func ClearLocalGitflowConfig(t *testing.T, dir string) {
 			continue
 		}
 		seen[key] = true
-		// --unset-all removes multi-value keys too; ignore "not found".
-		_, _ = RunGit(t, dir, "config", "--local", "--unset-all", key)
+		// --unset-all removes multi-value keys too. The key was just enumerated
+		// from --get-regexp, so it exists; only exit 5 ("key not found", e.g. a
+		// concurrent unset) is benign — any other failure is unexpected and would
+		// leave the config partially cleared, so fail the test loudly.
+		if _, err := RunGit(t, dir, "config", "--local", "--unset-all", key); err != nil {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) && exitErr.ExitCode() == 5 {
+				continue
+			}
+			t.Fatalf("Failed to unset local gitflow config %s: %v", key, err)
+		}
 	}
 }
 


### PR DESCRIPTION
Adds a committable `.gitflow` file that carries the `gitflow.*` configuration so a fresh clone works with minimal setup, copying those keys submodule-style into the clone's local `.git/config` where every read site sees them.

The mechanism is a raw copy (not `include.path` or side-file reads): only `gitflow.*` keys are enumerated from `.gitflow` and written into local config, so a committed file can never inject `core.*`/`alias.*` or trigger code execution, and native git layering handles global/local precedence. `init --shared` authors the structured config to `<toplevel>/.gitflow` and copies it into local. First-run activation runs from a `PersistentPreRunE` on the root command: when a clone is unconfigured but `.gitflow` is present it prompts (interactive), auto-activates (`gitflow.shared.autoInit=true`), or prints a hint pointing at `git flow config sync` (non-interactive), all TTY-aware and gated by a hook-trust policy (`gitflow.path.hooks` is skipped unless `gitflow.shared.trustHooks=true`). New `config sync` re-copies the shared-managed key set (overwrite plus stale-key removal) and `config status` reports drift (exit code 6), both exempt from activation so they stay scriptable. `--shared` is added to every config CRUD verb (add/edit/rename/delete), reading and writing `.gitflow` then re-syncing local. Dynamic topic registration folds in `.gitflow`-declared branch types so custom `git flow <type>` commands exist before activation. Default `git flow init` behavior is unchanged and non-breaking. Touches `cmd/init.go`, `cmd/config.go`, `cmd/firstrun.go`, `cmd/topicbranch.go`, `cmd/root.go`, `internal/config/shared.go`, `internal/git/config.go`, `internal/errors/errors.go`, the `isterminal_*` build-tagged terminal detection, and docs (`git-flow-init.1`, `git-flow-config.1`, `gitflow-config.5`, `CONFIGURATION.md`).

Closes #135

## Remarks

- Went through a Codex-gated test plan and a Codex code review; all accepted findings are fixed on the branch (config verbs exempt from first-run activation, hint points at `config sync`, `--shared` CRUD works on a fresh clone, status surfaces stale hooks after trust revocation, Unix terminal-detection build tags narrowed to match constant availability).
- One finding is deferred to a follow-up: `config edit topic --tag=false` does not clear an existing `tag=true` because `SaveConfigWithScope` only serializes `tag` when true. This is pre-existing behavior that also reproduces on `main` for local edits and is outside #135's scope.
- Multi-line git-config values are not supported by the raw copy; no `gitflow.*` value is ever multi-line, so this is a documented limitation, not a gap.

**Review focus:**
- `internal/config/shared.go` - shared-managed key predicate, raw copy with stale removal and hook-trust filter, drift compare
- `cmd/firstrun.go` - first-run activation branches (prompt / auto-init / hint), TTY and hook-trust gating
- `cmd/config.go` - `sync`/`status` executors and `--shared` routing through the shared path