### PR TITLE
fix(config): Parse booleans per git-config rules

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -249,6 +249,10 @@ git flow release finish v1.0 --tag  # Force tagging for this invocation
 
 Not every option spans all three layers. Layer 1 is reserved for essential branch-type properties — many command options exist only at Layer 2 and Layer 3. For example, `sign`, `keep`, and publish `push-options` are purely operational and have no Layer 1 equivalent.
 
+### Boolean Values
+
+Options listed with `Values: true, false` accept every git-config boolean spelling, at both Layer 1 and Layer 2: `true`, `yes`, `on` and any non-zero integer are true; `false`, `no`, `off`, `0` and an empty value are false; matching is case-insensitive. An unrecognized value is treated as `false`. Note that inverse options such as `no-rebase` and `notag` are separate keys rather than falsy spellings of the positive option. See the **Boolean Values** section of `docs/gitflow-config.5.md` for the full rule.
+
 ## Shared Configuration (.gitflow)
 
 By default git-flow configuration lives in `.git/config`, which is never committed, so every clone must run `git flow init`. A committable `.gitflow` file at the repository root lets a team share one configuration.

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -92,7 +92,7 @@ func performDelete(repo *git.Repo, branchType, name, fullBranchName string, bran
 	} else {
 		configKey := fmt.Sprintf("gitflow.%s.delete.fetch", branchType)
 		fetchConfig, err := repo.GetConfig(configKey)
-		if err == nil && fetchConfig == "true" {
+		if err == nil && config.ParseBool(fetchConfig) {
 			shouldFetch = true
 		}
 	}
@@ -106,7 +106,7 @@ func performDelete(repo *git.Repo, branchType, name, fullBranchName string, bran
 		// Check config if not specified
 		configKey := fmt.Sprintf("gitflow.%s.delete.force", branchType)
 		forceConfig, err := repo.GetConfig(configKey)
-		if err == nil && forceConfig == "true" {
+		if err == nil && config.ParseBool(forceConfig) {
 			forceDelete = true
 		}
 	}
@@ -120,7 +120,7 @@ func performDelete(repo *git.Repo, branchType, name, fullBranchName string, bran
 		// Check config if not specified
 		configKey := fmt.Sprintf("gitflow.branch.%s.deleteRemote", branchType)
 		remoteConfig, err := repo.GetConfig(configKey)
-		if err == nil && remoteConfig == "true" {
+		if err == nil && config.ParseBool(remoteConfig) {
 			deleteRemote = true
 		}
 	}

--- a/docs/gitflow-config.5.md
+++ b/docs/gitflow-config.5.md
@@ -80,6 +80,23 @@ Many command options exist only at Layer 2 — they have no Layer 1 equivalent b
 ### Layer 3: Command-Line Flags
 Command-line flags always take the highest precedence and override both configuration layers. Use these for one-off overrides.
 
+### Boolean Values
+
+Every option documented below as *Type*: boolean — both Layer 1 branch properties and Layer 2 command options — accepts the full set of git-config(1) boolean spellings:
+
+- **True**: **true**, **yes**, **on**, and any non-zero integer (**1**, **5**, **-1**)
+- **False**: **false**, **no**, **off**, **0**, and an empty value
+
+Matching is case-insensitive, so **Yes**, **ON**, and **True** all work.
+
+An unrecognized value (for example **maybe**) is treated as **false**. This differs from git-config(1) itself, which reports a "bad boolean" error for such a value.
+
+Inverse options such as **no-rebase**, **no-squash**, **notag**, and **ff** are **separate configuration keys**, not falsy spellings of the positive option. Setting `gitflow.feature.finish.rebase = off` does not disable a rebase strategy inherited from Layer 1 — it merely declines to enable one. To disable it, set the inverse key instead:
+
+```bash
+git config gitflow.feature.finish.no-rebase true
+```
+
 ## GLOBAL CONFIGURATION
 
 ### Core Settings

--- a/docs/gitflow-config.5.md
+++ b/docs/gitflow-config.5.md
@@ -82,7 +82,7 @@ Command-line flags always take the highest precedence and override both configur
 
 ### Boolean Values
 
-Every option documented below as *Type*: boolean — both Layer 1 branch properties and Layer 2 command options — accepts the full set of git-config(1) boolean spellings:
+Every boolean option in this document accepts the full set of git-config(1) boolean spellings — Layer 1 branch properties and Layer 2 command options alike, however each one is annotated (*Type*: boolean, an inline "(boolean)" note, or a description in terms of **true**/**false**):
 
 - **True**: **true**, **yes**, **on**, and any non-zero integer (**1**, **5**, **-1**)
 - **False**: **false**, **no**, **off**, **0**, and an empty value

--- a/internal/config/bool.go
+++ b/internal/config/bool.go
@@ -1,0 +1,13 @@
+package config
+
+// ParseBool interprets a raw git-config value using git-config(1) boolean
+// semantics: "true"/"yes"/"on" and any non-zero integer are true; "false"/"no"/
+// "off"/"0" and the empty string are false; matching is case-insensitive.
+// Unlike git-config(1), which errors on an unparseable value, an unrecognized
+// value resolves to false — the resolvers have no channel to surface the error.
+func ParseBool(value string) bool {
+	// Placeholder preserving the pre-fix behavior so the new tests fail on
+	// behavior rather than on a missing symbol. Replaced by the real
+	// implementation in the follow-up commit.
+	return value == "true"
+}

--- a/internal/config/bool.go
+++ b/internal/config/bool.go
@@ -11,6 +11,12 @@ import (
 // Unlike git-config(1), which errors on an unparseable value, an unrecognized
 // value resolves to false — the resolvers have no channel to surface the error.
 //
+// The integer case is bounded by strconv.Atoi: an integer outside the range
+// it can parse is not recognized and follows the unrecognized-value rule
+// above. git-config(1) rejects out-of-range integers as well, and its own
+// boolean range is narrower still (32-bit int), so the limit is unobservable
+// on values git accepts as booleans.
+//
 // The value is deliberately not trimmed: a whitespace-padded value matches no
 // spelling and strconv.Atoi rejects it, so it follows the unrecognized-value
 // rule above. Whether padded input can reach here at all differs by read path

--- a/internal/config/bool.go
+++ b/internal/config/bool.go
@@ -11,9 +11,11 @@ import (
 // Unlike git-config(1), which errors on an unparseable value, an unrecognized
 // value resolves to false — the resolvers have no channel to surface the error.
 //
-// The value is not trimmed: git rejects a whitespace-padded boolean as a bad
-// value, and strconv.Atoi rejects padded integers, so padded input follows the
-// unrecognized-value rule.
+// The value is deliberately not trimmed: a whitespace-padded value matches no
+// spelling and strconv.Atoi rejects it, so it follows the unrecognized-value
+// rule above. Whether padded input can reach here at all differs by read path
+// — repo.GetConfig trims, while the resolver and branch-property paths pass
+// the raw value through.
 func ParseBool(value string) bool {
 	switch strings.ToLower(value) {
 	case "true", "yes", "on":

--- a/internal/config/bool.go
+++ b/internal/config/bool.go
@@ -1,13 +1,31 @@
 package config
 
+import (
+	"strconv"
+	"strings"
+)
+
 // ParseBool interprets a raw git-config value using git-config(1) boolean
 // semantics: "true"/"yes"/"on" and any non-zero integer are true; "false"/"no"/
 // "off"/"0" and the empty string are false; matching is case-insensitive.
 // Unlike git-config(1), which errors on an unparseable value, an unrecognized
 // value resolves to false — the resolvers have no channel to surface the error.
+//
+// The value is not trimmed: git rejects a whitespace-padded boolean as a bad
+// value, and strconv.Atoi rejects padded integers, so padded input follows the
+// unrecognized-value rule.
 func ParseBool(value string) bool {
-	// Placeholder preserving the pre-fix behavior so the new tests fail on
-	// behavior rather than on a missing symbol. Replaced by the real
-	// implementation in the follow-up commit.
-	return value == "true"
+	switch strings.ToLower(value) {
+	case "true", "yes", "on":
+		return true
+	case "false", "no", "off", "0", "":
+		return false
+	}
+
+	// Any integer is a valid git-config boolean: zero is false, non-zero true.
+	n, err := strconv.Atoi(value)
+	if err != nil {
+		return false
+	}
+	return n != 0
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -295,10 +295,10 @@ func ParseBranchConfigLines(branchLines []string) map[string]BranchConfig {
 		}
 
 		if autoUpdate, ok := properties["autoupdate"]; ok {
-			branchConfig.AutoUpdate = autoUpdate == "true"
+			branchConfig.AutoUpdate = ParseBool(autoUpdate)
 		}
 		if tag, ok := properties["tag"]; ok {
-			branchConfig.Tag = tag == "true"
+			branchConfig.Tag = ParseBool(tag)
 		}
 		if tagPrefix, ok := properties["tagprefix"]; ok {
 			branchConfig.TagPrefix = tagPrefix

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -311,7 +311,7 @@ func resolveFinishForceDelete(cfg *Config, branchType string, retentionOpts *Bra
 // getCommandConfigBool gets a boolean config value from preloaded config
 func getCommandConfigBool(cfg *Config, configKey string) bool {
 	value, exists := cfg.CommandConfig[configKey]
-	return exists && value == "true"
+	return exists && ParseBool(value)
 }
 
 // getCommandConfigString gets a string config value from preloaded config
@@ -462,7 +462,7 @@ func resolveShouldFetch(cfg *Config, branchType, cmd string, defaultFetch bool, 
 	// Layer 2: Command-specific config (can set true OR false)
 	configKey := fmt.Sprintf("gitflow.%s.%s.fetch", branchType, cmd)
 	if value, exists := cfg.CommandConfig[configKey]; exists {
-		shouldFetch = value == "true"
+		shouldFetch = ParseBool(value)
 	}
 
 	// Layer 3: Command-line flags override config
@@ -494,7 +494,7 @@ func resolveFinishNoVerify(cfg *Config, branchType string, noVerify *bool) bool 
 	// Note: Git config keys are stored lowercase, so we use "noverify" not "noVerify"
 	configKey := fmt.Sprintf("gitflow.%s.finish.noverify", branchType)
 	if value, exists := cfg.CommandConfig[configKey]; exists {
-		skipVerify = value == "true"
+		skipVerify = ParseBool(value)
 	}
 
 	// Layer 3: Command-line flags override config
@@ -537,7 +537,7 @@ func resolveFinishPushTag(cfg *Config, branchType string, resolvedPush bool, pus
 	// Layer 2: Command-specific config, honored only when the key exists so an
 	// unset key does not clobber the derived default.
 	if v, ok := cfg.CommandConfig[fmt.Sprintf("gitflow.%s.finish.pushtag", branchType)]; ok {
-		pushTagVal = v == "true"
+		pushTagVal = ParseBool(v)
 	}
 
 	// Layer 3: Command-line flags override config
@@ -611,7 +611,7 @@ func resolveIntegrateShouldTag(cfg *Config, branchName string, tagOpts *TagOptio
 
 	// Layer 2: command-specific config
 	if value, exists := cfg.CommandConfig[fmt.Sprintf("gitflow.%s.integrate.tag", branchName)]; exists {
-		shouldTag = value == "true"
+		shouldTag = ParseBool(value)
 	}
 
 	// Layer 3: command-line flags override config
@@ -692,7 +692,7 @@ func resolveIntegrateMessageFile(cfg *Config, branchName string, tagOpts *TagOpt
 func resolveIntegrateShouldFetch(cfg *Config, branchName string, fetch *bool) bool {
 	shouldFetch := false
 	if value, exists := cfg.CommandConfig[fmt.Sprintf("gitflow.%s.integrate.fetch", branchName)]; exists {
-		shouldFetch = value == "true"
+		shouldFetch = ParseBool(value)
 	}
 	if fetch != nil {
 		shouldFetch = *fetch

--- a/internal/config/shared.go
+++ b/internal/config/shared.go
@@ -86,14 +86,14 @@ func isHookPathKey(key string) bool {
 // repository's merged git config.
 func SharedTrustHooks(repo *git.Repo) bool {
 	v, err := repo.GetConfig("gitflow.shared.trustHooks")
-	return err == nil && v == "true"
+	return err == nil && ParseBool(v)
 }
 
 // SharedAutoInit reports whether gitflow.shared.autoInit is set true in the
 // repository's merged git config.
 func SharedAutoInit(repo *git.Repo) bool {
 	v, err := repo.GetConfig("gitflow.shared.autoInit")
-	return err == nil && v == "true"
+	return err == nil && ParseBool(v)
 }
 
 // SharedConfigValid parses the .gitflow file and reports whether it is a valid

--- a/test/cmd/delete_test.go
+++ b/test/cmd/delete_test.go
@@ -1695,3 +1695,133 @@ func TestDeleteHotfixWithoutInitialization(t *testing.T) {
 		t.Errorf("Expected 'not initialized' error, got: %s", output)
 	}
 }
+
+// TestDeleteForceConfigYesForceDeletes tests that gitflow.feature.delete.force=yes
+// enables force deletion, matching git-config's truthy "yes" spelling.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Sets gitflow.feature.delete.force=yes
+// 3. Creates a feature branch with an unmerged commit
+// 4. Deletes without --force flag
+// 5. Verifies the branch is deleted
+func TestDeleteForceConfigYesForceDeletes(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	output, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.feature.delete.force", "yes"); err != nil {
+		t.Fatalf("Failed to set config: %v", err)
+	}
+
+	output, err = testutil.RunGitFlow(t, dir, "feature", "start", "test-force-yes")
+	if err != nil {
+		t.Fatalf("Failed to create feature branch: %v\nOutput: %s", err, output)
+	}
+
+	testutil.WriteFile(t, dir, "force-yes.txt", "unmerged content")
+	if _, err := testutil.RunGit(t, dir, "add", "force-yes.txt"); err != nil {
+		t.Fatalf("Failed to add file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Add unmerged file"); err != nil {
+		t.Fatalf("Failed to commit file: %v", err)
+	}
+
+	output, err = testutil.RunGitFlow(t, dir, "feature", "delete", "test-force-yes")
+	if err != nil {
+		t.Fatalf("Expected delete to succeed with force=yes config: %v\nOutput: %s", err, output)
+	}
+
+	if testutil.BranchExists(t, dir, "feature/test-force-yes") {
+		t.Error("Expected feature branch to be deleted")
+	}
+}
+
+// TestDeleteFetchConfigOnFetches tests that gitflow.feature.delete.fetch=on triggers
+// the fetch, matching git-config's truthy "on" spelling.
+// Steps:
+// 1. Sets up a test repository with remote (includes git-flow init)
+// 2. Starts a feature branch
+// 3. Sets gitflow.feature.delete.fetch to on
+// 4. Runs 'git flow feature delete test-fetch-on' (no flag)
+// 5. Verifies output contains "Fetching from remote"
+// 6. Verifies the branch is deleted
+func TestDeleteFetchConfigOnFetches(t *testing.T) {
+	t.Parallel()
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "test-fetch-on"); err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.feature.delete.fetch", "on"); err != nil {
+		t.Fatalf("Failed to set config: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "delete", "test-fetch-on")
+	if err != nil {
+		t.Fatalf("Failed to delete feature branch: %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(output, "Fetching from remote") {
+		t.Errorf("Expected fetch to occur with fetch=on config. Output: %s", output)
+	}
+	if testutil.BranchExists(t, dir, "feature/test-fetch-on") {
+		t.Error("Expected feature branch to be deleted")
+	}
+}
+
+// TestDeleteRemoteConfigOneDeletesRemote tests that gitflow.branch.feature.deleteRemote=1
+// enables remote deletion, matching git-config's truthy non-zero-integer spelling.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow
+// 2. Sets gitflow.branch.feature.deleteRemote=1
+// 3. Creates a feature branch
+// 4. Adds a bare remote and pushes the branch, verifying it exists there
+// 5. Deletes the branch without --remote flag
+// 6. Verifies the branch is deleted both locally and on the remote
+func TestDeleteRemoteConfigOneDeletesRemote(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "init"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.branch.feature.deleteRemote", "1"); err != nil {
+		t.Fatalf("Failed to set config: %v", err)
+	}
+
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "test-remote-one"); err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+
+	bareDir, err := testutil.AddRemote(t, dir, "origin", true)
+	if err != nil {
+		t.Fatalf("Failed to add remote: %v", err)
+	}
+	defer testutil.CleanupTestRepo(t, bareDir)
+
+	remoteBranch := "feature/test-remote-one"
+	if !testutil.BranchExists(t, bareDir, remoteBranch) {
+		t.Fatalf("Feature branch not found on remote")
+	}
+
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "delete", "test-remote-one"); err != nil {
+		t.Fatalf("Failed to delete feature branch: %v", err)
+	}
+
+	if testutil.BranchExists(t, dir, remoteBranch) {
+		t.Error("Feature branch still exists locally")
+	}
+	if testutil.BranchExists(t, bareDir, remoteBranch) {
+		t.Error("Feature branch still exists on remote")
+	}
+}

--- a/test/cmd/finish_fetch_test.go
+++ b/test/cmd/finish_fetch_test.go
@@ -1069,3 +1069,104 @@ func TestFinishParentAbsentOnRemoteIsBenign(t *testing.T) {
 		t.Error("Expected feature.txt to be merged into local develop")
 	}
 }
+
+// TestFinishFeatureFetchConfigOnFetches tests that gitflow.feature.finish.fetch=on
+// enables the fetch, matching git-config's truthy "on" spelling.
+// Steps:
+// 1. Sets up a test repository with a remote and initializes git-flow
+// 2. Configures gitflow.feature.finish.fetch = on
+// 3. Creates a feature branch and commits a test file
+// 4. Finishes the feature branch without any fetch flag
+// 5. Verifies "Fetching from remote" appears in output
+// 6. Verifies the feature branch is deleted and the file exists on develop
+func TestFinishFeatureFetchConfigOnFetches(t *testing.T) {
+	t.Parallel()
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.feature.finish.fetch", "on"); err != nil {
+		t.Fatalf("Failed to configure fetch option: %v", err)
+	}
+
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "test-config-on-fetch"); err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+
+	testutil.WriteFile(t, dir, "config-on-fetch-test.txt", "test content")
+	if _, err := testutil.RunGit(t, dir, "add", "config-on-fetch-test.txt"); err != nil {
+		t.Fatalf("Failed to add file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Add config on-fetch test file"); err != nil {
+		t.Fatalf("Failed to commit file: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "test-config-on-fetch")
+	if err != nil {
+		t.Fatalf("Failed to finish feature branch: %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(output, "Fetching from remote") {
+		t.Errorf("Expected fetch to occur with fetch=on. Output: %s", output)
+	}
+	if testutil.BranchExists(t, dir, "feature/test-config-on-fetch") {
+		t.Error("Expected feature branch to be deleted")
+	}
+	if _, err := testutil.RunGit(t, dir, "checkout", "develop"); err != nil {
+		t.Fatalf("Failed to checkout develop: %v", err)
+	}
+	if !testutil.FileExists(t, dir, "config-on-fetch-test.txt") {
+		t.Error("Expected config-on-fetch-test.txt to exist in develop branch")
+	}
+}
+
+// TestFinishFeatureFetchConfigNoSkipsFetch tests that gitflow.feature.finish.fetch=no
+// skips the fetch, matching git-config's falsy "no" spelling. Distinguishes a falsy
+// value from an unset key, which would fetch (the finish default is true).
+// Steps:
+// 1. Sets up a test repository with a remote and initializes git-flow
+// 2. Configures gitflow.feature.finish.fetch = no
+// 3. Creates a feature branch and commits a test file
+// 4. Finishes the feature branch without any fetch flag
+// 5. Verifies "Fetching from remote" does NOT appear in output
+// 6. Verifies the feature branch is deleted and the file exists on develop
+func TestFinishFeatureFetchConfigNoSkipsFetch(t *testing.T) {
+	t.Parallel()
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.feature.finish.fetch", "no"); err != nil {
+		t.Fatalf("Failed to configure fetch option: %v", err)
+	}
+
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "test-config-no-fetch-word"); err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+
+	testutil.WriteFile(t, dir, "config-no-fetch-word-test.txt", "test content")
+	if _, err := testutil.RunGit(t, dir, "add", "config-no-fetch-word-test.txt"); err != nil {
+		t.Fatalf("Failed to add file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Add config no-fetch word test file"); err != nil {
+		t.Fatalf("Failed to commit file: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "test-config-no-fetch-word")
+	if err != nil {
+		t.Fatalf("Failed to finish feature branch: %v\nOutput: %s", err, output)
+	}
+
+	if strings.Contains(output, "Fetching from remote") {
+		t.Errorf("Expected no fetch with fetch=no. Output: %s", output)
+	}
+	if testutil.BranchExists(t, dir, "feature/test-config-no-fetch-word") {
+		t.Error("Expected feature branch to be deleted")
+	}
+	if _, err := testutil.RunGit(t, dir, "checkout", "develop"); err != nil {
+		t.Fatalf("Failed to checkout develop: %v", err)
+	}
+	if !testutil.FileExists(t, dir, "config-no-fetch-word-test.txt") {
+		t.Error("Expected config-no-fetch-word-test.txt to exist in develop branch")
+	}
+}

--- a/test/cmd/finish_noverify_test.go
+++ b/test/cmd/finish_noverify_test.go
@@ -758,3 +758,61 @@ func TestFinishFeatureInvalidNoVerifyConfig(t *testing.T) {
 		t.Error("Feature branch should still exist when finish failed due to hook")
 	}
 }
+
+// TestFinishFeatureNoVerifyConfigOneBypassesHook tests that gitflow.feature.finish.noVerify=1
+// bypasses the hook, matching git-config's truthy non-zero-integer spelling.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow
+// 2. Sets gitflow.feature.finish.noVerify=1 in git config
+// 3. Creates a feature branch and commits a test file
+// 4. Adds a different commit on develop to force a non-fast-forward merge
+// 5. Installs pre-merge-commit and pre-commit hooks that reject (exit code 1)
+// 6. Finishes the feature branch without any CLI flags
+// 7. Verifies the finish operation succeeds (hook bypassed via config)
+// 8. Verifies the feature branch is deleted
+// 9. Verifies changes are merged into develop
+func TestFinishFeatureNoVerifyConfigOneBypassesHook(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v", err)
+	}
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.feature.finish.noVerify", "1"); err != nil {
+		t.Fatalf("Failed to set noVerify config: %v", err)
+	}
+
+	if _, err := testutil.RunGitFlow(t, dir, "feature", "start", "config-one-test"); err != nil {
+		t.Fatalf("Failed to start feature: %v", err)
+	}
+
+	testutil.WriteFile(t, dir, "feature.txt", "feature content")
+	_, _ = testutil.RunGit(t, dir, "add", "feature.txt")
+	_, _ = testutil.RunGit(t, dir, "commit", "-m", "Add feature file")
+
+	// Add a commit to develop to force a non-fast-forward merge
+	_, _ = testutil.RunGit(t, dir, "checkout", "develop")
+	testutil.WriteFile(t, dir, "develop.txt", "develop content")
+	_, _ = testutil.RunGit(t, dir, "add", "develop.txt")
+	_, _ = testutil.RunGit(t, dir, "commit", "-m", "Add develop file")
+
+	_, _ = testutil.RunGit(t, dir, "checkout", "feature/config-one-test")
+
+	createRejectingHooks(t, dir)
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "--no-fetch", "config-one-test")
+	if err != nil {
+		t.Fatalf("Expected finish to succeed with noVerify=1 config, but it failed: %v\nOutput: %s", err, output)
+	}
+
+	if testutil.BranchExists(t, dir, "feature/config-one-test") {
+		t.Error("Feature branch should be deleted after successful finish")
+	}
+
+	featureFile := filepath.Join(dir, "feature.txt")
+	if _, err := os.Stat(featureFile); os.IsNotExist(err) {
+		t.Error("Feature file should exist on develop after merge")
+	}
+}

--- a/test/cmd/finish_noverify_test.go
+++ b/test/cmd/finish_noverify_test.go
@@ -788,17 +788,33 @@ func TestFinishFeatureNoVerifyConfigOneBypassesHook(t *testing.T) {
 		t.Fatalf("Failed to start feature: %v", err)
 	}
 
-	testutil.WriteFile(t, dir, "feature.txt", "feature content")
-	_, _ = testutil.RunGit(t, dir, "add", "feature.txt")
-	_, _ = testutil.RunGit(t, dir, "commit", "-m", "Add feature file")
+	if err := testutil.WriteFile(t, dir, "feature.txt", "feature content"); err != nil {
+		t.Fatalf("Failed to write feature file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "add", "feature.txt"); err != nil {
+		t.Fatalf("Failed to stage feature file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Add feature file"); err != nil {
+		t.Fatalf("Failed to commit feature file: %v", err)
+	}
 
 	// Add a commit to develop to force a non-fast-forward merge
-	_, _ = testutil.RunGit(t, dir, "checkout", "develop")
-	testutil.WriteFile(t, dir, "develop.txt", "develop content")
-	_, _ = testutil.RunGit(t, dir, "add", "develop.txt")
-	_, _ = testutil.RunGit(t, dir, "commit", "-m", "Add develop file")
+	if _, err := testutil.RunGit(t, dir, "checkout", "develop"); err != nil {
+		t.Fatalf("Failed to check out develop: %v", err)
+	}
+	if err := testutil.WriteFile(t, dir, "develop.txt", "develop content"); err != nil {
+		t.Fatalf("Failed to write develop file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "add", "develop.txt"); err != nil {
+		t.Fatalf("Failed to stage develop file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Add develop file"); err != nil {
+		t.Fatalf("Failed to commit develop file: %v", err)
+	}
 
-	_, _ = testutil.RunGit(t, dir, "checkout", "feature/config-one-test")
+	if _, err := testutil.RunGit(t, dir, "checkout", "feature/config-one-test"); err != nil {
+		t.Fatalf("Failed to check out feature branch: %v", err)
+	}
 
 	createRejectingHooks(t, dir)
 

--- a/test/cmd/finish_push_test.go
+++ b/test/cmd/finish_push_test.go
@@ -963,3 +963,245 @@ func TestFinishFetchShorthandForwardsFlag(t *testing.T) {
 		t.Errorf("Expected fetch to occur via shorthand --fetch (flag forwarded, overriding config). Output: %s", output)
 	}
 }
+
+// TestFinishPushConfigYesEnablesPush tests that gitflow.release.finish.push=yes
+// enables the push, matching git-config's truthy "yes" spelling. This is the
+// exact repro from issue #182.
+// Steps:
+// 1. Sets up a classic repo with origin
+// 2. Sets gitflow.release.finish.push=yes
+// 3. Creates release branch '1.0.0' with one commit
+// 4. Runs 'git flow release finish 1.0.0 --no-fetch' (no push flag)
+// 5. Verifies exit 0 and main and develop up to date with origin
+// 6. Verifies tag 1.0.0 exists on origin (derived from the resolved branch push)
+// 7. Verifies output contains the main, develop and tag push lines
+func TestFinishPushConfigYesEnablesPush(t *testing.T) {
+	t.Parallel()
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.release.finish.push", "yes"); err != nil {
+		t.Fatalf("Failed to configure push: %v", err)
+	}
+
+	createTopicCommit(t, dir, "release", "1.0.0", "release.txt", "release content")
+
+	output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0", "--no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to finish release: %v\nOutput: %s", err, output)
+	}
+
+	if got := testutil.CommitsAhead(t, dir, "origin/main", "main"); got != 0 {
+		t.Errorf("Expected main up to date with origin (push=yes), got %d ahead", got)
+	}
+	if got := testutil.CommitsAhead(t, dir, "origin/develop", "develop"); got != 0 {
+		t.Errorf("Expected develop up to date with origin (push=yes), got %d ahead", got)
+	}
+	if !testutil.RemoteTagExists(t, dir, "origin", "1.0.0") {
+		t.Error("Expected tag 1.0.0 to exist on origin (derived from push=yes)")
+	}
+	if !strings.Contains(output, pushMainLine) {
+		t.Errorf("Expected main push line. Output: %s", output)
+	}
+	if !strings.Contains(output, pushDevelLine) {
+		t.Errorf("Expected develop push line. Output: %s", output)
+	}
+	if !strings.Contains(output, pushTag100Line) {
+		t.Errorf("Expected tag push line. Output: %s", output)
+	}
+}
+
+// TestFinishPushConfigFalseDoesNotPush tests that gitflow.release.finish.push=false
+// still suppresses the push after boolean parsing changed.
+// Steps:
+// 1. Sets up a classic repo with origin
+// 2. Sets gitflow.release.finish.push=false
+// 3. Creates release branch '1.0.0' with one commit
+// 4. Runs 'git flow release finish 1.0.0 --no-fetch'
+// 5. Verifies exit 0 and main and develop ahead of origin (nothing pushed)
+// 6. Verifies tag 1.0.0 is NOT on origin and no push header appears
+func TestFinishPushConfigFalseDoesNotPush(t *testing.T) {
+	t.Parallel()
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.release.finish.push", "false"); err != nil {
+		t.Fatalf("Failed to configure push: %v", err)
+	}
+
+	createTopicCommit(t, dir, "release", "1.0.0", "release.txt", "release content")
+
+	output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0", "--no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to finish release: %v\nOutput: %s", err, output)
+	}
+
+	if got := testutil.CommitsAhead(t, dir, "origin/main", "main"); got == 0 {
+		t.Errorf("Expected main ahead of origin (push=false), got %d ahead", got)
+	}
+	if got := testutil.CommitsAhead(t, dir, "origin/develop", "develop"); got == 0 {
+		t.Errorf("Expected develop ahead of origin (push=false), got %d ahead", got)
+	}
+	if testutil.RemoteTagExists(t, dir, "origin", "1.0.0") {
+		t.Error("Expected tag 1.0.0 NOT to be on origin (push=false)")
+	}
+	if strings.Contains(output, pushHeader) {
+		t.Errorf("Expected no push with push=false. Output: %s", output)
+	}
+}
+
+// TestFinishPushConfigOffDoesNotPush tests that gitflow.release.finish.push=off
+// suppresses the push, matching git-config's falsy "off" spelling.
+// Steps:
+// 1. Sets up a classic repo with origin
+// 2. Sets gitflow.release.finish.push=off
+// 3. Creates release branch '1.0.0' with one commit
+// 4. Runs 'git flow release finish 1.0.0 --no-fetch'
+// 5. Verifies exit 0 and main and develop ahead of origin (nothing pushed)
+// 6. Verifies tag 1.0.0 is NOT on origin and no push header appears
+func TestFinishPushConfigOffDoesNotPush(t *testing.T) {
+	t.Parallel()
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.release.finish.push", "off"); err != nil {
+		t.Fatalf("Failed to configure push: %v", err)
+	}
+
+	createTopicCommit(t, dir, "release", "1.0.0", "release.txt", "release content")
+
+	output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0", "--no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to finish release: %v\nOutput: %s", err, output)
+	}
+
+	if got := testutil.CommitsAhead(t, dir, "origin/main", "main"); got == 0 {
+		t.Errorf("Expected main ahead of origin (push=off), got %d ahead", got)
+	}
+	if got := testutil.CommitsAhead(t, dir, "origin/develop", "develop"); got == 0 {
+		t.Errorf("Expected develop ahead of origin (push=off), got %d ahead", got)
+	}
+	if testutil.RemoteTagExists(t, dir, "origin", "1.0.0") {
+		t.Error("Expected tag 1.0.0 NOT to be on origin (push=off)")
+	}
+	if strings.Contains(output, pushHeader) {
+		t.Errorf("Expected no push with push=off. Output: %s", output)
+	}
+}
+
+// TestFinishPushTagConfigYesPushesTag tests that gitflow.release.finish.pushtag=yes
+// pushes the tag alongside the branches.
+// Steps:
+// 1. Sets up a classic repo with origin
+// 2. Sets gitflow.release.finish.push=true and gitflow.release.finish.pushtag=yes
+// 3. Creates release branch '1.0.0' with one commit
+// 4. Runs 'git flow release finish 1.0.0 --no-fetch'
+// 5. Verifies exit 0 and tag 1.0.0 exists on origin
+// 6. Verifies main and develop are up to date with origin
+func TestFinishPushTagConfigYesPushesTag(t *testing.T) {
+	t.Parallel()
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.release.finish.push", "true"); err != nil {
+		t.Fatalf("Failed to configure push: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.release.finish.pushtag", "yes"); err != nil {
+		t.Fatalf("Failed to configure pushtag: %v", err)
+	}
+
+	createTopicCommit(t, dir, "release", "1.0.0", "release.txt", "release content")
+
+	output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0", "--no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to finish release: %v\nOutput: %s", err, output)
+	}
+
+	if !testutil.RemoteTagExists(t, dir, "origin", "1.0.0") {
+		t.Error("Expected tag 1.0.0 to exist on origin (pushtag=yes)")
+	}
+	if got := testutil.CommitsAhead(t, dir, "origin/main", "main"); got != 0 {
+		t.Errorf("Expected main up to date with origin, got %d ahead", got)
+	}
+	if got := testutil.CommitsAhead(t, dir, "origin/develop", "develop"); got != 0 {
+		t.Errorf("Expected develop up to date with origin, got %d ahead", got)
+	}
+}
+
+// TestFinishPushTagConfigOffSuppressesTag tests that an explicitly falsy
+// gitflow.release.finish.pushtag=off beats the push-derived default true.
+// Steps:
+// 1. Sets up a classic repo with origin
+// 2. Sets gitflow.release.finish.push=true and gitflow.release.finish.pushtag=off
+// 3. Creates release branch '1.0.0' with one commit
+// 4. Runs 'git flow release finish 1.0.0 --no-fetch'
+// 5. Verifies exit 0 and main and develop up to date with origin (branches pushed)
+// 6. Verifies tag 1.0.0 is NOT on origin (the present-but-falsy key wins)
+func TestFinishPushTagConfigOffSuppressesTag(t *testing.T) {
+	t.Parallel()
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.release.finish.push", "true"); err != nil {
+		t.Fatalf("Failed to configure push: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.release.finish.pushtag", "off"); err != nil {
+		t.Fatalf("Failed to configure pushtag: %v", err)
+	}
+
+	createTopicCommit(t, dir, "release", "1.0.0", "release.txt", "release content")
+
+	output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0", "--no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to finish release: %v\nOutput: %s", err, output)
+	}
+
+	if got := testutil.CommitsAhead(t, dir, "origin/main", "main"); got != 0 {
+		t.Errorf("Expected main up to date with origin, got %d ahead", got)
+	}
+	if got := testutil.CommitsAhead(t, dir, "origin/develop", "develop"); got != 0 {
+		t.Errorf("Expected develop up to date with origin, got %d ahead", got)
+	}
+	if testutil.RemoteTagExists(t, dir, "origin", "1.0.0") {
+		t.Error("Expected tag 1.0.0 NOT to be on origin (pushtag=off)")
+	}
+}
+
+// TestFinishPushConfigYesNoPushFlagOverrides tests that --no-push still beats a
+// truthy non-"true" spelling of gitflow.feature.finish.push.
+// Steps:
+// 1. Sets up a single-track repo with origin tracking main
+// 2. Sets gitflow.feature.finish.push=yes
+// 3. Creates feature branch 'login' with one commit
+// 4. Runs 'git flow feature finish login --no-push --no-fetch'
+// 5. Verifies exit 0 and main ahead of origin (nothing pushed)
+// 6. Verifies output contains no "Pushing to remote" header
+func TestFinishPushConfigYesNoPushFlagOverrides(t *testing.T) {
+	t.Parallel()
+	dir, remoteDir := setupSingleTrackWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.feature.finish.push", "yes"); err != nil {
+		t.Fatalf("Failed to configure push: %v", err)
+	}
+
+	createTopicCommit(t, dir, "feature", "login", "login.txt", "login content")
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "login", "--no-push", "--no-fetch")
+	if err != nil {
+		t.Fatalf("Failed to finish feature branch: %v\nOutput: %s", err, output)
+	}
+
+	if got := testutil.CommitsAhead(t, dir, "origin/main", "main"); got == 0 {
+		t.Errorf("Expected main ahead of origin (--no-push overrides push=yes), got %d ahead", got)
+	}
+	if strings.Contains(output, pushHeader) {
+		t.Errorf("Expected no push with --no-push. Output: %s", output)
+	}
+}

--- a/test/cmd/finish_strategy_test.go
+++ b/test/cmd/finish_strategy_test.go
@@ -1677,3 +1677,131 @@ func TestFinishUpdateMessageCLIOverridesConfig(t *testing.T) {
 		t.Errorf("Expected CLI update message '%s' to override config, got '%s'", cliUpdateMessage, strings.TrimSpace(commitMsg))
 	}
 }
+
+// TestMergeStrategyConfigYesEnablesRebase tests that gitflow.feature.finish.rebase=yes
+// selects the rebase strategy, matching git-config's truthy "yes" spelling.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Sets gitflow.feature.finish.rebase=yes (Layer-1 default is merge)
+// 3. Creates a feature branch with a commit
+// 4. Adds a commit on develop
+// 5. Finishes without any flags
+// 6. Verifies the rebase strategy was used and both files exist on develop
+func TestMergeStrategyConfigYesEnablesRebase(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	output, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.feature.finish.rebase", "yes"); err != nil {
+		t.Fatalf("Failed to set rebase config: %v", err)
+	}
+
+	output, err = testutil.RunGitFlow(t, dir, "feature", "start", "rebase-yes-test")
+	if err != nil {
+		t.Fatalf("Failed to start feature branch: %v\nOutput: %s", err, output)
+	}
+
+	testutil.WriteFile(t, dir, "feature.txt", "feature content")
+	if _, err := testutil.RunGit(t, dir, "add", "feature.txt"); err != nil {
+		t.Fatalf("Failed to add feature file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Add feature file"); err != nil {
+		t.Fatalf("Failed to commit feature file: %v", err)
+	}
+
+	if _, err := testutil.RunGit(t, dir, "checkout", "develop"); err != nil {
+		t.Fatalf("Failed to switch to develop: %v", err)
+	}
+	testutil.WriteFile(t, dir, "develop.txt", "develop content")
+	if _, err := testutil.RunGit(t, dir, "add", "develop.txt"); err != nil {
+		t.Fatalf("Failed to add develop file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Add develop file"); err != nil {
+		t.Fatalf("Failed to commit develop file: %v", err)
+	}
+
+	output, err = testutil.RunGitFlow(t, dir, "feature", "finish", "rebase-yes-test")
+	if err != nil {
+		t.Fatalf("Failed to finish feature branch: %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(output, "Merging using strategy: rebase") {
+		t.Errorf("Expected rebase strategy from rebase=yes config, got: %s", output)
+	}
+
+	if _, err := testutil.RunGit(t, dir, "checkout", "develop"); err != nil {
+		t.Fatalf("Failed to checkout develop: %v", err)
+	}
+	if !testutil.FileExists(t, dir, "feature.txt") {
+		t.Error("Expected feature.txt to exist in develop branch")
+	}
+	if !testutil.FileExists(t, dir, "develop.txt") {
+		t.Error("Expected develop.txt to exist in develop branch")
+	}
+}
+
+// TestMergeStrategyFalsyPositiveKeyDoesNotDisableRebase tests that a falsy value on
+// the positive rebase key does not flip a Layer-1 rebase strategy back to merge.
+// The positive key is one-directional by design; no-rebase is the way to disable it.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Sets gitflow.branch.feature.upstreamstrategy=rebase (Layer 1)
+// 3. Sets gitflow.feature.finish.rebase=off (Layer 2, falsy positive key)
+// 4. Creates a feature branch with a commit and adds a commit on develop
+// 5. Finishes without any flags
+// 6. Verifies the rebase strategy is still used
+func TestMergeStrategyFalsyPositiveKeyDoesNotDisableRebase(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	output, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.branch.feature.upstreamstrategy", "rebase"); err != nil {
+		t.Fatalf("Failed to set upstream strategy config: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.feature.finish.rebase", "off"); err != nil {
+		t.Fatalf("Failed to set rebase config: %v", err)
+	}
+
+	output, err = testutil.RunGitFlow(t, dir, "feature", "start", "falsy-positive-test")
+	if err != nil {
+		t.Fatalf("Failed to start feature branch: %v\nOutput: %s", err, output)
+	}
+
+	testutil.WriteFile(t, dir, "feature.txt", "feature content")
+	if _, err := testutil.RunGit(t, dir, "add", "feature.txt"); err != nil {
+		t.Fatalf("Failed to add feature file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Add feature file"); err != nil {
+		t.Fatalf("Failed to commit feature file: %v", err)
+	}
+
+	if _, err := testutil.RunGit(t, dir, "checkout", "develop"); err != nil {
+		t.Fatalf("Failed to switch to develop: %v", err)
+	}
+	testutil.WriteFile(t, dir, "develop.txt", "develop content")
+	if _, err := testutil.RunGit(t, dir, "add", "develop.txt"); err != nil {
+		t.Fatalf("Failed to add develop file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Add develop file"); err != nil {
+		t.Fatalf("Failed to commit develop file: %v", err)
+	}
+
+	output, err = testutil.RunGitFlow(t, dir, "feature", "finish", "falsy-positive-test")
+	if err != nil {
+		t.Fatalf("Failed to finish feature branch: %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(output, "Merging using strategy: rebase") {
+		t.Errorf("Expected Layer-1 rebase to survive a falsy positive key, got: %s", output)
+	}
+}

--- a/test/cmd/integrate_tags_test.go
+++ b/test/cmd/integrate_tags_test.go
@@ -314,3 +314,44 @@ func TestIntegrateMessageSetsTagMessage(t *testing.T) {
 		t.Errorf("Expected tag message to contain 'integrate note', got: %s", msg)
 	}
 }
+
+// TestIntegrateTagConfigOnCreatesTag verifies that gitflow.<base>.integrate.tag=on
+// creates the configured tag, matching git-config's truthy "on" spelling.
+//
+// Steps:
+//  1. init --defaults; add C to develop; set integrate.tag on and
+//     integrate.tagname v3.0.0 (no --tag/--notag).
+//  2. Run: git flow integrate develop.
+//  3. Assert annotated tag v3.0.0 on main's tip.
+func TestIntegrateTagConfigOnCreatesTag(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	integAddCommit(t, dir, "develop", "c.txt", "C", "Add C on develop")
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.develop.integrate.tag", "on"); err != nil {
+		t.Fatalf("Failed to set integrate.tag config: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.develop.integrate.tagname", "v3.0.0"); err != nil {
+		t.Fatalf("Failed to set integrate.tagname config: %v", err)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop")
+	if err != nil {
+		t.Fatalf("integrate develop failed: %v\nOutput: %s", err, out)
+	}
+
+	if !integTagExists(t, dir, "v3.0.0") {
+		t.Fatal("Expected configured tag v3.0.0 to be created with integrate.tag=on")
+	}
+	if !integTagIsAnnotated(t, dir, "v3.0.0") {
+		t.Error("Expected v3.0.0 to be an annotated tag")
+	}
+	if integRevParse(t, dir, "v3.0.0^{commit}") != integRevParse(t, dir, "main") {
+		t.Error("Expected v3.0.0 to point at main's tip")
+	}
+}

--- a/test/cmd/integrate_test.go
+++ b/test/cmd/integrate_test.go
@@ -419,3 +419,51 @@ func TestIntegrateFetchParentCheckedOutSurfacesFailure(t *testing.T) {
 		t.Errorf("Expected R (%s) absent from local main after the refused fetch", rCommit)
 	}
 }
+
+// TestIntegrateFetchConfigYesPullsRemoteChanges verifies that
+// gitflow.<base>.integrate.fetch=yes incorporates remote parent commits before
+// integrating, matching git-config's truthy "yes" spelling. The Layer-1 default
+// is false, so only a truthy config can pull R in.
+//
+// Steps:
+//  1. SetupTestRepoWithRemote; set gitflow.develop.integrate.fetch yes.
+//  2. Clone the remote and push commit R to main.
+//  3. Give local develop commit C not on local main; leave HEAD on develop.
+//  4. Run: git flow integrate develop (no fetch flag).
+//  5. Assert main contains both R (fetched) and C.
+func TestIntegrateFetchConfigYesPullsRemoteChanges(t *testing.T) {
+	t.Parallel()
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.develop.integrate.fetch", "yes"); err != nil {
+		t.Fatalf("Failed to set integrate.fetch config: %v", err)
+	}
+
+	// Second working copy that pushes R to main on the remote.
+	secondDir := t.TempDir()
+	if _, err := testutil.RunGit(t, secondDir, "clone", remoteDir, "."); err != nil {
+		t.Fatalf("Failed to clone remote: %v", err)
+	}
+	testutil.ConfigureGitIdentity(t, secondDir)
+	rCommit := integAddCommit(t, secondDir, "main", "remote.txt", "R", "Add R on remote main")
+	if _, err := testutil.RunGit(t, secondDir, "push", "origin", "main"); err != nil {
+		t.Fatalf("Failed to push R to remote: %v", err)
+	}
+
+	// Local develop gets commit C not on local main.
+	cCommit := integAddCommit(t, dir, "develop", "c.txt", "C", "Add C on develop")
+
+	out, err := testutil.RunGitFlow(t, dir, "integrate", "develop")
+	if err != nil {
+		t.Fatalf("integrate develop failed: %v\nOutput: %s", err, out)
+	}
+
+	if !integIsAncestor(t, dir, rCommit, "main") {
+		t.Errorf("Expected fetched commit R (%s) to be present on main with integrate.fetch=yes", rCommit)
+	}
+	if !integIsAncestor(t, dir, cCommit, "main") {
+		t.Errorf("Expected commit C (%s) to be present on main", cCommit)
+	}
+}

--- a/test/cmd/shared_activation_test.go
+++ b/test/cmd/shared_activation_test.go
@@ -339,3 +339,32 @@ func assertExitCode(t *testing.T, err error, want errors.ExitCode) {
 		t.Errorf("expected exit code %d, got %d", int(want), ee.ExitCode)
 	}
 }
+
+// TestFirstRunAutoInitYesActivates covers the git-config truthy "yes" spelling of
+// gitflow.shared.autoInit: a non-interactive run auto-copies with a notice.
+// Steps:
+// 1. Builds a fresh-clone fixture and sets gitflow.shared.autoInit=yes locally
+// 2. Runs 'feature start my-thing' non-interactively
+// 3. Verifies a one-line auto-init notice, local config copied, and the branch exists
+func TestFirstRunAutoInitYesActivates(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupFreshCloneWithShared(t, testutil.AuthorSharedConfig(t))
+	defer testutil.CleanupTestRepo(t, dir)
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.shared.autoInit", "yes"); err != nil {
+		t.Fatalf("failed to set autoInit: %v", err)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "feature", "start", "my-thing")
+	if err != nil {
+		t.Fatalf("auto-init feature start failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "auto-initialized") || !strings.Contains(out, ".gitflow") {
+		t.Errorf("expected an auto-init notice naming .gitflow, got: %s", out)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.feature.prefix"); v != "feature/" {
+		t.Errorf("expected local feature.prefix copied, got %q", v)
+	}
+	if !testutil.BranchExists(t, dir, "feature/my-thing") {
+		t.Error("expected feature/my-thing to be created")
+	}
+}

--- a/test/cmd/shared_copy_test.go
+++ b/test/cmd/shared_copy_test.go
@@ -392,3 +392,30 @@ func TestSharedCustomDottedTypeAvailableBeforeActivation(t *testing.T) {
 		t.Error("expected qa.Release/x branch to be created with its dotted name preserved")
 	}
 }
+
+// TestSharedHookPathCopiedWhenTrustHooksYes covers the git-config truthy "yes"
+// spelling of gitflow.shared.trustHooks: the hook path is copied on activation.
+// Steps:
+// 1. Builds a fresh-clone fixture whose .gitflow sets gitflow.path.hooks
+// 2. Sets local gitflow.shared.trustHooks=yes and gitflow.shared.autoInit=true
+// 3. Runs 'feature start x' (activates)
+// 4. Verifies local config contains gitflow.path.hooks=/some/hooks
+func TestSharedHookPathCopiedWhenTrustHooksYes(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupFreshCloneWithShared(t, testutil.AuthorSharedConfig(t))
+	defer testutil.CleanupTestRepo(t, dir)
+	testutil.SharedConfigSet(t, dir, "gitflow.path.hooks", "/some/hooks")
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.shared.trustHooks", "yes"); err != nil {
+		t.Fatalf("failed to set trustHooks: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "--local", "gitflow.shared.autoInit", "true"); err != nil {
+		t.Fatalf("failed to set autoInit: %v", err)
+	}
+
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "start", "x"); err != nil {
+		t.Fatalf("feature start failed: %v\n%s", err, out)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.path.hooks"); v != "/some/hooks" {
+		t.Errorf("expected local gitflow.path.hooks=/some/hooks when trusted, got %q", v)
+	}
+}

--- a/test/cmd/start_test.go
+++ b/test/cmd/start_test.go
@@ -1053,3 +1053,35 @@ func TestStartDefaultUnreachableRemoteWarnsAndCreates(t *testing.T) {
 		t.Error("Expected feature/unreachable-default-test branch to exist")
 	}
 }
+
+// TestStartFetchConfigOffSkipsFetch tests that gitflow.feature.start.fetch=off skips
+// the fetch, matching git-config's falsy "off" spelling. Uses a remote-backed fixture
+// so the absence of "Fetching" reflects the config, not a missing remote.
+// Steps:
+// 1. Sets up a test repository with a remote and initializes git-flow
+// 2. Sets gitflow.feature.start.fetch=off; no flag
+// 3. Runs 'git flow feature start config-off-test'
+// 4. Verifies no "Fetching from" line appears
+// 5. Verifies the feature branch is created
+func TestStartFetchConfigOffSkipsFetch(t *testing.T) {
+	t.Parallel()
+	dir, remoteDir := testutil.SetupTestRepoWithRemote(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer testutil.CleanupTestRepo(t, remoteDir)
+
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.feature.start.fetch", "off"); err != nil {
+		t.Fatalf("Failed to set config: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "start", "config-off-test")
+	if err != nil {
+		t.Fatalf("Failed to run git-flow feature start: %v\nOutput: %s", err, output)
+	}
+
+	if strings.Contains(output, "Fetching from") {
+		t.Errorf("Expected no fetch due to config off, but output indicates fetching: %s", output)
+	}
+	if !testutil.BranchExists(t, dir, "feature/config-off-test") {
+		t.Error("Expected feature/config-off-test branch to exist")
+	}
+}

--- a/test/internal/config/config_test.go
+++ b/test/internal/config/config_test.go
@@ -629,6 +629,81 @@ func TestConfigClearIsolatedToTargetRepo(t *testing.T) {
 	}
 }
 
+// TestParseBranchConfigLinesAutoUpdateYes tests that the autoupdate branch property
+// accepts git-config's "yes" spelling.
+// Steps:
+// 1. Builds raw config lines declaring develop as a base branch with autoupdate=yes
+// 2. Calls config.ParseBranchConfigLines on them
+// 3. Verifies develop's AutoUpdate is true
+func TestParseBranchConfigLinesAutoUpdateYes(t *testing.T) {
+	t.Parallel()
+
+	lines := []string{
+		"gitflow.branch.develop.type base",
+		"gitflow.branch.develop.autoupdate yes",
+	}
+
+	result := config.ParseBranchConfigLines(lines)
+
+	develop, ok := result["develop"]
+	if !ok {
+		t.Fatalf("Expected a develop branch config, got keys %v", keysOf(result))
+	}
+	if !develop.AutoUpdate {
+		t.Error("Expected AutoUpdate to be true for autoupdate=yes")
+	}
+}
+
+// TestParseBranchConfigLinesTagYes tests that the tag branch property accepts
+// git-config's "yes" spelling.
+// Steps:
+// 1. Builds raw config lines declaring release as a topic branch with tag=yes
+// 2. Calls config.ParseBranchConfigLines on them
+// 3. Verifies release's Tag is true
+func TestParseBranchConfigLinesTagYes(t *testing.T) {
+	t.Parallel()
+
+	lines := []string{
+		"gitflow.branch.release.type topic",
+		"gitflow.branch.release.tag yes",
+	}
+
+	result := config.ParseBranchConfigLines(lines)
+
+	release, ok := result["release"]
+	if !ok {
+		t.Fatalf("Expected a release branch config, got keys %v", keysOf(result))
+	}
+	if !release.Tag {
+		t.Error("Expected Tag to be true for tag=yes")
+	}
+}
+
+// TestParseBranchConfigLinesTagOff tests that the tag branch property treats
+// git-config's "off" spelling as false.
+// Steps:
+// 1. Builds raw config lines declaring release as a topic branch with tag=off
+// 2. Calls config.ParseBranchConfigLines on them
+// 3. Verifies release's Tag is false
+func TestParseBranchConfigLinesTagOff(t *testing.T) {
+	t.Parallel()
+
+	lines := []string{
+		"gitflow.branch.release.type topic",
+		"gitflow.branch.release.tag off",
+	}
+
+	result := config.ParseBranchConfigLines(lines)
+
+	release, ok := result["release"]
+	if !ok {
+		t.Fatalf("Expected a release branch config, got keys %v", keysOf(result))
+	}
+	if release.Tag {
+		t.Error("Expected Tag to be false for tag=off")
+	}
+}
+
 func keysOf(m map[string]config.BranchConfig) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {

--- a/test/internal/config/parsebool_test.go
+++ b/test/internal/config/parsebool_test.go
@@ -100,9 +100,10 @@ func TestParseBoolUnrecognizedValue(t *testing.T) {
 }
 
 // TestParseBoolWhitespacePaddedValue tests that ParseBool itself does not trim its input.
-// git-config(1) rejects whitespace-padded booleans as bad values, so the helper's
-// contract is to treat them as unrecognized. This is a statement about the helper
-// only: both callers trim upstream, so a padded value may never reach it padded.
+// A padded value matches no spelling and strconv.Atoi rejects it, so the helper's
+// contract is to treat it as unrecognized. This is a statement about the helper
+// only: whether padded input can reach it differs by read path — repo.GetConfig
+// trims, while the resolver and branch-property paths pass the raw value through.
 // Steps:
 // 1. Calls config.ParseBool with " yes", "true " and " 1"
 // 2. Verifies all three resolve to false

--- a/test/internal/config/parsebool_test.go
+++ b/test/internal/config/parsebool_test.go
@@ -1,0 +1,153 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/gittower/git-flow-next/internal/config"
+)
+
+// TestParseBoolTruthyLiterals tests that git-config(1)'s truthy literals all parse as true.
+// Steps:
+// 1. Calls config.ParseBool with "true", "yes", "on" and "1"
+// 2. Verifies every input resolves to true
+func TestParseBoolTruthyLiterals(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []string{"true", "yes", "on", "1"} {
+		if !config.ParseBool(value) {
+			t.Errorf("ParseBool(%q) = false, want true", value)
+		}
+	}
+}
+
+// TestParseBoolFalsyLiterals tests that git-config(1)'s falsy literals all parse as false.
+// Steps:
+// 1. Calls config.ParseBool with "false", "no", "off" and "0"
+// 2. Verifies every input resolves to false
+func TestParseBoolFalsyLiterals(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []string{"false", "no", "off", "0"} {
+		if config.ParseBool(value) {
+			t.Errorf("ParseBool(%q) = true, want false", value)
+		}
+	}
+}
+
+// TestParseBoolEmptyString tests that an empty value resolves to false.
+// Steps:
+// 1. Calls config.ParseBool with ""
+// 2. Verifies the result is false
+func TestParseBoolEmptyString(t *testing.T) {
+	t.Parallel()
+
+	if config.ParseBool("") {
+		t.Error("ParseBool(\"\") = true, want false")
+	}
+}
+
+// TestParseBoolNonZeroIntegers tests that any non-zero integer of either sign is truthy.
+// Steps:
+// 1. Calls config.ParseBool with "5", "42" and "-1"
+// 2. Verifies every input resolves to true
+func TestParseBoolNonZeroIntegers(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []string{"5", "42", "-1"} {
+		if !config.ParseBool(value) {
+			t.Errorf("ParseBool(%q) = false, want true", value)
+		}
+	}
+}
+
+// TestParseBoolCaseInsensitive tests that boolean literals match case-insensitively.
+// Steps:
+// 1. Calls config.ParseBool with "Yes", "ON", "True" and "Off"
+// 2. Verifies the first three resolve to true and "Off" resolves to false
+func TestParseBoolCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		value string
+		want  bool
+	}{
+		{"Yes", true},
+		{"ON", true},
+		{"True", true},
+		{"Off", false},
+	}
+
+	for _, tc := range cases {
+		if got := config.ParseBool(tc.value); got != tc.want {
+			t.Errorf("ParseBool(%q) = %v, want %v", tc.value, got, tc.want)
+		}
+	}
+}
+
+// TestParseBoolUnrecognizedValue tests that an unparseable value degrades to false.
+// Steps:
+//  1. Calls config.ParseBool with "maybe" and "truue"
+//  2. Verifies both resolve to false without panicking (there is no error return,
+//     so an unrecognized value is treated as "off")
+func TestParseBoolUnrecognizedValue(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []string{"maybe", "truue"} {
+		if config.ParseBool(value) {
+			t.Errorf("ParseBool(%q) = true, want false", value)
+		}
+	}
+}
+
+// TestParseBoolWhitespacePaddedValue tests that ParseBool itself does not trim its input.
+// git-config(1) rejects whitespace-padded booleans as bad values, so the helper's
+// contract is to treat them as unrecognized. This is a statement about the helper
+// only: both callers trim upstream, so a padded value may never reach it padded.
+// Steps:
+// 1. Calls config.ParseBool with " yes", "true " and " 1"
+// 2. Verifies all three resolve to false
+func TestParseBoolWhitespacePaddedValue(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []string{" yes", "true ", " 1"} {
+		if config.ParseBool(value) {
+			t.Errorf("ParseBool(%q) = true, want false", value)
+		}
+	}
+}
+
+// TestParseBoolSignedAndPaddedIntegers tests signed and zero-padded integer forms.
+// Steps:
+//  1. Calls config.ParseBool with "+5", "007" and "-0"
+//  2. Verifies "+5" and "007" resolve to true and "-0" resolves to false (it
+//     parses to the integer 0)
+func TestParseBoolSignedAndPaddedIntegers(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		value string
+		want  bool
+	}{
+		{"+5", true},
+		{"007", true},
+		{"-0", false},
+	}
+
+	for _, tc := range cases {
+		if got := config.ParseBool(tc.value); got != tc.want {
+			t.Errorf("ParseBool(%q) = %v, want %v", tc.value, got, tc.want)
+		}
+	}
+}
+
+// TestParseBoolIntegerOverflow tests that an integer too large for int degrades to false.
+// Steps:
+// 1. Calls config.ParseBool with "99999999999999999999"
+// 2. Verifies the result is false (unparseable, so the unrecognized-value rule applies)
+func TestParseBoolIntegerOverflow(t *testing.T) {
+	t.Parallel()
+
+	if config.ParseBool("99999999999999999999") {
+		t.Error("ParseBool(\"99999999999999999999\") = true, want false")
+	}
+}


### PR DESCRIPTION
Routes every boolean configuration read through a single `config.ParseBool` helper implementing git-config(1) semantics, so spellings like `yes`, `on`, `1`, and `TRUE` stop being silently ignored.

Boolean values were compared against the literal string `"true"` at thirteen independent sites, which made `git config gitflow.release.finish.push yes` a no-op and left falsy spellings like `no` and `off` working only by accident. The new `internal/config/bool.go` maps `true`/`yes`/`on` and any non-zero integer to true, and `false`/`no`/`off`/`0`/empty to false, case-insensitively; all thirteen sites now call it. Those are six in `internal/config/resolver.go` (including `getCommandConfigBool`, which alone covers sixteen keys), two in `internal/config/config.go` inside `ParseBranchConfigLines` (which also serves `.gitflow`-sourced branch definitions, so shared config is fixed for free), two in `internal/config/shared.go`, and three in `cmd/delete.go`. Only value interpretation changes: the presence-vs-absence guards are untouched, so an unset key still falls through to its Layer 1 default rather than being read as false. Coverage is a table-driven unit suite for the helper plus a behavior test per affected key across `test/cmd/`; the existing suite passes unmodified, which is the regression guard the spec asked for.

Resolves #182

### Remarks

- `gitflow.shared.autoInit` and `gitflow.shared.trustHooks` are folded in beyond the issue's "Affected config keys" list. Those keys landed with #183 after #182 was written, and including them here was authorized in a comment on #181.
- Unrecognized values resolve to false rather than erroring. git-config(1) reports a "bad boolean" for `maybe` or a whitespace-padded ` yes`, but the resolvers have no channel to surface that error, so false is the only implementable behavior. The deviation is documented at the `ParseBool` definition and in the manpage.
- `getCommandConfigBool` stays one-directional. Inverse options such as `no-rebase` and `notag` are separate configuration keys, not falsy spellings of the positive key, so `gitflow.feature.finish.rebase = off` still does not disable a strategy inherited from Layer 1. Making the helper presence-aware would change resolution semantics beyond this issue.
- Docs: `docs/gitflow-config.5.md` gains a Boolean Values section covering the accepted spellings and both caveats above; `CONFIGURATION.md` cross-references it rather than duplicating the rule.

**Review focus:**
- `internal/config/bool.go` — the helper and its documented deviations from git-config(1)
- `internal/config/resolver.go` — that the `exists`/`ok` presence guards are unchanged at all five inline sites