### PR TITLE
feat(init): Add opt-in repository creation

### DIFF
--- a/cmd/firstrun.go
+++ b/cmd/firstrun.go
@@ -74,7 +74,7 @@ func firstRunActivation(cmd *cobra.Command) error {
 	switch {
 	case config.SharedAutoInit(repo):
 		return activateAutoInit(repo)
-	case firstRunInteractive():
+	case stdinIsInteractive():
 		return activatePrompt(repo)
 	default:
 		fmt.Fprintf(os.Stderr, "Note: this repository has a shared %s configuration that has not been activated.\nRun 'git flow config sync' to activate it, or set gitflow.shared.autoInit=true to activate automatically.\n", config.SharedConfigFileName)
@@ -143,12 +143,14 @@ func activatePrompt(repo *git.Repo) error {
 	return nil
 }
 
-// firstRunInteractive reports whether the first-run activation decision should
-// treat stdin as interactive. It honors the test-only GIT_FLOW_ASSUME_INTERACTIVE
-// override (set to "1" to force interactive, since the subprocess test harness
-// cannot allocate a PTY); otherwise it uses the real terminal check, so a pipe or
-// /dev/null counts as non-interactive.
-func firstRunInteractive() bool {
+// stdinIsInteractive reports whether stdin should be treated as interactive,
+// i.e. whether it is safe to ask the user a question. It is shared by first-run
+// shared-config activation and by init's repository-creation prompt. It honors
+// the test-only GIT_FLOW_ASSUME_INTERACTIVE override (set to "1" to force
+// interactive, since the subprocess test harness cannot allocate a PTY);
+// otherwise it uses the real terminal check, so a pipe or /dev/null counts as
+// non-interactive.
+func stdinIsInteractive() bool {
 	if os.Getenv("GIT_FLOW_ASSUME_INTERACTIVE") == "1" {
 		return true
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gittower/git-flow-next/internal/config"
 	"github.com/gittower/git-flow-next/internal/errors"
 	"github.com/gittower/git-flow-next/internal/git"
+	"github.com/gittower/git-flow-next/internal/util"
 	"github.com/spf13/cobra"
 )
 
@@ -32,6 +33,11 @@ Configuration scope options control where settings are stored:
   --file=<path>       Store in specified file
   --shared            Write a committable .gitflow file and copy it into local config
 
+Outside a git repository, --init creates one in the current directory and then
+initializes git-flow in it; without --init an interactive run asks first, and a
+non-interactive run fails. The created repository's initial branch is the
+resolved git-flow trunk.
+
 Use --custom for interactive custom configuration.
 If git-flow-avh configuration exists, it will be imported.`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -53,13 +59,14 @@ If git-flow-avh configuration exists, it will be imported.`,
 		systemScope, _ := cmd.Flags().GetBool("system")
 		fileScope, _ := cmd.Flags().GetString("file")
 		sharedScope, _ := cmd.Flags().GetBool("shared")
-		InitCommand(useDefaults, !noCreateBranches, force, preset, custom, mainBranch, developBranch, featurePrefix, bugfixPrefix, releasePrefix, hotfixPrefix, supportPrefix, tagPrefix, localScope, globalScope, systemScope, fileScope, sharedScope)
+		initRepo, _ := cmd.Flags().GetBool("init")
+		InitCommand(useDefaults, !noCreateBranches, force, preset, custom, mainBranch, developBranch, featurePrefix, bugfixPrefix, releasePrefix, hotfixPrefix, supportPrefix, tagPrefix, localScope, globalScope, systemScope, fileScope, sharedScope, initRepo)
 	},
 }
 
 // InitCommand is the implementation of the init command
-func InitCommand(useDefaults, createBranches, force bool, preset string, custom bool, mainBranch, developBranch, featurePrefix, bugfixPrefix, releasePrefix, hotfixPrefix, supportPrefix, tagPrefix string, localScope, globalScope, systemScope bool, fileScope string, sharedScope bool) {
-	if err := initFlow(useDefaults, createBranches, force, preset, custom, mainBranch, developBranch, featurePrefix, bugfixPrefix, releasePrefix, hotfixPrefix, supportPrefix, tagPrefix, localScope, globalScope, systemScope, fileScope, sharedScope); err != nil {
+func InitCommand(useDefaults, createBranches, force bool, preset string, custom bool, mainBranch, developBranch, featurePrefix, bugfixPrefix, releasePrefix, hotfixPrefix, supportPrefix, tagPrefix string, localScope, globalScope, systemScope bool, fileScope string, sharedScope bool, initRepo bool) {
+	if err := initFlow(useDefaults, createBranches, force, preset, custom, mainBranch, developBranch, featurePrefix, bugfixPrefix, releasePrefix, hotfixPrefix, supportPrefix, tagPrefix, localScope, globalScope, systemScope, fileScope, sharedScope, initRepo); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -72,7 +79,7 @@ func InitCommand(useDefaults, createBranches, force bool, preset string, custom 
 }
 
 // initFlow performs the actual initialization logic and returns any errors
-func initFlow(useDefaults, createBranches, force bool, preset string, custom bool, mainBranch, developBranch, featurePrefix, bugfixPrefix, releasePrefix, hotfixPrefix, supportPrefix, tagPrefix string, localScope, globalScope, systemScope bool, fileScope string, sharedScope bool) error {
+func initFlow(useDefaults, createBranches, force bool, preset string, custom bool, mainBranch, developBranch, featurePrefix, bugfixPrefix, releasePrefix, hotfixPrefix, supportPrefix, tagPrefix string, localScope, globalScope, systemScope bool, fileScope string, sharedScope bool, initRepo bool) error {
 	// Validate mutual exclusivity of scope flags. --shared is not a git config
 	// scope; it selects "write structured config to <toplevel>/.gitflow, then
 	// copy gitflow.* into local .git/config", so it cannot be combined with the
@@ -126,14 +133,32 @@ func initFlow(useDefaults, createBranches, force bool, preset string, custom boo
 
 	// Open a handle for the invocation directory. A failure here means we are not
 	// inside a git work tree — the same condition the old git.IsGitRepo() guarded.
+	// Outside a repository, --init (or an affirmative answer to the prompt on
+	// interactive stdin) authorizes creating one; the repository itself is created
+	// further down, once configuration resolution has determined the trunk branch
+	// that becomes its initial branch.
 	repo, err := openRepo()
+	createRepo := false
 	if err != nil {
-		return &errors.GitError{Operation: "check if git repository", Err: fmt.Errorf("not a git repository. Please run 'git init' first")}
+		repo = nil
+		switch {
+		case initRepo:
+			createRepo = true
+		case stdinIsInteractive() && confirmCreateRepository():
+			createRepo = true
+		case stdinIsInteractive():
+			return &errors.GitError{Operation: "check if git repository", Err: fmt.Errorf("no git repository. Run 'git init' first, or re-run with --init")}
+		default:
+			return &errors.GitError{Operation: "check if git repository", Err: fmt.Errorf("not a git repository. Please run 'git init' first")}
+		}
 	}
 
 	// Shared scope has its own "already configured" detection based on the
-	// presence of the committed .gitflow file, not on git config scopes.
-	if sharedScope {
+	// presence of the committed .gitflow file, not on git config scopes. Outside a
+	// repository there is no work tree to look for .gitflow in, so the probe is
+	// skipped; a stray untracked .gitflow in a directory the user just asked to
+	// turn into a repository will be overwritten, which is acceptable.
+	if sharedScope && repo != nil {
 		if config.SharedConfigExists(repo) && !force {
 			fmt.Fprintln(os.Stderr, "Git-flow is already configured via the shared .gitflow file. Use --force to rewrite it.")
 			return &errors.AlreadyInitializedError{}
@@ -205,8 +230,15 @@ func initFlow(useDefaults, createBranches, force bool, preset string, custom boo
 	// Check if any configuration options are provided
 	hasConfigFlags := mainBranch != "" || developBranch != "" || featurePrefix != "" || bugfixPrefix != "" || releasePrefix != "" || hotfixPrefix != "" || supportPrefix != "" || tagPrefix != ""
 
-	// Check if git-flow-avh config exists and no explicit options are provided
-	if config.CheckGitFlowAVHConfig(repo) && preset == "" && !custom && !useDefaults && !hasConfigFlags {
+	// Check if git-flow-avh config exists and no explicit options are provided.
+	//
+	// AVH detection needs a repository handle, and on the --init path there is no
+	// repository yet (it cannot be created until configuration resolution has
+	// determined the trunk). Skipping it is correct rather than merely pragmatic: a
+	// brand-new repository has no local config, so the only AVH keys it could ever
+	// see would come from global/system config, which is not a repository being
+	// migrated from git-flow-avh.
+	if repo != nil && config.CheckGitFlowAVHConfig(repo) && preset == "" && !custom && !useDefaults && !hasConfigFlags {
 		fmt.Println("Found existing git-flow-avh configuration, importing...")
 		var err error
 		cfg, err = config.ImportGitFlowAVHConfig(repo)
@@ -256,6 +288,40 @@ func initFlow(useDefaults, createBranches, force bool, preset string, custom boo
 	// Apply overrides if any were provided
 	if mainBranch != "" || developBranch != "" || featurePrefix != "" || bugfixPrefix != "" || releasePrefix != "" || hotfixPrefix != "" || supportPrefix != "" || tagPrefix != "" {
 		cfg = config.ApplyOverrides(cfg, overrides)
+	}
+
+	// Create the repository now that configuration resolution has settled: the
+	// initial branch must be the resolved git-flow trunk, overriding any ambient
+	// init.defaultBranch. This has to happen before the identity fast-fail and the
+	// config save below, both of which need a live repository / a .git directory.
+	if createRepo {
+		trunk := cfg.TrunkBranch()
+		if trunk == "" {
+			return &errors.InvalidInputError{Message: "cannot create a repository: the resolved configuration has no trunk branch"}
+		}
+		// Validate before calling git: `git init --initial-branch=<bad name>` fails
+		// with exit 128 but still leaves a .git directory behind, so a rejected name
+		// would otherwise strand a broken repository in the user's directory.
+		if err := util.ValidateBranchName(trunk); err != nil {
+			return &errors.InvalidBranchNameError{BranchName: trunk}
+		}
+		dir, err := os.Getwd()
+		if err != nil {
+			return &errors.GitError{Operation: "determine current directory", Err: err}
+		}
+		output, err := git.Init(dir, trunk)
+		if err != nil {
+			return &errors.GitError{Operation: "initialize git repository", Err: err}
+		}
+		if output != "" {
+			fmt.Println(output)
+		}
+		// NOT openRepo(): it memoizes the pre-creation "not a git repository"
+		// failure for the lifetime of the process (see cmd/repo.go).
+		repo, err = reopenRepo()
+		if err != nil {
+			return &errors.GitError{Operation: "open created repository", Err: err}
+		}
 	}
 
 	// Fail fast if an initial commit would be created but no git identity is
@@ -319,6 +385,21 @@ func initFlow(useDefaults, createBranches, force bool, preset string, custom boo
 
 	fmt.Println("Git flow has been initialized")
 	return nil
+}
+
+// confirmCreateRepository asks whether to create a git repository in the
+// invocation directory. It is only reached outside a repository, on interactive
+// stdin, without --init. It uses fmt.Scanln rather than bufio.NewReader(os.Stdin)
+// on purpose: a bufio reader would buffer far more than one line of piped stdin,
+// and the separate reader created later in interactiveConfig would never see the
+// remaining answers. fmt.Scanln also yields the right default — a bare Enter
+// leaves the response empty, which declines.
+func confirmCreateRepository() bool {
+	fmt.Print("No git repository here. Create one? [y/N]: ")
+	var response string
+	fmt.Scanln(&response)
+	response = strings.ToLower(strings.TrimSpace(response))
+	return response == "y" || response == "yes"
 }
 
 // createGitFlowBranches creates the base branches if they don't exist
@@ -753,6 +834,7 @@ func init() {
 	initCmd.Flags().StringP("hotfix", "x", "", "Hotfix branch prefix")
 	initCmd.Flags().StringP("support", "s", "", "Support branch prefix")
 	initCmd.Flags().StringP("tag", "t", "", "Version tag prefix")
+	initCmd.Flags().Bool("init", false, "Create a git repository in the current directory if there is none")
 
 	// Configuration scope options
 	initCmd.Flags().Bool("local", false, "Store configuration in repository's .git/config")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -154,12 +154,26 @@ func initFlow(useDefaults, createBranches, force bool, preset string, custom boo
 	}
 
 	// Shared scope has its own "already configured" detection based on the
-	// presence of the committed .gitflow file, not on git config scopes. Outside a
-	// repository there is no work tree to look for .gitflow in, so the probe is
-	// skipped; a stray untracked .gitflow in a directory the user just asked to
-	// turn into a repository will be overwritten, which is acceptable.
-	if sharedScope && repo != nil {
-		if config.SharedConfigExists(repo) && !force {
+	// presence of the committed .gitflow file, not on git config scopes. On the
+	// create path there is no repository yet, so the probe looks in the invocation
+	// directory — the work-tree root the repository is about to get. It has to run
+	// before creation, both so a refusal leaves no stray .git behind and because
+	// `git config --file` merges into an existing .gitflow instead of truncating
+	// it: without this guard a pre-existing file (a source tarball shipping
+	// .gitflow but no .git, say) would silently blend its stale keys into the new
+	// configuration.
+	if sharedScope && !force {
+		sharedExists := false
+		if repo != nil {
+			sharedExists = config.SharedConfigExists(repo)
+		} else {
+			dir, err := os.Getwd()
+			if err != nil {
+				return &errors.GitError{Operation: "determine current directory", Err: err}
+			}
+			sharedExists = config.SharedConfigExistsIn(dir)
+		}
+		if sharedExists {
 			fmt.Fprintln(os.Stderr, "Git-flow is already configured via the shared .gitflow file. Use --force to rewrite it.")
 			return &errors.AlreadyInitializedError{}
 		}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -147,7 +147,7 @@ func initFlow(useDefaults, createBranches, force bool, preset string, custom boo
 		case stdinIsInteractive() && confirmCreateRepository():
 			createRepo = true
 		case stdinIsInteractive():
-			return &errors.GitError{Operation: "check if git repository", Err: fmt.Errorf("no git repository. Run 'git init' first, or re-run with --init")}
+			return &errors.RepositoryCreationDeclinedError{}
 		default:
 			return &errors.GitError{Operation: "check if git repository", Err: fmt.Errorf("not a git repository. Please run 'git init' first")}
 		}

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -37,6 +37,23 @@ func openRepo() (*git.Repo, error) {
 	return cachedRepo, cachedErr
 }
 
+// reopenRepo re-resolves the invocation directory after `git flow init --init`
+// has created the repository. openRepo memoizes its result — including the "not
+// a git repository" failure — so it must not be reused once the directory has
+// become a repository. This resolves afresh and primes the memo (marking it
+// resolved even if openRepo has not run yet) so any later openRepo caller in
+// this process observes the created repository.
+func reopenRepo() (*git.Repo, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	repo, openErr := git.Open(dir)
+	repoOnce.Do(func() {})
+	cachedRepo, cachedErr = repo, openErr
+	return repo, openErr
+}
+
 // mustOpenRepo opens the invocation repository or exits the process. A failure
 // here means the invocation directory is not inside a git repository — a git
 // error, not a "git-flow not initialized" condition (which is detected later,

--- a/docs/git-flow-init.1.md
+++ b/docs/git-flow-init.1.md
@@ -6,7 +6,7 @@ git-flow-init - Initialize git-flow in a repository
 
 ## SYNOPSIS
 
-**git-flow init** [**-f**|**--force**] [**--preset**=*preset*] [**--custom**] [**--defaults**] [**--shared**|**--local**|**--global**|**--system**|**--file**=*path*] [*options*]
+**git-flow init** [**-f**|**--force**] [**--init**] [**--preset**=*preset*] [**--custom**] [**--defaults**] [**--shared**|**--local**|**--global**|**--system**|**--file**=*path*] [*options*]
 
 ## DESCRIPTION
 
@@ -24,6 +24,9 @@ Initialize git-flow configuration in the current Git repository. This command se
 
 **-f**, **--force**
 : Force reconfiguration of git-flow even if already initialized. Without this option, **git flow init** will fail if configuration already exists (in non-interactive mode) or prompt for confirmation (in interactive mode).
+
+**--init**
+: Create a git repository in the current directory when there is none, then initialize git-flow in it. Without this option, running **git flow init** outside a repository fails (exit status **3**) when stdin is not an interactive terminal, and prompts **No git repository here. Create one? [y/N]** when it is; declining creates nothing. Inside an existing repository **--init** is a no-op. The created repository's initial branch is the resolved git-flow trunk (for example **main** with **--defaults**, or **trunk** with **--main trunk**), overriding any ambient **init.defaultBranch**. **--init** governs only repository creation — it does not change how configuration is selected, and it applies with every configuration scope option, including **--global**, **--system**, **--file** and **--shared**.
 
 ### Preset Options
 
@@ -255,17 +258,14 @@ By default, git-flow stores configuration in the repository's **.git/config** fi
 **0**
 : Successful initialization
 
-**1**
-: Repository not found or not a git repository
-
 **2**
-: Repository already initialized (use config commands to modify)
+: Invalid options — for example multiple configuration scope options, or an invalid branch name
 
 **3**
-: Invalid preset or configuration options
+: The current directory is not a git repository and repository creation was not authorized (no **--init**, and either no interactive terminal or the prompt was declined)
 
 **6**
-: A required precondition failed — for example, the repository has no commits and branch creation is requested but no git identity (**user.name** and **user.email**) is configured
+: A required precondition failed — git-flow is already initialized and **--force** was not given, or the repository has no commits and branch creation is requested but no git identity (**user.name** and **user.email**) is configured
 
 ## SEE ALSO
 
@@ -273,6 +273,8 @@ By default, git-flow stores configuration in the repository's **.git/config** fi
 
 ## NOTES
 
+- Outside a git repository, **git-flow init** never creates one implicitly; creation requires **--init** or an affirmative answer to the interactive prompt. This preserves the safety of typing **git flow init** in the wrong empty directory
+- When **--init** creates the repository, the identity precondition described below still applies. The repository is created before the check runs, so a failure leaves an initialized-but-unconfigured repository behind; configure **user.name**/**user.email** and re-run, which then takes the ordinary "already a repository" path
 - **git-flow init** requires **--force** to reconfigure an already initialized repository in non-interactive mode
 - In interactive mode without **--force**, users are prompted for confirmation before reconfiguring
 - Existing branches are preserved during initialization

--- a/docs/git-flow-init.1.md
+++ b/docs/git-flow-init.1.md
@@ -258,11 +258,14 @@ By default, git-flow stores configuration in the repository's **.git/config** fi
 **0**
 : Successful initialization
 
+**1**
+: Usage error — an unknown option or an unexpected argument
+
 **2**
 : Invalid options — for example multiple configuration scope options, or an invalid branch name
 
 **3**
-: The current directory is not a git repository and repository creation was not authorized (no **--init**, and either no interactive terminal or the prompt was declined)
+: Git operation failed (for example the current directory is not a git repository and repository creation was not authorized — no **--init**, and either no interactive terminal or the prompt was declined)
 
 **6**
 : A required precondition failed — git-flow is already initialized and **--force** was not given, or the repository has no commits and branch creation is requested but no git identity (**user.name** and **user.email**) is configured
@@ -279,7 +282,7 @@ By default, git-flow stores configuration in the repository's **.git/config** fi
 - In interactive mode without **--force**, users are prompted for confirmation before reconfiguring
 - Existing branches are preserved during initialization
 - When initializing a repository with no existing commits, **git-flow init** creates an empty initial commit to enable branch creation. No files are added to the working directory
-- Creating that initial commit requires a configured git identity. When the repository has no commits and branch creation is requested, **git-flow init** verifies that both **user.name** and **user.email** are set (in local, global, or system config) before writing any configuration. If the identity is missing, init fails fast with an actionable error (exit status **6**) and leaves the repository untouched, so it can be re-run after configuring the identity. Repositories that already have commits, or runs with **--no-create-branches**, do not require an identity
+- Creating that initial commit requires a configured git identity. When the repository has no commits and branch creation is requested, **git-flow init** verifies that both **user.name** and **user.email** are set (in local, global, or system config) before writing any configuration. If the identity is missing, init fails fast with an actionable error (exit status **6**) and writes no configuration, so it can be re-run after configuring the identity. A repository that **--init** created moments earlier is not rolled back and stays in place, as described above. Repositories that already have commits, or runs with **--no-create-branches**, do not require an identity
 - Compatible with repositories previously initialized with git-flow-avh
 - Configuration scope options (**--local**, **--global**, **--system**, **--file**) only affect the **init** command. All other git-flow commands (start, finish, update, etc.) always read from merged config using Git's standard precedence (local > global > system)
 - When checking initialization status without an explicit scope flag, git-flow checks merged config and reports which scope the configuration was found in

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,6 +51,24 @@ func (c *Config) ResolveBranchName(name string) (canonical string, found bool) {
 	return "", false
 }
 
+// TrunkBranch returns the configuration's trunk branch — the base branch with no
+// parent. When several base branches have no parent (no shipped preset produces
+// that) the lexicographically smallest name wins, so the result never depends on
+// Go's randomized map iteration order. It returns "" for a configuration with no
+// trunk.
+func (c *Config) TrunkBranch() string {
+	trunk := ""
+	for name, branch := range c.Branches {
+		if branch.Type != string(BranchTypeBase) || branch.Parent != "" {
+			continue
+		}
+		if trunk == "" || name < trunk {
+			trunk = name
+		}
+	}
+	return trunk
+}
+
 // MergeStrategy represents the strategy for merging branches
 type MergeStrategy string
 

--- a/internal/config/shared.go
+++ b/internal/config/shared.go
@@ -21,7 +21,15 @@ func SharedConfigPath(repo *git.Repo) string {
 
 // SharedConfigExists reports whether a .gitflow file is present at the repo root.
 func SharedConfigExists(repo *git.Repo) bool {
-	info, err := os.Stat(SharedConfigPath(repo))
+	return SharedConfigExistsIn(repo.WorkTree())
+}
+
+// SharedConfigExistsIn reports whether a .gitflow file is present in dir. It
+// serves callers that have no repository handle yet — notably `init --shared
+// --init`, which must probe the invocation directory before creating the
+// repository that would become its work-tree root.
+func SharedConfigExistsIn(dir string) bool {
+	info, err := os.Stat(filepath.Join(dir, SharedConfigFileName))
 	return err == nil && !info.IsDir()
 }
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -582,6 +582,22 @@ func (e *AlreadyInitializedError) ExitCode() ExitCode {
 	return ExitCodeValidationError
 }
 
+// RepositoryCreationDeclinedError indicates the user answered no to the prompt
+// offering to create a git repository. Nothing failed here — the user declined —
+// so the message is printed verbatim instead of being wrapped in GitError's
+// "failed to <operation>" phrasing. The exit code matches the non-interactive
+// "not a git repository" path so callers see one code for "no repository to
+// work in", however that conclusion was reached.
+type RepositoryCreationDeclinedError struct{}
+
+func (e *RepositoryCreationDeclinedError) Error() string {
+	return "no git repository. Run 'git init' first, or re-run with --init"
+}
+
+func (e *RepositoryCreationDeclinedError) ExitCode() ExitCode {
+	return ExitCodeGitError
+}
+
 // MissingUserIdentityError indicates git user.name/user.email are not configured
 type MissingUserIdentityError struct{}
 

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -72,6 +72,25 @@ func (r *Repo) gitCmd(args ...string) *exec.Cmd {
 	return gitCommand(r.workTree, args...)
 }
 
+// Init creates a new git repository in dir with initialBranch as its initial
+// branch, overriding any ambient init.defaultBranch. dir must already exist and
+// must not already be a repository (callers check that first). It returns git's
+// own output ("Initialized empty Git repository in ...") so the caller can show
+// it, since CombinedOutput would otherwise swallow it.
+func Init(dir string, initialBranch string) (string, error) {
+	if strings.TrimSpace(dir) == "" {
+		return "", fmt.Errorf("git.Init: directory must not be empty")
+	}
+	if strings.TrimSpace(initialBranch) == "" {
+		return "", fmt.Errorf("git.Init: initial branch must not be empty")
+	}
+	output, err := gitCommand(dir, "init", "--initial-branch="+initialBranch).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to initialize git repository in %s: %s: %w", dir, strings.TrimSpace(string(output)), err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
 // Open resolves dir to a git repository and returns a handle carrying absolute
 // work-tree, git-dir, and common-git-dir paths. It errors on an empty dir or a
 // directory that is not inside a git work tree; it never falls back to the

--- a/test/cmd/init_test.go
+++ b/test/cmd/init_test.go
@@ -2024,7 +2024,7 @@ func TestInitWithInitFlagFailsWithoutIdentity(t *testing.T) {
 // 3. Runs 'git flow init' answering 'n'
 // 4. Verifies the command fails with exit code 3
 // 5. Verifies the prompt text was shown
-// 6. Verifies the decline message names both 'git init' and '--init'
+// 6. Verifies the decline message names both 'git init' and '--init', and that it does not read as an internal check failure
 // 7. Verifies no .git directory exists and the directory is still empty
 // 8. Verifies configuration prompting was never reached
 func TestInitInteractiveDeclineDoesNotCreateRepository(t *testing.T) {
@@ -2040,11 +2040,11 @@ func TestInitInteractiveDeclineDoesNotCreateRepository(t *testing.T) {
 	if !strings.Contains(output, "Create one? [y/N]") {
 		t.Errorf("Expected the creation prompt in output, got: %s", output)
 	}
-	if !strings.Contains(output, "git init") {
-		t.Errorf("Expected the decline message to name 'git init', got: %s", output)
+	if !strings.Contains(output, "no git repository. Run 'git init' first, or re-run with --init") {
+		t.Errorf("Expected the decline message naming 'git init' and '--init', got: %s", output)
 	}
-	if !strings.Contains(output, "--init") {
-		t.Errorf("Expected the decline message to name '--init', got: %s", output)
+	if strings.Contains(output, "failed to check if git repository") {
+		t.Errorf("Expected a decline message, not an internal check failure, got: %s", output)
 	}
 	if hasGitDir(t, dir) {
 		t.Error("Expected no .git directory after declining")
@@ -2069,7 +2069,7 @@ func TestInitInteractiveDeclineDoesNotCreateRepository(t *testing.T) {
 // 3. Runs 'git flow init' answering with an empty line
 // 4. Verifies the command fails with exit code 3
 // 5. Verifies the prompt text was shown
-// 6. Verifies the decline message names both 'git init' and '--init'
+// 6. Verifies the decline message names both 'git init' and '--init', and that it does not read as an internal check failure
 // 7. Verifies no .git directory exists and the directory is still empty
 // 8. Verifies configuration prompting was never reached
 func TestInitInteractiveEmptyAnswerDoesNotCreateRepository(t *testing.T) {
@@ -2085,11 +2085,11 @@ func TestInitInteractiveEmptyAnswerDoesNotCreateRepository(t *testing.T) {
 	if !strings.Contains(output, "Create one? [y/N]") {
 		t.Errorf("Expected the creation prompt in output, got: %s", output)
 	}
-	if !strings.Contains(output, "git init") {
-		t.Errorf("Expected the decline message to name 'git init', got: %s", output)
+	if !strings.Contains(output, "no git repository. Run 'git init' first, or re-run with --init") {
+		t.Errorf("Expected the decline message naming 'git init' and '--init', got: %s", output)
 	}
-	if !strings.Contains(output, "--init") {
-		t.Errorf("Expected the decline message to name '--init', got: %s", output)
+	if strings.Contains(output, "failed to check if git repository") {
+		t.Errorf("Expected a decline message, not an internal check failure, got: %s", output)
 	}
 	if hasGitDir(t, dir) {
 		t.Error("Expected no .git directory after declining")

--- a/test/cmd/init_test.go
+++ b/test/cmd/init_test.go
@@ -2118,7 +2118,9 @@ func TestInitInteractiveEmptyAnswerDoesNotCreateRepository(t *testing.T) {
 //  5. Verifies both the creation prompt and the configuration prompts were shown
 //  6. Verifies a repository now exists at the directory
 //  7. Verifies the custom-main and custom-dev branches were created
-//  8. Verifies gitflow.version and gitflow.branch.custom-main.type were written,
+//  8. Verifies no stray 'main' branch exists, proving the repository was created
+//     after the trunk was resolved rather than before
+//  9. Verifies gitflow.version and gitflow.branch.custom-main.type were written,
 //     proving the answers after the prompt were read
 func TestInitInteractiveAcceptCreatesRepository(t *testing.T) {
 	t.Parallel()
@@ -2154,6 +2156,12 @@ func TestInitInteractiveAcceptCreatesRepository(t *testing.T) {
 	}
 	if !branchExists(t, dir, "custom-dev") {
 		t.Error("Expected 'custom-dev' branch to exist")
+	}
+	// The trunk is only known once interactive configuration has run, so the
+	// repository must be created after it. Creating it earlier would fall back to
+	// the ambient init.defaultBranch and strand a 'main' branch here.
+	if branchExists(t, dir, "main") {
+		t.Error("Expected no stray 'main' branch: the repository must be created after the trunk is resolved")
 	}
 	if v := getGitConfigWithScope(t, dir, "gitflow.version", "local"); v != "1.0" {
 		t.Errorf("Expected gitflow.version to be '1.0', got: %s", v)

--- a/test/cmd/init_test.go
+++ b/test/cmd/init_test.go
@@ -2379,3 +2379,115 @@ func TestInitWithInitFlagAndSharedScopeWritesSharedConfig(t *testing.T) {
 		t.Error("Expected 'develop' branch to exist")
 	}
 }
+
+// seedSharedConfigFile writes a .gitflow file into dir carrying a key that
+// DefaultConfig() never produces, and returns its path plus the exact bytes
+// written. The marker key makes a merge (rather than a clean rewrite) visible.
+func seedSharedConfigFile(t *testing.T, dir string) (string, []byte) {
+	t.Helper()
+	content := []byte("[gitflow]\n\tversion = 1.0\n\tprecious = keepme\n")
+	path := filepath.Join(dir, ".gitflow")
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatalf("Failed to seed .gitflow: %v", err)
+	}
+	return path, content
+}
+
+// TestInitWithInitFlagAndSharedScopeRefusesExistingSharedConfig tests that
+// --shared --init honors the same pre-existing .gitflow guard as the in-repo
+// path: a directory that carries a .gitflow but no .git (a source tarball, say)
+// is refused without --force, and no repository is created for it.
+// Steps:
+// 1. Creates a temporary directory that is not a git repository
+// 2. Seeds a .gitflow there carrying a key the defaults never write
+// 3. Seeds a global git config with a user identity
+// 4. Runs 'git flow init --defaults --init --shared' without --force
+// 5. Verifies the command fails with exit code 6 and names --force
+// 6. Verifies the .gitflow file is byte-identical to the seeded one
+// 7. Verifies no .git directory was created
+// 8. Verifies .gitflow is still the only entry in the directory
+func TestInitWithInitFlagAndSharedScopeRefusesExistingSharedConfig(t *testing.T) {
+	t.Parallel()
+	dir := setupNonRepoDir(t)
+	sharedPath, seeded := seedSharedConfigFile(t, dir)
+	env, _ := identityConfigEnv(t, nil)
+
+	output, err := runGitFlowWithEnv(t, dir, env, "init", "--defaults", "--init", "--shared")
+	if code := exitCodeOf(t, err); code != 6 {
+		t.Fatalf("Expected exit code 6, got %d\nOutput: %s", code, output)
+	}
+	if !strings.Contains(output, "already configured via the shared .gitflow file") {
+		t.Errorf("Expected output to report the existing .gitflow, got: %s", output)
+	}
+	if !strings.Contains(output, "--force") {
+		t.Errorf("Expected output to name --force, got: %s", output)
+	}
+	after, readErr := os.ReadFile(sharedPath)
+	if readErr != nil {
+		t.Fatalf("Failed to read .gitflow: %v", readErr)
+	}
+	if string(after) != string(seeded) {
+		t.Errorf("Expected .gitflow to be left untouched, got:\n%s", after)
+	}
+	if v := getGitConfigFromFile(t, sharedPath, "gitflow.precious"); v != "keepme" {
+		t.Errorf("Expected the pre-existing gitflow.precious to survive, got: %s", v)
+	}
+	if hasGitDir(t, dir) {
+		t.Error("Expected no .git directory: the .gitflow guard must run before creation")
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("Failed to read directory: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("Expected .gitflow to stay the only entry, got %d entries", len(entries))
+	}
+}
+
+// TestInitWithInitFlagAndSharedScopeForceReplacesExistingSharedConfig tests that
+// --shared --init --force rewrites a pre-existing .gitflow cleanly instead of
+// merging into it, and still creates the repository.
+// Steps:
+// 1. Creates a temporary directory that is not a git repository
+// 2. Seeds a .gitflow there carrying a key the defaults never write
+// 3. Seeds a global git config with a user identity
+// 4. Runs 'git flow init --defaults --init --shared --force'
+// 5. Verifies the command succeeds and a .git directory exists
+// 6. Verifies the stale key is gone from .gitflow and from local config
+// 7. Verifies the git-flow keys were written to .gitflow and copied to local
+// 8. Verifies the main and develop base branches were created
+func TestInitWithInitFlagAndSharedScopeForceReplacesExistingSharedConfig(t *testing.T) {
+	t.Parallel()
+	dir := setupNonRepoDir(t)
+	sharedPath, _ := seedSharedConfigFile(t, dir)
+	env, _ := identityConfigEnv(t, nil)
+
+	output, err := runGitFlowWithEnv(t, dir, env, "init", "--defaults", "--init", "--shared", "--force")
+	if err != nil {
+		t.Fatalf("Expected success, got error: %v\nOutput: %s", err, output)
+	}
+	if !hasGitDir(t, dir) {
+		t.Error("Expected a .git directory to be created")
+	}
+	if v := getGitConfigFromFile(t, sharedPath, "gitflow.precious"); v != "" {
+		t.Errorf("Expected the stale gitflow.precious to be gone from .gitflow, got: %s", v)
+	}
+	if v := getGitConfigWithScope(t, dir, "gitflow.precious", "local"); v != "" {
+		t.Errorf("Expected no stale gitflow.precious in local config, got: %s", v)
+	}
+	if v := getGitConfigFromFile(t, sharedPath, "gitflow.version"); v != "1.0" {
+		t.Errorf("Expected gitflow.version '1.0' in .gitflow, got: %s", v)
+	}
+	if v := getGitConfigFromFile(t, sharedPath, "gitflow.branch.develop.parent"); v != "main" {
+		t.Errorf("Expected gitflow.branch.develop.parent 'main' in .gitflow, got: %s", v)
+	}
+	if v := getGitConfigWithScope(t, dir, "gitflow.version", "local"); v != "1.0" {
+		t.Errorf("Expected gitflow.version '1.0' copied into local config, got: %s", v)
+	}
+	if !branchExists(t, dir, "main") {
+		t.Error("Expected 'main' branch to exist")
+	}
+	if !branchExists(t, dir, "develop") {
+		t.Error("Expected 'develop' branch to exist")
+	}
+}

--- a/test/cmd/init_test.go
+++ b/test/cmd/init_test.go
@@ -1692,3 +1692,690 @@ func TestInitFileRelativePathResolvesAgainstInvocationDir(t *testing.T) {
 		t.Errorf("work-tree-root cfgdir was created/read; --file did not resolve against invocation dir")
 	}
 }
+
+// runGitFlowWithInputAndEnv runs git-flow with both piped stdin and custom
+// environment variables. The repository-creation prompt is gated on interactive
+// stdin (GIT_FLOW_ASSUME_INTERACTIVE=1, since the subprocess harness cannot
+// allocate a PTY) and also consumes stdin, so neither runGitFlowWithInput nor
+// runGitFlowWithEnv is sufficient on its own.
+func runGitFlowWithInputAndEnv(t *testing.T, dir string, input string, env []string, args ...string) (string, error) {
+	t.Helper()
+	gitFlowPath := testutil.GitFlowPath()
+	cmd := exec.Command(gitFlowPath, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), env...)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatalf("Failed to get stdin pipe: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Failed to start command: %v", err)
+	}
+	io.WriteString(stdin, input)
+	stdin.Close()
+	err = cmd.Wait()
+	return stdout.String() + stderr.String(), err
+}
+
+// setupNonRepoDir returns a temporary directory that is deliberately NOT a git
+// repository, for the "git flow init outside a repository" scenarios.
+func setupNonRepoDir(t *testing.T) string {
+	t.Helper()
+	return t.TempDir()
+}
+
+// hasGitDir reports whether dir contains a .git entry, i.e. whether a
+// repository was created there.
+func hasGitDir(t *testing.T, dir string) bool {
+	t.Helper()
+	_, err := os.Stat(filepath.Join(dir, ".git"))
+	return err == nil
+}
+
+// identityConfigEnv seeds a writable temporary global git config with a user
+// identity plus any extra key/value settings, and returns the environment
+// pointing git at it with the system config isolated, together with the path of
+// the seeded global config file (tests asserting on --global writes need it).
+// Unlike isolatedConfigEnv it supplies an identity, so init can create the
+// initial commit. It also pins LC_ALL=C so assertions on git's own output
+// ("Initialized empty Git repository") are not defeated by a translated locale.
+func identityConfigEnv(t *testing.T, extra map[string]string) ([]string, string) {
+	t.Helper()
+	globalConfigFile := filepath.Join(t.TempDir(), "gitconfig-global")
+	settings := map[string]string{"user.name": "A", "user.email": "a@b.c"}
+	for k, v := range extra {
+		settings[k] = v
+	}
+	for k, v := range settings {
+		if _, err := testutil.RunGit(t, t.TempDir(), "config", "--file", globalConfigFile, k, v); err != nil {
+			t.Fatalf("Failed to seed global %s: %v", k, err)
+		}
+	}
+	env := []string{"GIT_CONFIG_GLOBAL=" + globalConfigFile, "GIT_CONFIG_SYSTEM=" + os.DevNull, "LC_ALL=C"}
+	return env, globalConfigFile
+}
+
+// TestInitCreatesRepositoryWithInitFlag tests that --init creates a git
+// repository in an empty directory and then initializes git-flow in it.
+// Steps:
+//  1. Creates a temporary directory that is not a git repository
+//  2. Seeds a temporary global git config with a user identity
+//  3. Runs 'git flow init --defaults --init' in that directory
+//  4. Verifies the command succeeds
+//  5. Verifies a .git directory exists and the directory is inside a work tree
+//  6. Verifies gitflow.version is 1.0 in local config
+//  7. Verifies the main and develop base branches were created
+//  8. Verifies the output reports both git-flow initialization and git's own
+//     'Initialized empty Git repository' line (presence only, never ordering)
+func TestInitCreatesRepositoryWithInitFlag(t *testing.T) {
+	t.Parallel()
+	dir := setupNonRepoDir(t)
+	env, _ := identityConfigEnv(t, nil)
+
+	output, err := runGitFlowWithEnv(t, dir, env, "init", "--defaults", "--init")
+	if err != nil {
+		t.Fatalf("Expected success, got error: %v\nOutput: %s", err, output)
+	}
+	if !hasGitDir(t, dir) {
+		t.Error("Expected a .git directory to be created")
+	}
+	insideWorkTree, err := testutil.RunGit(t, dir, "rev-parse", "--is-inside-work-tree")
+	if err != nil {
+		t.Fatalf("Expected the directory to be a work tree: %v", err)
+	}
+	if strings.TrimSpace(insideWorkTree) != "true" {
+		t.Errorf("Expected 'true' from rev-parse --is-inside-work-tree, got: %s", insideWorkTree)
+	}
+	if v := getGitConfigWithScope(t, dir, "gitflow.version", "local"); v != "1.0" {
+		t.Errorf("Expected gitflow.version to be '1.0', got: %s", v)
+	}
+	if !branchExists(t, dir, "main") {
+		t.Error("Expected 'main' branch to exist")
+	}
+	if !branchExists(t, dir, "develop") {
+		t.Error("Expected 'develop' branch to exist")
+	}
+	if !strings.Contains(output, "Initializing git-flow with default settings") {
+		t.Errorf("Expected output to contain 'Initializing git-flow with default settings', got: %s", output)
+	}
+	if !strings.Contains(output, "Git flow has been initialized") {
+		t.Errorf("Expected output to contain 'Git flow has been initialized', got: %s", output)
+	}
+	if !strings.Contains(output, "Initialized empty Git repository") {
+		t.Errorf("Expected output to surface git's own 'Initialized empty Git repository' line, got: %s", output)
+	}
+}
+
+// TestInitWithInitFlagUsesTrunkAsInitialBranch tests that the repository created
+// by --init uses the resolved git-flow trunk as its initial branch, overriding
+// an ambient init.defaultBranch.
+// Steps:
+//  1. Creates a temporary directory that is not a git repository
+//  2. Seeds a global git config with an identity and init.defaultBranch=legacy
+//  3. Runs 'git flow init --defaults --init --no-create-branches' so HEAD stays
+//     unborn and the initial branch remains observable
+//  4. Verifies the command succeeds
+//  5. Verifies HEAD points at 'main', not 'legacy'
+//  6. Verifies no 'legacy' branch exists
+//  7. Verifies gitflow.version is 1.0 in local config
+func TestInitWithInitFlagUsesTrunkAsInitialBranch(t *testing.T) {
+	t.Parallel()
+	dir := setupNonRepoDir(t)
+	env, _ := identityConfigEnv(t, map[string]string{"init.defaultBranch": "legacy"})
+
+	output, err := runGitFlowWithEnv(t, dir, env, "init", "--defaults", "--init", "--no-create-branches")
+	if err != nil {
+		t.Fatalf("Expected success, got error: %v\nOutput: %s", err, output)
+	}
+	head, err := testutil.RunGit(t, dir, "symbolic-ref", "--short", "HEAD")
+	if err != nil {
+		t.Fatalf("Failed to read HEAD: %v", err)
+	}
+	if strings.TrimSpace(head) != "main" {
+		t.Errorf("Expected initial branch 'main', got: %s", strings.TrimSpace(head))
+	}
+	if branchExists(t, dir, "legacy") {
+		t.Error("Expected no 'legacy' branch; init.defaultBranch must not win over the trunk")
+	}
+	if v := getGitConfigWithScope(t, dir, "gitflow.version", "local"); v != "1.0" {
+		t.Errorf("Expected gitflow.version to be '1.0', got: %s", v)
+	}
+}
+
+// TestInitWithInitFlagUsesCustomMainAsInitialBranch tests that --main drives the
+// initial branch of the repository created by --init.
+// Steps:
+// 1. Creates a temporary directory that is not a git repository
+// 2. Seeds a global git config with an identity and init.defaultBranch=legacy
+// 3. Runs 'git flow init --init --main trunk --no-create-branches'
+// 4. Verifies the command succeeds
+// 5. Verifies HEAD points at 'trunk'
+// 6. Verifies gitflow.branch.trunk.type is 'base' in local config
+func TestInitWithInitFlagUsesCustomMainAsInitialBranch(t *testing.T) {
+	t.Parallel()
+	dir := setupNonRepoDir(t)
+	env, _ := identityConfigEnv(t, map[string]string{"init.defaultBranch": "legacy"})
+
+	output, err := runGitFlowWithEnv(t, dir, env, "init", "--init", "--main", "trunk", "--no-create-branches")
+	if err != nil {
+		t.Fatalf("Expected success, got error: %v\nOutput: %s", err, output)
+	}
+	head, err := testutil.RunGit(t, dir, "symbolic-ref", "--short", "HEAD")
+	if err != nil {
+		t.Fatalf("Failed to read HEAD: %v", err)
+	}
+	if strings.TrimSpace(head) != "trunk" {
+		t.Errorf("Expected initial branch 'trunk', got: %s", strings.TrimSpace(head))
+	}
+	if v := getGitConfigWithScope(t, dir, "gitflow.branch.trunk.type", "local"); v != "base" {
+		t.Errorf("Expected gitflow.branch.trunk.type to be 'base', got: %s", v)
+	}
+}
+
+// TestInitWithoutInitFlagOutsideRepositoryFails tests that the default behavior
+// outside a git repository is unchanged: an error, and nothing created.
+// Steps:
+//  1. Creates a temporary directory that is not a git repository
+//  2. Seeds a global git config with an identity so the failure is unambiguously
+//     the missing repository (stdin is a pipe and GIT_FLOW_ASSUME_INTERACTIVE is unset)
+//  3. Runs 'git flow init --defaults' without --init
+//  4. Verifies the command fails with exit code 3
+//  5. Verifies the output still names 'git init' as the remedy
+//  6. Verifies no .git directory was created
+//  7. Verifies the directory is still completely empty
+func TestInitWithoutInitFlagOutsideRepositoryFails(t *testing.T) {
+	t.Parallel()
+	dir := setupNonRepoDir(t)
+	env, _ := identityConfigEnv(t, nil)
+
+	output, err := runGitFlowWithEnv(t, dir, env, "init", "--defaults")
+	if code := exitCodeOf(t, err); code != 3 {
+		t.Fatalf("Expected exit code 3, got %d\nOutput: %s", code, output)
+	}
+	if !strings.Contains(output, "not a git repository. Please run 'git init' first") {
+		t.Errorf("Expected output to contain the unchanged not-a-repository message, got: %s", output)
+	}
+	if hasGitDir(t, dir) {
+		t.Error("Expected no .git directory to be created")
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("Failed to read directory: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("Expected the directory to stay empty, got %d entries", len(entries))
+	}
+}
+
+// TestInitFlagIsNoOpInExistingRepository tests that --init is a no-op inside an
+// existing git repository: no new repository, no re-init, ordinary git-flow setup.
+// Steps:
+// 1. Creates a test repository with a commit and an identity
+// 2. Records its work-tree root and HEAD commit
+// 3. Runs 'git flow init --defaults --init' with LC_ALL=C pinned
+// 4. Verifies the command succeeds
+// 5. Verifies the work-tree root is unchanged (no nested repository)
+// 6. Verifies the commit reachable from main is unchanged
+// 7. Verifies git-flow really initialized (develop branch, gitflow.version)
+// 8. Verifies git never reported creating or reinitializing a repository
+func TestInitFlagIsNoOpInExistingRepository(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	topBefore, err := testutil.RunGit(t, dir, "rev-parse", "--show-toplevel")
+	if err != nil {
+		t.Fatalf("Failed to read work-tree root: %v", err)
+	}
+	headBefore, err := testutil.RunGit(t, dir, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("Failed to read HEAD: %v", err)
+	}
+
+	output, err := runGitFlowWithEnv(t, dir, []string{"LC_ALL=C"}, "init", "--defaults", "--init")
+	if err != nil {
+		t.Fatalf("Expected success, got error: %v\nOutput: %s", err, output)
+	}
+
+	topAfter, err := testutil.RunGit(t, dir, "rev-parse", "--show-toplevel")
+	if err != nil {
+		t.Fatalf("Failed to read work-tree root after init: %v", err)
+	}
+	if strings.TrimSpace(topAfter) != strings.TrimSpace(topBefore) {
+		t.Errorf("Expected work-tree root %q, got %q", strings.TrimSpace(topBefore), strings.TrimSpace(topAfter))
+	}
+	mainAfter, err := testutil.RunGit(t, dir, "rev-parse", "main")
+	if err != nil {
+		t.Fatalf("Failed to read main after init: %v", err)
+	}
+	if strings.TrimSpace(mainAfter) != strings.TrimSpace(headBefore) {
+		t.Errorf("Expected main to stay at %q, got %q", strings.TrimSpace(headBefore), strings.TrimSpace(mainAfter))
+	}
+	if !branchExists(t, dir, "develop") {
+		t.Error("Expected 'develop' branch to exist")
+	}
+	if v := getGitConfigWithScope(t, dir, "gitflow.version", "local"); v != "1.0" {
+		t.Errorf("Expected gitflow.version to be '1.0', got: %s", v)
+	}
+	if strings.Contains(output, "Initialized empty Git repository") {
+		t.Errorf("Expected no repository creation inside an existing repository, got: %s", output)
+	}
+	if strings.Contains(output, "Reinitialized existing Git repository") {
+		t.Errorf("Expected no 'git init' against the existing repository, got: %s", output)
+	}
+}
+
+// TestInitWithInitFlagFailsWithoutIdentity tests that --init on a directory with
+// no git identity anywhere fails fast with the identity error, leaving the
+// created .git in place but writing no configuration.
+// Steps:
+// 1. Creates a temporary directory that is not a git repository
+// 2. Isolates global and system config so no identity is visible
+// 3. Runs 'git flow init --defaults --init'
+// 4. Verifies the command fails with exit code 6 and the identity message
+// 5. Verifies the output does not leak an opaque 'exit status 128'
+// 6. Verifies the .git directory is still present (no rollback is required)
+// 7. Verifies config queries against the directory work (positive control)
+// 8. Verifies no gitflow configuration was written
+// 9. Verifies neither main nor develop was created
+func TestInitWithInitFlagFailsWithoutIdentity(t *testing.T) {
+	t.Parallel()
+	dir := setupNonRepoDir(t)
+	env := isolatedConfigEnv()
+
+	output, err := runGitFlowWithEnv(t, dir, env, "init", "--defaults", "--init")
+	if code := exitCodeOf(t, err); code != 6 {
+		t.Fatalf("Expected exit code 6, got %d\nOutput: %s", code, output)
+	}
+	if !strings.Contains(output, "git user identity is not configured") {
+		t.Errorf("Expected output to contain 'git user identity is not configured', got: %s", output)
+	}
+	if strings.Contains(output, "exit status 128") {
+		t.Errorf("Expected no opaque 'exit status 128' in output, got: %s", output)
+	}
+	if !hasGitDir(t, dir) {
+		t.Error("Expected the created .git directory to remain in place")
+	}
+	if _, err := testutil.RunGit(t, dir, "rev-parse", "--git-dir"); err != nil {
+		t.Fatalf("Positive control failed: config queries against %s do not work: %v", dir, err)
+	}
+	if v := getGitConfigWithScope(t, dir, "gitflow.version", "local"); v != "" {
+		t.Errorf("Expected no gitflow.version to be written, got: %s", v)
+	}
+	if keys := gitflowConfigKeysLocal(t, dir); keys != "" {
+		t.Errorf("Expected no local gitflow.* config, got: %s", keys)
+	}
+	if branchExists(t, dir, "main") {
+		t.Error("Expected no 'main' branch")
+	}
+	if branchExists(t, dir, "develop") {
+		t.Error("Expected no 'develop' branch")
+	}
+}
+
+// TestInitInteractiveDeclineDoesNotCreateRepository tests that answering 'n' to
+// the repository-creation prompt aborts without creating anything.
+// Steps:
+// 1. Creates a temporary directory that is not a git repository
+// 2. Seeds an identity and forces interactive stdin (GIT_FLOW_ASSUME_INTERACTIVE=1)
+// 3. Runs 'git flow init' answering 'n'
+// 4. Verifies the command fails with exit code 3
+// 5. Verifies the prompt text was shown
+// 6. Verifies the decline message names both 'git init' and '--init'
+// 7. Verifies no .git directory exists and the directory is still empty
+// 8. Verifies configuration prompting was never reached
+func TestInitInteractiveDeclineDoesNotCreateRepository(t *testing.T) {
+	t.Parallel()
+	dir := setupNonRepoDir(t)
+	baseEnv, _ := identityConfigEnv(t, nil)
+	env := append(baseEnv, "GIT_FLOW_ASSUME_INTERACTIVE=1")
+
+	output, err := runGitFlowWithInputAndEnv(t, dir, "n\n", env, "init")
+	if code := exitCodeOf(t, err); code != 3 {
+		t.Fatalf("Expected exit code 3, got %d\nOutput: %s", code, output)
+	}
+	if !strings.Contains(output, "Create one? [y/N]") {
+		t.Errorf("Expected the creation prompt in output, got: %s", output)
+	}
+	if !strings.Contains(output, "git init") {
+		t.Errorf("Expected the decline message to name 'git init', got: %s", output)
+	}
+	if !strings.Contains(output, "--init") {
+		t.Errorf("Expected the decline message to name '--init', got: %s", output)
+	}
+	if hasGitDir(t, dir) {
+		t.Error("Expected no .git directory after declining")
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("Failed to read directory: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("Expected the directory to stay empty, got %d entries", len(entries))
+	}
+	if strings.Contains(output, "Branch name for production releases") {
+		t.Errorf("Expected no configuration prompting after a decline, got: %s", output)
+	}
+}
+
+// TestInitInteractiveEmptyAnswerDoesNotCreateRepository tests that a bare Enter
+// at the repository-creation prompt takes the [y/N] default and declines.
+// Steps:
+// 1. Creates a temporary directory that is not a git repository
+// 2. Seeds an identity and forces interactive stdin (GIT_FLOW_ASSUME_INTERACTIVE=1)
+// 3. Runs 'git flow init' answering with an empty line
+// 4. Verifies the command fails with exit code 3
+// 5. Verifies the prompt text was shown
+// 6. Verifies the decline message names both 'git init' and '--init'
+// 7. Verifies no .git directory exists and the directory is still empty
+// 8. Verifies configuration prompting was never reached
+func TestInitInteractiveEmptyAnswerDoesNotCreateRepository(t *testing.T) {
+	t.Parallel()
+	dir := setupNonRepoDir(t)
+	baseEnv, _ := identityConfigEnv(t, nil)
+	env := append(baseEnv, "GIT_FLOW_ASSUME_INTERACTIVE=1")
+
+	output, err := runGitFlowWithInputAndEnv(t, dir, "\n", env, "init")
+	if code := exitCodeOf(t, err); code != 3 {
+		t.Fatalf("Expected exit code 3, got %d\nOutput: %s", code, output)
+	}
+	if !strings.Contains(output, "Create one? [y/N]") {
+		t.Errorf("Expected the creation prompt in output, got: %s", output)
+	}
+	if !strings.Contains(output, "git init") {
+		t.Errorf("Expected the decline message to name 'git init', got: %s", output)
+	}
+	if !strings.Contains(output, "--init") {
+		t.Errorf("Expected the decline message to name '--init', got: %s", output)
+	}
+	if hasGitDir(t, dir) {
+		t.Error("Expected no .git directory after declining")
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("Failed to read directory: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("Expected the directory to stay empty, got %d entries", len(entries))
+	}
+	if strings.Contains(output, "Branch name for production releases") {
+		t.Errorf("Expected no configuration prompting after a decline, got: %s", output)
+	}
+}
+
+// TestInitInteractiveAcceptCreatesRepository tests that answering 'y' to the
+// repository-creation prompt creates the repository and then runs the ordinary
+// interactive configuration, whose answers must not be swallowed by the prompt.
+// Steps:
+//  1. Creates a temporary directory that is not a git repository
+//  2. Seeds an identity and forces interactive stdin (GIT_FLOW_ASSUME_INTERACTIVE=1)
+//  3. Runs 'git flow init' answering 'y' followed by the legacy interactive
+//     configuration answers (custom-main, custom-dev, the four prefixes, tag prefix)
+//  4. Verifies the command succeeds
+//  5. Verifies both the creation prompt and the configuration prompts were shown
+//  6. Verifies a repository now exists at the directory
+//  7. Verifies the custom-main and custom-dev branches were created
+//  8. Verifies gitflow.version and gitflow.branch.custom-main.type were written,
+//     proving the answers after the prompt were read
+func TestInitInteractiveAcceptCreatesRepository(t *testing.T) {
+	t.Parallel()
+	dir := setupNonRepoDir(t)
+	baseEnv, _ := identityConfigEnv(t, nil)
+	env := append(baseEnv, "GIT_FLOW_ASSUME_INTERACTIVE=1")
+
+	// y to create the repo, then the legacy interactive-config answers:
+	// main, develop, feature, bugfix, release, hotfix, support, tag prefix.
+	input := "y\ncustom-main\ncustom-dev\nfeature/\nbugfix/\nrelease/\nhotfix/\nsupport/\n\n"
+	output, err := runGitFlowWithInputAndEnv(t, dir, input, env, "init")
+	if err != nil {
+		t.Fatalf("Expected success, got error: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "Create one? [y/N]") {
+		t.Errorf("Expected the creation prompt in output, got: %s", output)
+	}
+	if !strings.Contains(output, "Branch name for production releases") {
+		t.Errorf("Expected the interactive configuration prompts in output, got: %s", output)
+	}
+	if !hasGitDir(t, dir) {
+		t.Error("Expected a .git directory to be created")
+	}
+	insideWorkTree, err := testutil.RunGit(t, dir, "rev-parse", "--is-inside-work-tree")
+	if err != nil {
+		t.Fatalf("Expected the directory to be a work tree: %v", err)
+	}
+	if strings.TrimSpace(insideWorkTree) != "true" {
+		t.Errorf("Expected 'true' from rev-parse --is-inside-work-tree, got: %s", insideWorkTree)
+	}
+	if !branchExists(t, dir, "custom-main") {
+		t.Error("Expected 'custom-main' branch to exist")
+	}
+	if !branchExists(t, dir, "custom-dev") {
+		t.Error("Expected 'custom-dev' branch to exist")
+	}
+	if v := getGitConfigWithScope(t, dir, "gitflow.version", "local"); v != "1.0" {
+		t.Errorf("Expected gitflow.version to be '1.0', got: %s", v)
+	}
+	if v := getGitConfigWithScope(t, dir, "gitflow.branch.custom-main.type", "local"); v != "base" {
+		t.Errorf("Expected gitflow.branch.custom-main.type to be 'base', got: %s", v)
+	}
+}
+
+// TestInitWithInitFlagWritesLocalScopeConfig tests that --init writes the
+// git-flow configuration into the created repository's local scope by default.
+// Steps:
+//  1. Creates a temporary directory that is not a git repository
+//  2. Seeds a global git config with a user identity
+//  3. Runs 'git flow init --defaults --init' with no scope flag
+//  4. Verifies the command succeeds
+//  5. Verifies gitflow.version, gitflow.initialized and
+//     gitflow.branch.develop.parent are all present in local config
+func TestInitWithInitFlagWritesLocalScopeConfig(t *testing.T) {
+	t.Parallel()
+	dir := setupNonRepoDir(t)
+	env, _ := identityConfigEnv(t, nil)
+
+	output, err := runGitFlowWithEnv(t, dir, env, "init", "--defaults", "--init")
+	if err != nil {
+		t.Fatalf("Expected success, got error: %v\nOutput: %s", err, output)
+	}
+	if v := getGitConfigWithScope(t, dir, "gitflow.version", "local"); v != "1.0" {
+		t.Errorf("Expected gitflow.version to be '1.0', got: %s", v)
+	}
+	if v := getGitConfigWithScope(t, dir, "gitflow.initialized", "local"); v != "true" {
+		t.Errorf("Expected gitflow.initialized to be 'true', got: %s", v)
+	}
+	if v := getGitConfigWithScope(t, dir, "gitflow.branch.develop.parent", "local"); v != "main" {
+		t.Errorf("Expected gitflow.branch.develop.parent to be 'main', got: %s", v)
+	}
+}
+
+// TestInitFlagInSubdirectoryDoesNotCreateNestedRepository tests that --init in a
+// subdirectory of an existing repository configures the outer repository instead
+// of creating a nested one.
+// Steps:
+// 1. Creates a test repository and a 'nested' subdirectory inside it
+// 2. Runs 'git flow init --defaults --init' from the subdirectory
+// 3. Verifies the command succeeds
+// 4. Verifies no .git directory was created in the subdirectory
+// 5. Verifies the subdirectory still resolves to the outer work-tree root
+// 6. Verifies the outer repository was configured (gitflow.version)
+func TestInitFlagInSubdirectoryDoesNotCreateNestedRepository(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	sub := filepath.Join(dir, "nested")
+	if err := os.MkdirAll(sub, 0755); err != nil {
+		t.Fatalf("Failed to create nested directory: %v", err)
+	}
+
+	output, err := runGitFlow(t, sub, "init", "--defaults", "--init")
+	if err != nil {
+		t.Fatalf("Expected success, got error: %v\nOutput: %s", err, output)
+	}
+	if hasGitDir(t, sub) {
+		t.Error("Expected no nested .git directory in the subdirectory")
+	}
+	subTop, err := testutil.RunGit(t, sub, "rev-parse", "--show-toplevel")
+	if err != nil {
+		t.Fatalf("Failed to read work-tree root from the subdirectory: %v", err)
+	}
+	outerTop, err := testutil.RunGit(t, dir, "rev-parse", "--show-toplevel")
+	if err != nil {
+		t.Fatalf("Failed to read outer work-tree root: %v", err)
+	}
+	if strings.TrimSpace(subTop) != strings.TrimSpace(outerTop) {
+		t.Errorf("Expected work-tree root %q from the subdirectory, got %q", strings.TrimSpace(outerTop), strings.TrimSpace(subTop))
+	}
+	if v := getGitConfigWithScope(t, dir, "gitflow.version", "local"); v != "1.0" {
+		t.Errorf("Expected the outer repository to be configured, got gitflow.version: %s", v)
+	}
+}
+
+// TestInitWithInitFlagRejectsInvalidTrunkName tests that an invalid trunk name
+// is rejected before 'git init' runs, so no broken repository is left behind.
+// Steps:
+// 1. Creates a temporary directory that is not a git repository
+// 2. Seeds a global git config with a user identity
+// 3. Runs 'git flow init --init --main "bad name" --no-create-branches'
+// 4. Verifies the command fails with exit code 2 and names the invalid branch
+// 5. Verifies the output does not leak an opaque 'exit status 128'
+// 6. Verifies no .git directory exists and the directory is still empty
+func TestInitWithInitFlagRejectsInvalidTrunkName(t *testing.T) {
+	t.Parallel()
+	dir := setupNonRepoDir(t)
+	env, _ := identityConfigEnv(t, nil)
+
+	output, err := runGitFlowWithEnv(t, dir, env, "init", "--init", "--main", "bad name", "--no-create-branches")
+	if code := exitCodeOf(t, err); code != 2 {
+		t.Fatalf("Expected exit code 2, got %d\nOutput: %s", code, output)
+	}
+	if !strings.Contains(output, "invalid branch name: bad name") {
+		t.Errorf("Expected output to contain 'invalid branch name: bad name', got: %s", output)
+	}
+	if strings.Contains(output, "exit status 128") {
+		t.Errorf("Expected no opaque 'exit status 128' in output, got: %s", output)
+	}
+	if hasGitDir(t, dir) {
+		t.Error("Expected no .git directory after a rejected trunk name")
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("Failed to read directory: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("Expected the directory to stay empty, got %d entries", len(entries))
+	}
+}
+
+// TestInitWithInitFlagAndGlobalScopeCreatesRepository tests that repository
+// creation is gated only on --init, never on the configuration scope: --global
+// still creates the repository while writing the config globally.
+// Steps:
+// 1. Creates a temporary directory that is not a git repository
+// 2. Seeds a writable temporary global git config with a user identity
+// 3. Runs 'git flow init --defaults --init --global --no-create-branches'
+// 4. Verifies the command succeeds and a .git directory exists
+// 5. Verifies gitflow.version landed in the global config file
+// 6. Verifies config queries against the directory work (positive control)
+// 7. Verifies nothing was written to the repository's local scope
+func TestInitWithInitFlagAndGlobalScopeCreatesRepository(t *testing.T) {
+	t.Parallel()
+	dir := setupNonRepoDir(t)
+	env, globalConfigFile := identityConfigEnv(t, nil)
+
+	output, err := runGitFlowWithEnv(t, dir, env, "init", "--defaults", "--init", "--global", "--no-create-branches")
+	if err != nil {
+		t.Fatalf("Expected success, got error: %v\nOutput: %s", err, output)
+	}
+	if !hasGitDir(t, dir) {
+		t.Error("Expected a .git directory to be created")
+	}
+	if v := getGitConfigFromFile(t, globalConfigFile, "gitflow.version"); v != "1.0" {
+		t.Errorf("Expected gitflow.version '1.0' in the global config file, got: %s", v)
+	}
+	if _, err := testutil.RunGit(t, dir, "rev-parse", "--git-dir"); err != nil {
+		t.Fatalf("Positive control failed: config queries against %s do not work: %v", dir, err)
+	}
+	if v := getGitConfigWithScope(t, dir, "gitflow.version", "local"); v != "" {
+		t.Errorf("Expected no local gitflow.version with --global, got: %s", v)
+	}
+}
+
+// TestInitWithInitFlagAbortsWhenAlreadyInitializedGlobally tests that an
+// already-initialized global configuration aborts before the repository is
+// created, so no stray .git is left behind.
+// Steps:
+// 1. Creates a temporary directory that is not a git repository
+// 2. Seeds a global git config with an identity and gitflow.version=1.0
+// 3. Runs 'git flow init --defaults --init'
+// 4. Verifies the command fails with exit code 6
+// 5. Verifies the output reports the global configuration
+// 6. Verifies no .git directory was created and the directory is still empty
+func TestInitWithInitFlagAbortsWhenAlreadyInitializedGlobally(t *testing.T) {
+	t.Parallel()
+	dir := setupNonRepoDir(t)
+	env, _ := identityConfigEnv(t, map[string]string{"gitflow.version": "1.0"})
+
+	output, err := runGitFlowWithEnv(t, dir, env, "init", "--defaults", "--init")
+	if code := exitCodeOf(t, err); code != 6 {
+		t.Fatalf("Expected exit code 6, got %d\nOutput: %s", code, output)
+	}
+	if !strings.Contains(output, "Git-flow is configured via global config") {
+		t.Errorf("Expected output to report the global configuration, got: %s", output)
+	}
+	if hasGitDir(t, dir) {
+		t.Error("Expected no .git directory: the already-initialized check must run before creation")
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("Failed to read directory: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("Expected the directory to stay empty, got %d entries", len(entries))
+	}
+}
+
+// TestInitWithInitFlagAndSharedScopeWritesSharedConfig tests that --shared --init
+// authors the .gitflow file at the created repository's work-tree root and copies
+// it into local config, proving the re-resolved repository handle is correct.
+// Steps:
+// 1. Creates a temporary directory that is not a git repository
+// 2. Seeds a global git config with a user identity
+// 3. Runs 'git flow init --defaults --init --shared'
+// 4. Verifies the command succeeds and a .git directory exists
+// 5. Verifies a .gitflow file exists at the directory root with gitflow.version
+// 6. Verifies gitflow.version was also copied into local config
+// 7. Verifies the main and develop base branches were created
+func TestInitWithInitFlagAndSharedScopeWritesSharedConfig(t *testing.T) {
+	t.Parallel()
+	dir := setupNonRepoDir(t)
+	env, _ := identityConfigEnv(t, nil)
+
+	output, err := runGitFlowWithEnv(t, dir, env, "init", "--defaults", "--init", "--shared")
+	if err != nil {
+		t.Fatalf("Expected success, got error: %v\nOutput: %s", err, output)
+	}
+	if !hasGitDir(t, dir) {
+		t.Error("Expected a .git directory to be created")
+	}
+	sharedPath := filepath.Join(dir, ".gitflow")
+	if _, err := os.Stat(sharedPath); err != nil {
+		t.Fatalf("Expected a .gitflow file at %s: %v", sharedPath, err)
+	}
+	if v := getGitConfigFromFile(t, sharedPath, "gitflow.version"); v != "1.0" {
+		t.Errorf("Expected gitflow.version '1.0' in .gitflow, got: %s", v)
+	}
+	if v := getGitConfigWithScope(t, dir, "gitflow.version", "local"); v != "1.0" {
+		t.Errorf("Expected gitflow.version '1.0' copied into local config, got: %s", v)
+	}
+	if !branchExists(t, dir, "main") {
+		t.Error("Expected 'main' branch to exist")
+	}
+	if !branchExists(t, dir, "develop") {
+		t.Error("Expected 'develop' branch to exist")
+	}
+}

--- a/test/internal/config/config_test.go
+++ b/test/internal/config/config_test.go
@@ -636,3 +636,58 @@ func keysOf(m map[string]config.BranchConfig) []string {
 	}
 	return keys
 }
+
+// TestTrunkBranchReturnsUnparentedBaseBranch tests that TrunkBranch reports the
+// base branch with no parent for the shipped default configuration.
+// Steps:
+// 1. Builds config.DefaultConfig()
+// 2. Calls TrunkBranch()
+// 3. Verifies it returns "main"
+func TestTrunkBranchReturnsUnparentedBaseBranch(t *testing.T) {
+	t.Parallel()
+	if got := config.DefaultConfig().TrunkBranch(); got != "main" {
+		t.Errorf("Expected trunk 'main', got %q", got)
+	}
+}
+
+// TestTrunkBranchTieBreakIsLexicographic tests that TrunkBranch is deterministic
+// when several base branches have no parent, despite Go's randomized map
+// iteration order.
+// Steps:
+// 1. Builds a Config with two unparented base branches, "zulu" and "alpha"
+// 2. Calls TrunkBranch() at least 20 times
+// 3. Verifies every call returns "alpha", the lexicographically smallest name
+func TestTrunkBranchTieBreakIsLexicographic(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{
+		Version: "1.0",
+		Branches: map[string]config.BranchConfig{
+			"zulu":  {Type: string(config.BranchTypeBase)},
+			"alpha": {Type: string(config.BranchTypeBase)},
+		},
+	}
+	for i := 0; i < 20; i++ {
+		if got := cfg.TrunkBranch(); got != "alpha" {
+			t.Fatalf("Iteration %d: expected trunk 'alpha', got %q", i, got)
+		}
+	}
+}
+
+// TestTrunkBranchWithoutTrunkReturnsEmpty tests that TrunkBranch returns an
+// empty string for a configuration whose base branches all have a parent.
+// Steps:
+// 1. Builds a Config whose only base branch has a non-empty Parent
+// 2. Calls TrunkBranch()
+// 3. Verifies it returns ""
+func TestTrunkBranchWithoutTrunkReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{
+		Version: "1.0",
+		Branches: map[string]config.BranchConfig{
+			"develop": {Type: string(config.BranchTypeBase), Parent: "main"},
+		},
+	}
+	if got := cfg.TrunkBranch(); got != "" {
+		t.Errorf("Expected empty trunk, got %q", got)
+	}
+}


### PR DESCRIPTION
Adds an opt-in `--init` flag and an interactive `[y/N]` prompt so `git flow init` can create the git repository when the current directory is not one, instead of always erroring out.

The non-repository gate in `cmd/init.go` becomes a creation decision: `--init` creates without asking, interactive stdin asks first, and everything else keeps today's error and exit code. Creation runs after configuration resolution rather than at the gate, because the created repository's initial branch must be the resolved git-flow trunk (`git init --initial-branch=<trunk>`) rather than an ambient `init.defaultBranch`; both paths then converge on the unchanged identity check, config save and branch creation, so the identity fast-fail and scope handling apply to a freshly created repository for free. Supporting pieces are `git.Init(dir, initialBranch)` in `internal/git/repo.go`, `(*Config).TrunkBranch()` in `internal/config/config.go`, `reopenRepo()` in `cmd/repo.go` (needed because `openRepo` memoizes the pre-creation "not a git repository" failure for the lifetime of the process), and the rename of `firstRunInteractive` to `stdinIsInteractive`. Coverage is 18 integration scenarios plus 3 unit tests: the flag, the prompt, both decline paths, the unchanged default outside a repository, the no-op inside one, the identity fast-fail, local/global/shared scope, nested subdirectories, and an invalid trunk name.

Closes #125

### Remarks

Three deliberate deviations from the literal transcripts in the spec:

- The "not a git repository" error keeps its existing exit code 3, not the 1 shown in the spec's transcript. The spec's normative text calls that path unchanged, and its Out of Scope section forbids changing existing behavior beyond gating creation. The interactive-decline path uses the same code, so every "no repository to work in" outcome reports one code.
- `Initialized empty Git repository in ...` prints after the "Initializing git-flow..." line, because the trunk has to be resolved before `git init --initial-branch` can run. Only the ordering of those two output lines differs from the transcript.
- AVH config import detection is skipped on the repository-creation path. It needs a repository handle that cannot exist yet, and a brand-new repository could only ever carry AVH keys from global or system config, which is not a repository being migrated.

Two review findings were fixed on the branch. `--shared --init` now honors the same pre-existing `.gitflow` guard as the in-repo path — `git config --file` merges into an existing file rather than truncating it, so stale keys previously blended into the new configuration and neither the refusal nor the `--force` requirement applied. And the declined-prompt message no longer reads as an internal probe failure ("failed to check if git repository: ...") when nothing failed and the user simply said no.

The docs commit also corrects a pre-existing error in the init manpage's EXIT STATUS table, which listed the wrong codes for "not a git repository", "already initialized" and "invalid options". That correction is documentation-only and unrelated to this change.

**Review focus:**
- `cmd/init.go:134-154` - the creation decision at the non-repository gate
- `cmd/init.go:307-339` - creation after configuration resolution, with trunk validation ahead of `git init`
- `cmd/repo.go:46-56` - `reopenRepo` and the memo priming
- `internal/config/shared.go` - `SharedConfigExistsIn` and the repo-less `--shared` probe