### PR TITLE
feat(version): Print bare version number first

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -19,7 +19,10 @@ var versionCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Long:  `Display version information for git-flow-next.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("git-flow-next version %s\n", Version)
+		// Version number first, then a parenthesized edition marker: the same
+		// shape git-flow-avh uses ("1.12.3 (AVH Edition)"), so tooling that
+		// parses the first whitespace-separated token works unchanged.
+		fmt.Printf("%s (git-flow-next)\n", Version)
 		if BuildDate != "unknown" {
 			fmt.Printf("Build date: %s\n", BuildDate)
 		}

--- a/docs/git-flow.1.md
+++ b/docs/git-flow.1.md
@@ -39,7 +39,7 @@ This implementation maintains compatibility with existing git-flow repositories 
 : Integrate a base branch into its parent (e.g. develop into main). See **git-flow-integrate**(1).
 
 **version**
-: Show version information.
+: Show version information. Prints `<version> (git-flow-next)`, so tooling that parses the first whitespace-separated token reads a bare version number.
 
 ### Topic Branch Commands
 

--- a/test/cmd/shared_activation_test.go
+++ b/test/cmd/shared_activation_test.go
@@ -205,7 +205,7 @@ func TestNoSharedFileBehavesAsToday(t *testing.T) {
 // Steps:
 // 1. Creates a bare repository
 // 2. Runs 'git flow version' in it
-// 3. Verifies exit 0, normal version output, and no .gitflow text or panic
+// 3. Verifies exit 0, output exactly '<version> (git-flow-next)', and no .gitflow text or panic
 func TestBareRepoNoSharedDetection(t *testing.T) {
 	t.Parallel()
 	bareDir, err := os.MkdirTemp("", "git-flow-test-bare-*")
@@ -221,9 +221,7 @@ func TestBareRepoNoSharedDetection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("version in bare repo failed: %v\n%s", err, out)
 	}
-	if !strings.Contains(out, "git-flow-next version") {
-		t.Errorf("expected version output, got: %s", out)
-	}
+	assertVersionOutput(t, out)
 	if strings.Contains(out, ".gitflow") {
 		t.Errorf("expected no .gitflow text in bare-repo version output, got: %s", out)
 	}

--- a/test/cmd/version_test.go
+++ b/test/cmd/version_test.go
@@ -1,0 +1,112 @@
+package cmd_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/gittower/git-flow-next/test/testutil"
+	"github.com/gittower/git-flow-next/version"
+)
+
+// expectedVersionLine is the exact stdout 'git flow version' must produce.
+// It is built from version.Version rather than a literal so the tests stay
+// correct across releases, and so they fail loudly if the version value in
+// cmd/version.go ever drifts from version/version.go, which CLAUDE.md requires
+// to stay in sync.
+var expectedVersionLine = version.Version + " (git-flow-next)\n"
+
+// bareSemverPattern matches a version number with no tool-name prefix and no
+// leading 'v' - the shape AVH-compatible parsers read from the first token.
+var bareSemverPattern = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+
+// assertVersionOutput fails unless out is exactly the expected version line.
+func assertVersionOutput(t *testing.T, out string) {
+	t.Helper()
+
+	if out != expectedVersionLine {
+		t.Errorf("Expected output %q, got %q", expectedVersionLine, out)
+	}
+}
+
+// TestVersionOutputFormat verifies 'git flow version' writes the version number
+// before the tool name, on stdout, in an initialized repository.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Runs 'git flow version' capturing stdout and stderr separately
+// 3. Verifies the command exits 0
+// 4. Verifies stdout is exactly '<version> (git-flow-next)' with a trailing newline and nothing else
+// 5. Verifies stderr is empty
+func TestVersionOutputFormat(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	output, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+
+	stdout, stderr, err := testutil.RunGitFlowStreams(t, dir, "version")
+	if err != nil {
+		t.Fatalf("Failed to run version: %v\nStderr: %s", err, stderr)
+	}
+
+	assertVersionOutput(t, stdout)
+	if stderr != "" {
+		t.Errorf("Expected empty stderr, got %q", stderr)
+	}
+}
+
+// TestVersionNumberIsBareSemver verifies the version number carries no prefix,
+// which is the property AVH-compatible parsers rely on when they read the first
+// whitespace-separated token of the output.
+// Steps:
+// 1. Reads the canonical version constant
+// 2. Verifies it matches a bare semantic version with no tool name and no leading 'v'
+func TestVersionNumberIsBareSemver(t *testing.T) {
+	t.Parallel()
+
+	if !bareSemverPattern.MatchString(version.Version) {
+		t.Errorf("Expected version %q to be a bare semantic version", version.Version)
+	}
+}
+
+// TestVersionInUninitializedRepo verifies 'git flow version' prints the same
+// line in a repository without git-flow configuration, without printing a
+// first-run activation prompt or hint.
+// Steps:
+// 1. Sets up a test repository without running 'git flow init'
+// 2. Runs 'git flow version' non-interactively
+// 3. Verifies the command exits 0
+// 4. Verifies the output is exactly the expected version line, which proves no prompt or hint was appended
+func TestVersionInUninitializedRepo(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	out, err := testutil.RunGitFlow(t, dir, "version")
+	if err != nil {
+		t.Fatalf("Failed to run version in uninitialized repo: %v\nOutput: %s", err, out)
+	}
+
+	assertVersionOutput(t, out)
+}
+
+// TestVersionOutsideGitRepository verifies 'git flow version' prints the same
+// line outside any Git repository, without printing a Git error.
+// Steps:
+// 1. Creates a temporary directory that is not a Git repository
+// 2. Runs 'git flow version' in it
+// 3. Verifies the command exits 0
+// 4. Verifies the output is exactly the expected version line, which proves no Git error was appended
+func TestVersionOutsideGitRepository(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	out, err := testutil.RunGitFlow(t, dir, "version")
+	if err != nil {
+		t.Fatalf("Failed to run version outside a repository: %v\nOutput: %s", err, out)
+	}
+
+	assertVersionOutput(t, out)
+}

--- a/test/testutil/git.go
+++ b/test/testutil/git.go
@@ -151,9 +151,15 @@ func RunGitFlowStreams(t *testing.T, dir string, args ...string) (string, string
 	err := cmd.Run()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
+			// Report whatever the command actually printed, on either stream,
+			// so a failure is diagnosable even when it stays silent on stderr.
+			detail := strings.TrimSpace(strings.Join([]string{stderr.String(), stdout.String()}, "\n"))
+			if detail == "" {
+				detail = err.Error()
+			}
 			return stdout.String(), stderr.String(), &ExitError{
 				ExitCode: exitErr.ExitCode(),
-				Err:      fmt.Errorf("%s", stderr.String()),
+				Err:      fmt.Errorf("%s", detail),
 			}
 		}
 		return stdout.String(), stderr.String(), err

--- a/test/testutil/git.go
+++ b/test/testutil/git.go
@@ -136,6 +136,31 @@ func RunGitFlow(t *testing.T, dir string, args ...string) (string, error) {
 	return string(output), nil
 }
 
+// RunGitFlowStreams runs a git-flow command and returns stdout and stderr
+// separately. Use it when a test has to prove which stream carried the output;
+// RunGitFlow merges the two and cannot distinguish them.
+func RunGitFlowStreams(t *testing.T, dir string, args ...string) (string, string, error) {
+	cmd := exec.Command(gitFlowPath, args...)
+	cmd.Dir = dir
+	// Set GIT_EDITOR to colon (:) to prevent interactive editor from opening
+	// The colon is a shell builtin that does nothing and returns success
+	cmd.Env = append(os.Environ(), "GIT_EDITOR=:")
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return stdout.String(), stderr.String(), &ExitError{
+				ExitCode: exitErr.ExitCode(),
+				Err:      fmt.Errorf("%s", stderr.String()),
+			}
+		}
+		return stdout.String(), stderr.String(), err
+	}
+	return stdout.String(), stderr.String(), nil
+}
+
 // RunGitFlowWithInput runs a git-flow command with the provided input and returns its output
 func RunGitFlowWithInput(t *testing.T, dir string, input string, args ...string) (string, error) {
 	cmd := exec.Command(gitFlowPath, args...)


### PR DESCRIPTION
Reorders the line `git flow version` prints from `git-flow-next version 1.2.0` to `1.2.0 (git-flow-next)` so tooling written against git-flow-avh works against git-flow-next unchanged.

Callers commonly detect a git-flow installation by running `git flow version` and parsing the first whitespace-separated token. Against AVH that token is a bare version number; against git-flow-next it was the tool name, so those callers either misdetected the installation or had to special-case us. The new line mirrors AVH's shape without claiming to be AVH. Only the version line moves: exit codes, the stream it is written to, and the position of the optional `Build date:` / `Git commit:` lines are unchanged. Four integration tests pin the exact output across an initialized repository, a bare repository, a repository without git-flow configuration, and a directory outside any repository; a new `testutil.RunGitFlowStreams` helper lets the primary test assert the line lands on stdout with an empty stderr, which the existing merged-output helper cannot show.

Resolves #185

### Remarks

- The expected line is built from `version.Version` rather than a literal, so the assertions survive a release bump and fail if the value in `cmd/version.go` drifts out of sync with `version/version.go` — a rule CLAUDE.md states but nothing previously enforced.
- Breaking for any external script that matched the old `git-flow-next version <n>` string; the implementation commit carries a `BREAKING CHANGE:` footer so it surfaces in the release notes.
- The reporter's separate observation — that `scripts/build.sh` injects `-X` into `const` symbols, so build metadata never reaches the binary — is confirmed but deliberately out of scope here and gets its own issue.

**Review focus:**
- `test/testutil/git.go` — the new `RunGitFlowStreams` helper and its `ExitError` wrapping
- `test/cmd/version_test.go` — whether deriving the expected line from `version.Version` is the right contract