### PR TITLE
fix(config): Load Layer 2 config for avh repos

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -218,7 +218,7 @@ func Load(repo *git.Repo) (*Config, error) {
 		Branches:      make(map[string]BranchConfig),
 	}
 
-	// Load all gitflow.* command-specific config at once
+	// Load all gitflow.* config at once
 	allGitflowConfig, err := loadAllGitflowConfig(repo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load gitflow config: %w", err)
@@ -408,9 +408,18 @@ func CheckGitFlowAVHConfig(repo *git.Repo) bool {
 func ImportGitFlowAVHConfig(repo *git.Repo) (*Config, error) {
 	config := DefaultConfig()
 
+	// Load all gitflow.* config at once so that command-specific
+	// settings like gitflow.release.finish.push are honoured even
+	// when the repo was initialised with git-flow-avh.
+	allGitflowConfig, err := loadAllGitflowConfig(repo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load gitflow config: %w", err)
+	}
+	config.CommandConfig = allGitflowConfig
+
 	// Check for custom remote in git-flow-avh config
-	remote, err := repo.GetConfig("gitflow.origin")
-	if err == nil && remote != "" {
+	remote, ok := allGitflowConfig["gitflow.origin"]
+	if ok && remote != "" {
 		config.Remote = remote
 	}
 

--- a/test/cmd/finish_push_test.go
+++ b/test/cmd/finish_push_test.go
@@ -1205,3 +1205,99 @@ func TestFinishPushConfigYesNoPushFlagOverrides(t *testing.T) {
 		t.Errorf("Expected no push with --no-push. Output: %s", output)
 	}
 }
+
+// setupAVHRepoWithRemote creates a repository initialised with git-flow-avh
+// style config (gitflow.prefix.* keys, no gitflow.version) and a bare remote
+// with main and develop pushed and tracked.
+//
+// This intentionally duplicates parts of testutil.SetupTestRepoWithRemote
+// because that helper runs "git flow init --defaults", which writes
+// gitflow.version and routes through Load() instead of ImportGitFlowAVHConfig.
+// An AVH-only repo must have no gitflow.version so the AVH import path is used.
+func setupAVHRepoWithRemote(t *testing.T) (string, string) {
+	t.Helper()
+	dir := testutil.SetupTestRepo(t)
+
+	// Set git-flow-avh config keys (no gitflow.version)
+	avhKeys := map[string]string{
+		"gitflow.branch.master":  "main",
+		"gitflow.branch.develop": "develop",
+		"gitflow.prefix.feature": "feature/",
+		"gitflow.prefix.release": "release/",
+		"gitflow.prefix.hotfix":  "hotfix/",
+		"gitflow.prefix.support": "support/",
+	}
+	for k, v := range avhKeys {
+		if _, err := testutil.RunGit(t, dir, "config", k, v); err != nil {
+			testutil.CleanupTestRepo(t, dir)
+			t.Fatalf("Failed to set avh config %s: %v", k, err)
+		}
+	}
+
+	// Create develop branch
+	if _, err := testutil.RunGit(t, dir, "checkout", "-b", "develop"); err != nil {
+		testutil.CleanupTestRepo(t, dir)
+		t.Fatalf("Failed to create develop: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "checkout", "main"); err != nil {
+		testutil.CleanupTestRepo(t, dir)
+		t.Fatalf("Failed to checkout main: %v", err)
+	}
+
+	// Add remote and push both branches
+	remoteDir, err := testutil.AddRemote(t, dir, "origin", false)
+	if err != nil {
+		testutil.CleanupTestRepo(t, dir)
+		t.Fatalf("Failed to add remote: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "push", "-u", "origin", "main"); err != nil {
+		testutil.CleanupTestRepo(t, dir)
+		testutil.CleanupTestRepo(t, remoteDir)
+		t.Fatalf("Failed to push main: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "push", "-u", "origin", "develop"); err != nil {
+		testutil.CleanupTestRepo(t, dir)
+		testutil.CleanupTestRepo(t, remoteDir)
+		t.Fatalf("Failed to push develop: %v", err)
+	}
+
+	return dir, remoteDir
+}
+
+// TestFinishPushAVHRepoConfigEnablesPush verifies that Layer 2 command config
+// (gitflow.feature.finish.push=true) triggers a push in a repo initialised with
+// git-flow-avh style config (no gitflow.version).
+// Steps:
+// 1. Sets up a repo with avh-style config and a remote tracking main and develop
+// 2. Sets gitflow.feature.finish.push=true
+// 3. Creates feature branch with one commit
+// 4. Finishes the feature without --push flag
+// 5. Verifies develop is up to date with origin (config alone triggers push)
+// 6. Verifies output contains the push header and develop push line
+func TestFinishPushAVHRepoConfigEnablesPush(t *testing.T) {
+	t.Parallel()
+	dir, remoteDir := setupAVHRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.feature.finish.push", "true"); err != nil {
+		t.Fatalf("Failed to configure push: %v", err)
+	}
+
+	createTopicCommit(t, dir, "feature", "login", "login.txt", "login content")
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "login", "--no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to finish feature in AVH repo: %v\nOutput: %s", err, output)
+	}
+
+	if got := testutil.CommitsAhead(t, dir, "origin/develop", "develop"); got != 0 {
+		t.Errorf("Expected develop up to date with origin (AVH repo, config push), got %d ahead. Output: %s", got, output)
+	}
+	if !strings.Contains(output, pushHeader) {
+		t.Errorf("Expected push header in output. Output: %s", output)
+	}
+	if !strings.Contains(output, pushDevelLine) {
+		t.Errorf("Expected develop push line in output. Output: %s", output)
+	}
+}

--- a/test/internal/config/config_test.go
+++ b/test/internal/config/config_test.go
@@ -408,6 +408,33 @@ func TestGitFlowAVHRemoteImport(t *testing.T) {
 	assert.Equal(t, "avh-remote", cfg.Remote, "git-flow-avh remote should be imported")
 }
 
+// TestGitFlowAVHCommandConfigImport verifies that ImportGitFlowAVHConfig
+// populates CommandConfig with Layer 2 command-specific settings.
+// Steps:
+// 1. Sets up a test repository with git-flow-avh style config
+// 2. Sets gitflow.release.finish.push=true and gitflow.feature.start.fetch=true
+// 3. Imports git-flow-avh config through a git.Repo handle
+// 4. Verifies both settings are present in CommandConfig
+func TestGitFlowAVHCommandConfigImport(t *testing.T) {
+	t.Parallel()
+	dir := setupTestRepo(t)
+	defer cleanupTestRepo(t, dir)
+
+	setConfig(t, dir, "gitflow.prefix.feature", "feature/")
+	setConfig(t, dir, "gitflow.release.finish.push", "true")
+	setConfig(t, dir, "gitflow.feature.start.fetch", "true")
+
+	cfg, err := config.ImportGitFlowAVHConfig(openRepo(t, dir))
+	if err != nil {
+		t.Fatalf("Failed to import git-flow-avh config: %v", err)
+	}
+
+	assert.Equal(t, "true", cfg.CommandConfig["gitflow.release.finish.push"],
+		"release.finish.push should be loaded into CommandConfig")
+	assert.Equal(t, "true", cfg.CommandConfig["gitflow.feature.start.fetch"],
+		"feature.start.fetch should be loaded into CommandConfig")
+}
+
 // TestLoadConfigPreservesBranchNameCase verifies that the canonical casing of a
 // branch name is preserved and remains case-insensitively resolvable.
 // Steps:


### PR DESCRIPTION
`ImportGitFlowAVHConfig` started from DefaultConfig which has an empty `CommandConfig` map and never called `loadAllGitflowConfig`. This silently ignored all command-specific settings (e.g. `gitflow.release.finish.push`) for repos initialised with git-flow-avh. 

Resolves #190