### PR TITLE
fix(config): Preserve omitted boolean flags on config edit

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -281,7 +281,8 @@ func ConfigAddTopicCommand(name, parent, prefix, startingPoint, upstreamStrategy
 	}
 }
 
-// ConfigEditBaseCommand edits a base branch configuration
+// ConfigEditBaseCommand edits a base branch configuration. A nil autoUpdate
+// means the flag was not provided, so the stored value is preserved.
 func ConfigEditBaseCommand(name, upstreamStrategy, downstreamStrategy string, autoUpdate *bool, shared bool) {
 	repo := mustOpenRepo()
 	if err := executeConfigEditBase(repo, name, upstreamStrategy, downstreamStrategy, autoUpdate, shared); err != nil {
@@ -296,7 +297,8 @@ func ConfigEditBaseCommand(name, upstreamStrategy, downstreamStrategy string, au
 	}
 }
 
-// ConfigEditTopicCommand edits a topic branch type configuration
+// ConfigEditTopicCommand edits a topic branch type configuration. A nil tag
+// means the flag was not provided, so the stored value is preserved.
 func ConfigEditTopicCommand(name, prefix, startingPoint, upstreamStrategy, downstreamStrategy string, tag *bool, shared bool) {
 	repo := mustOpenRepo()
 	if err := executeConfigEditTopic(repo, name, prefix, startingPoint, upstreamStrategy, downstreamStrategy, tag, shared); err != nil {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -115,7 +115,7 @@ Examples:
 
 		upstreamStrategy, _ := cmd.Flags().GetString("upstream-strategy")
 		downstreamStrategy, _ := cmd.Flags().GetString("downstream-strategy")
-		autoUpdate, _ := cmd.Flags().GetBool("auto-update")
+		autoUpdate := changedBoolPtr(cmd, "auto-update")
 
 		shared, _ := cmd.Flags().GetBool("shared")
 		ConfigEditBaseCommand(name, upstreamStrategy, downstreamStrategy, autoUpdate, shared)
@@ -138,7 +138,7 @@ Examples:
 		startingPoint, _ := cmd.Flags().GetString("starting-point")
 		upstreamStrategy, _ := cmd.Flags().GetString("upstream-strategy")
 		downstreamStrategy, _ := cmd.Flags().GetString("downstream-strategy")
-		tag, _ := cmd.Flags().GetBool("tag")
+		tag := changedBoolPtr(cmd, "tag")
 
 		shared, _ := cmd.Flags().GetBool("shared")
 		ConfigEditTopicCommand(name, prefix, startingPoint, upstreamStrategy, downstreamStrategy, tag, shared)
@@ -282,7 +282,7 @@ func ConfigAddTopicCommand(name, parent, prefix, startingPoint, upstreamStrategy
 }
 
 // ConfigEditBaseCommand edits a base branch configuration
-func ConfigEditBaseCommand(name, upstreamStrategy, downstreamStrategy string, autoUpdate bool, shared bool) {
+func ConfigEditBaseCommand(name, upstreamStrategy, downstreamStrategy string, autoUpdate *bool, shared bool) {
 	repo := mustOpenRepo()
 	if err := executeConfigEditBase(repo, name, upstreamStrategy, downstreamStrategy, autoUpdate, shared); err != nil {
 		var exitCode errors.ExitCode
@@ -297,7 +297,7 @@ func ConfigEditBaseCommand(name, upstreamStrategy, downstreamStrategy string, au
 }
 
 // ConfigEditTopicCommand edits a topic branch type configuration
-func ConfigEditTopicCommand(name, prefix, startingPoint, upstreamStrategy, downstreamStrategy string, tag bool, shared bool) {
+func ConfigEditTopicCommand(name, prefix, startingPoint, upstreamStrategy, downstreamStrategy string, tag *bool, shared bool) {
 	repo := mustOpenRepo()
 	if err := executeConfigEditTopic(repo, name, prefix, startingPoint, upstreamStrategy, downstreamStrategy, tag, shared); err != nil {
 		var exitCode errors.ExitCode
@@ -384,6 +384,18 @@ func ConfigListCommand() {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(int(exitCode))
 	}
+}
+
+// changedBoolPtr returns the flag's value when it was supplied on the command
+// line, or nil when it was omitted so the caller preserves the stored value.
+// Cobra reports false for an untouched Bool flag, which is why the edit path
+// cannot distinguish "omitted" from "--flag=false" without Changed().
+func changedBoolPtr(cmd *cobra.Command, name string) *bool {
+	if !cmd.Flags().Changed(name) {
+		return nil
+	}
+	v, _ := cmd.Flags().GetBool(name)
+	return &v
 }
 
 // loadConfigForEdit loads the configuration a CRUD verb should edit: the .gitflow
@@ -619,7 +631,7 @@ func executeConfigAddTopic(repo *git.Repo, name, parent, prefix, startingPoint, 
 	return nil
 }
 
-func executeConfigEditBase(repo *git.Repo, name, upstreamStrategy, downstreamStrategy string, autoUpdate bool, shared bool) error {
+func executeConfigEditBase(repo *git.Repo, name, upstreamStrategy, downstreamStrategy string, autoUpdate *bool, shared bool) error {
 	// Validate that git-flow is initialized. Only gate LOCAL edits: for --shared
 	// the target is the .gitflow file (whose existence loadConfigForEdit enforces
 	// with the correct "run 'git flow init --shared'" suggestion), so a fresh
@@ -668,8 +680,11 @@ func executeConfigEditBase(repo *git.Repo, name, upstreamStrategy, downstreamStr
 		branchConfig.DownstreamStrategy = downstreamStrategy
 	}
 
-	// Update auto-update setting
-	branchConfig.AutoUpdate = autoUpdate
+	// Update auto-update setting only when the flag was supplied; an omitted
+	// flag preserves the stored value.
+	if autoUpdate != nil {
+		branchConfig.AutoUpdate = *autoUpdate
+	}
 
 	// Update configuration
 	cfg.Branches[name] = branchConfig
@@ -683,7 +698,7 @@ func executeConfigEditBase(repo *git.Repo, name, upstreamStrategy, downstreamStr
 	return nil
 }
 
-func executeConfigEditTopic(repo *git.Repo, name, prefix, startingPoint, upstreamStrategy, downstreamStrategy string, tag bool, shared bool) error {
+func executeConfigEditTopic(repo *git.Repo, name, prefix, startingPoint, upstreamStrategy, downstreamStrategy string, tag *bool, shared bool) error {
 	// Validate that git-flow is initialized. Only gate LOCAL edits: for --shared
 	// the target is the .gitflow file (whose existence loadConfigForEdit enforces
 	// with the correct "run 'git flow init --shared'" suggestion), so a fresh
@@ -744,7 +759,11 @@ func executeConfigEditTopic(repo *git.Repo, name, prefix, startingPoint, upstrea
 		branchConfig.DownstreamStrategy = downstreamStrategy
 	}
 
-	branchConfig.Tag = tag
+	// Update tag setting only when the flag was supplied; an omitted flag
+	// preserves the stored value.
+	if tag != nil {
+		branchConfig.Tag = *tag
+	}
 
 	// Update configuration
 	cfg.Branches[name] = branchConfig

--- a/docs/git-flow-config.1.md
+++ b/docs/git-flow-config.1.md
@@ -105,10 +105,14 @@ Branch names are matched **case-insensitively**. The case used when a branch is 
 Same options as `add base`:
 - **--upstream-strategy**, **--downstream-strategy**, **--auto-update**
 
+The **--auto-update** default listed under `add base` does **not** apply here. On `edit`, an omitted **--auto-update** preserves the value already stored; only a supplied flag changes it, in either direction — **--auto-update=false** turns it off, **--auto-update** or **--auto-update=true** turns it on. On `add` an omitted boolean means **false**, because there the flag default is the intended value for a branch being created.
+
 ### Edit Topic Branch (`edit topic`)
 
 Same options as `add topic`:
 - **--prefix**, **--starting-point**, **--upstream-strategy**, **--downstream-strategy**, **--tag**
+
+The **--tag** default listed under `add topic` does **not** apply here. On `edit`, an omitted **--tag** preserves the value already stored; only a supplied flag changes it, in either direction — **--tag=false** clears it, **--tag** or **--tag=true** sets it. On `add` an omitted boolean means **false**, because there the flag default is the intended value for a branch type being created.
 
 ### Rename and Delete Commands
 

--- a/docs/gitflow-config.5.md
+++ b/docs/gitflow-config.5.md
@@ -190,6 +190,8 @@ Define how the branch type participates in the workflow:
 : Prefix for created tags (topic branches only).
 : *Default*: "" (no prefix)
 
+git-flow always writes **autoUpdate** and **tag** explicitly as **true** or **false**, so a configuration it wrote carries a line for both keys on every branch. This is informational only — an absent key still reads as **false**.
+
 ## COMMAND OVERRIDES
 
 Command overrides (Layer 2) control **how commands execute** for a branch type, using the pattern: **gitflow.*branchtype*.*command*.*option***

--- a/docs/gitflow-config.5.md
+++ b/docs/gitflow-config.5.md
@@ -183,14 +183,14 @@ Define how the branch type participates in the workflow:
 : *Default*: false
 
 **tag**
-: Branch type produces tags on finish (topic branches only). Setting this to **true** means the branch type's process includes tagging — e.g., releases and hotfixes produce tags as part of their workflow.
+: Branch type produces tags on finish. Setting this to **true** means the branch type's process includes tagging — e.g., releases and hotfixes produce tags as part of their workflow. Only topic branches finish into a parent, so the key has an effect there; git-flow writes it for base branches as well, where it stays **false**.
 : *Default*: false
 
 **tagprefix**
 : Prefix for created tags (topic branches only).
 : *Default*: "" (no prefix)
 
-git-flow always writes **autoUpdate** and **tag** explicitly as **true** or **false**, so a configuration it wrote carries a line for both keys on every branch. This is informational only — an absent key still reads as **false**.
+git-flow always writes **autoUpdate** and **tag** explicitly as **true** or **false**, so a configuration it wrote carries a line for both keys on every branch. An absent key still reads as **false**; the difference is that an explicit local **false** shadows a **true** inherited from an outer config scope, whereas an absent key does not. This applies to any configuration git-flow writes, including **git flow init**.
 
 ## COMMAND OVERRIDES
 
@@ -816,6 +816,8 @@ Create and manage **.gitflow** with:
 - **git flow config sync** — re-copy **.gitflow** into local config (overwrite + stale-key removal).
 - **git flow config status** — report drift between local config and **.gitflow** (exit **6** on drift).
 - **git flow config** *add|edit|rename|delete* **... --shared** — edit **.gitflow** and re-sync local.
+
+**Upgrading from an older version**: git-flow now writes **tag** on every branch, so a **.gitflow** authored before that change is missing those lines. Once a local write adds them, **git flow config status** reports drift on the **gitflow.branch.*.tag** keys and exits **6**. This resolves itself on the next **git flow config sync**, or on any **--shared** edit or **git flow init --shared**, which rewrites **.gitflow** with the explicit lines.
 
 ### Shared-managed key set
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -708,12 +708,13 @@ func SaveConfigWithScope(config *Config, scope git.ConfigScope, filePath string)
 			return fmt.Errorf("failed to set auto update for %s: %w", branchName, err)
 		}
 
-		// Set tag configuration only if true (false is default)
-		if branchConfig.Tag {
-			err = git.SetConfigWithScope(fmt.Sprintf("gitflow.branch.%s.tag", branchName), "true", scope, filePath)
-			if err != nil {
-				return fmt.Errorf("failed to set tag configuration for %s: %w", branchName, err)
-			}
+		// Set tag configuration. Written explicitly as true/false rather than
+		// omitted when false: an explicit local false must shadow a true inherited
+		// from an outer git config scope, and the writer stays a faithful
+		// serializer of the in-memory configuration with no special case.
+		err = git.SetConfigWithScope(fmt.Sprintf("gitflow.branch.%s.tag", branchName), strconv.FormatBool(branchConfig.Tag), scope, filePath)
+		if err != nil {
+			return fmt.Errorf("failed to set tag configuration for %s: %w", branchName, err)
 		}
 
 		// Set tag prefix if it exists

--- a/test/cmd/config_shared_crud_test.go
+++ b/test/cmd/config_shared_crud_test.go
@@ -307,6 +307,99 @@ func TestConfigEditBaseSharedUpdatesFileAndLocal(t *testing.T) {
 	}
 }
 
+// TestConfigEditTopicSharedTagFalsePersists covers scenario 8: an explicit
+// --tag=false with --shared must clear the stored true in .gitflow and land in
+// local through the shared→local re-sync.
+// Steps:
+// 1. init --shared --defaults (.gitflow has release.tag=true)
+// 2. Runs 'config edit topic release --tag=false --shared'
+// 3. Verifies release.tag is "false" in both .gitflow and local
+func TestConfigEditTopicSharedTagFalsePersists(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "edit", "topic", "release", "--tag=false", "--shared")
+	if err != nil {
+		t.Fatalf("config edit topic --tag=false --shared failed: %v\n%s", err, out)
+	}
+
+	if v := testutil.SharedConfigValue(t, dir, "gitflow.branch.release.tag"); v != "false" {
+		t.Errorf("expected .gitflow release.tag=false, got %q\n%s", v, out)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.release.tag"); v != "false" {
+		t.Errorf("expected local release.tag=false after re-sync, got %q\n%s", v, out)
+	}
+}
+
+// TestConfigEditTopicSharedPreservesTagWhenFlagOmitted covers scenario 9: an
+// omitted --tag with --shared must preserve the stored value in both stores.
+// Steps:
+// 1. init --shared --defaults (.gitflow has release.tag=true)
+// 2. Runs 'config edit topic release --prefix=rel/ --shared' without --tag
+// 3. Verifies release.prefix is "rel/" and release.tag is still "true" in both stores
+func TestConfigEditTopicSharedPreservesTagWhenFlagOmitted(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "edit", "topic", "release", "--prefix=rel/", "--shared")
+	if err != nil {
+		t.Fatalf("config edit topic --prefix=rel/ --shared failed: %v\n%s", err, out)
+	}
+
+	if v := testutil.SharedConfigValue(t, dir, "gitflow.branch.release.prefix"); v != "rel/" {
+		t.Errorf("expected .gitflow release.prefix=rel/, got %q\n%s", v, out)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.release.prefix"); v != "rel/" {
+		t.Errorf("expected local release.prefix=rel/, got %q\n%s", v, out)
+	}
+	if v := testutil.SharedConfigValue(t, dir, "gitflow.branch.release.tag"); v != "true" {
+		t.Errorf("expected omitted --tag to preserve .gitflow release.tag=true, got %q\n%s", v, out)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.release.tag"); v != "true" {
+		t.Errorf("expected omitted --tag to preserve local release.tag=true, got %q\n%s", v, out)
+	}
+}
+
+// TestConfigEditBaseSharedPreservesAutoUpdateWhenFlagOmitted covers scenario 10:
+// an omitted --auto-update with --shared must preserve the stored value in both
+// stores, and non-tagging types gain an explicit tag=false in both.
+// Steps:
+// 1. init --shared --defaults (develop.autoUpdate=true)
+// 2. Runs 'config edit base develop --upstream-strategy=merge --shared' without --auto-update
+// 3. Verifies develop.upstreamStrategy is "merge" and develop.autoUpdate is still "true" in both stores
+// 4. Verifies feature.tag is the explicit "false" in both stores
+func TestConfigEditBaseSharedPreservesAutoUpdateWhenFlagOmitted(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "edit", "base", "develop", "--upstream-strategy=merge", "--shared")
+	if err != nil {
+		t.Fatalf("config edit base --upstream-strategy=merge --shared failed: %v\n%s", err, out)
+	}
+
+	if v := testutil.SharedConfigValue(t, dir, "gitflow.branch.develop.upstreamStrategy"); v != "merge" {
+		t.Errorf("expected .gitflow develop.upstreamStrategy=merge, got %q\n%s", v, out)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.develop.upstreamStrategy"); v != "merge" {
+		t.Errorf("expected local develop.upstreamStrategy=merge, got %q\n%s", v, out)
+	}
+	if v := testutil.SharedConfigValue(t, dir, "gitflow.branch.develop.autoUpdate"); v != "true" {
+		t.Errorf("expected omitted --auto-update to preserve .gitflow develop.autoUpdate=true, got %q\n%s", v, out)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.develop.autoUpdate"); v != "true" {
+		t.Errorf("expected omitted --auto-update to preserve local develop.autoUpdate=true, got %q\n%s", v, out)
+	}
+	if v := testutil.SharedConfigValue(t, dir, "gitflow.branch.feature.tag"); v != "false" {
+		t.Errorf("expected .gitflow feature.tag=false written explicitly, got %q\n%s", v, out)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.feature.tag"); v != "false" {
+		t.Errorf("expected local feature.tag=false written explicitly, got %q\n%s", v, out)
+	}
+}
+
 // TestConfigRenameBaseSharedFileOnly covers scenario 30base-c: config rename base
 // --shared renames the section in .gitflow and re-syncs local.
 // Steps:

--- a/test/cmd/config_test.go
+++ b/test/cmd/config_test.go
@@ -1,6 +1,8 @@
 package cmd_test
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -1442,6 +1444,303 @@ func TestConfigAddBaseUsesExistingRef(t *testing.T) {
 
 	cfg := gitflowBranchConfig(t, tempDir)
 	assertContainsLine(t, cfg, "gitflow.branch.qa.type base", "existing ref add")
+}
+
+// TestConfigEditTopicTagFalsePersists covers scenario 1: an explicit --tag=false
+// on 'config edit topic' must be persisted, clearing a stored true.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults (release.tag=true)
+// 2. Runs 'config edit topic release --tag=false'
+// 3. Verifies local gitflow.branch.release.tag is "false"
+func TestConfigEditTopicTagFalsePersists(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "edit", "topic", "release", "--tag=false")
+	if err != nil {
+		t.Fatalf("config edit topic --tag=false failed: %v\nOutput: %s", err, out)
+	}
+
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.release.tag"); v != "false" {
+		t.Errorf("Expected local release.tag=false, got %q\nOutput: %s", v, out)
+	}
+}
+
+// TestConfigEditTopicTagTruePersists covers scenario 2: an explicit --tag=true on
+// 'config edit topic' must be persisted, setting a stored false.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults (feature does not tag)
+// 2. Runs 'config edit topic feature --tag=true'
+// 3. Verifies local gitflow.branch.feature.tag is "true"
+func TestConfigEditTopicTagTruePersists(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "edit", "topic", "feature", "--tag=true")
+	if err != nil {
+		t.Fatalf("config edit topic --tag=true failed: %v\nOutput: %s", err, out)
+	}
+
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.feature.tag"); v != "true" {
+		t.Errorf("Expected local feature.tag=true, got %q\nOutput: %s", v, out)
+	}
+}
+
+// TestConfigEditTopicPreservesTagWhenFlagOmitted covers scenario 3: an omitted
+// --tag on 'config edit topic' must preserve the stored value.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults (release.tag=true)
+// 2. Runs 'config edit topic release --prefix=rel/' without --tag
+// 3. Verifies local release.prefix is "rel/" and release.tag is still "true"
+func TestConfigEditTopicPreservesTagWhenFlagOmitted(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "edit", "topic", "release", "--prefix=rel/")
+	if err != nil {
+		t.Fatalf("config edit topic --prefix=rel/ failed: %v\nOutput: %s", err, out)
+	}
+
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.release.prefix"); v != "rel/" {
+		t.Errorf("Expected local release.prefix=rel/, got %q\nOutput: %s", v, out)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.release.tag"); v != "true" {
+		t.Errorf("Expected omitted --tag to preserve release.tag=true, got %q\nOutput: %s", v, out)
+	}
+}
+
+// TestConfigEditBasePreservesAutoUpdateWhenFlagOmitted covers scenario 4: an
+// omitted --auto-update on 'config edit base' must preserve the stored value.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults (develop.autoUpdate=true)
+// 2. Runs 'config edit base develop --upstream-strategy=merge' without --auto-update
+// 3. Verifies local develop.upstreamStrategy is "merge" and develop.autoUpdate is still "true"
+func TestConfigEditBasePreservesAutoUpdateWhenFlagOmitted(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "edit", "base", "develop", "--upstream-strategy=merge")
+	if err != nil {
+		t.Fatalf("config edit base --upstream-strategy=merge failed: %v\nOutput: %s", err, out)
+	}
+
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.develop.upstreamStrategy"); v != "merge" {
+		t.Errorf("Expected local develop.upstreamStrategy=merge, got %q\nOutput: %s", v, out)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.develop.autoUpdate"); v != "true" {
+		t.Errorf("Expected omitted --auto-update to preserve develop.autoUpdate=true, got %q\nOutput: %s", v, out)
+	}
+}
+
+// TestConfigEditBaseAutoUpdateFalsePersists covers scenario 5: an explicit
+// --auto-update=false on 'config edit base' must still win over the stored true.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults (develop.autoUpdate=true)
+// 2. Runs 'config edit base develop --auto-update=false'
+// 3. Verifies local develop.autoUpdate is "false"
+func TestConfigEditBaseAutoUpdateFalsePersists(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "edit", "base", "develop", "--auto-update=false")
+	if err != nil {
+		t.Fatalf("config edit base --auto-update=false failed: %v\nOutput: %s", err, out)
+	}
+
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.develop.autoUpdate"); v != "false" {
+		t.Errorf("Expected local develop.autoUpdate=false, got %q\nOutput: %s", v, out)
+	}
+}
+
+// TestConfigEditBaseAutoUpdateTrueOverridesAddedFalse covers scenario 6: an edit
+// can flip a boolean added as false back to true.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Runs 'config add base staging main --auto-update=false'
+// 3. Runs 'config edit base staging --auto-update=true'
+// 4. Verifies local staging.autoUpdate is "true"
+func TestConfigEditBaseAutoUpdateTrueOverridesAddedFalse(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+	if out, err := testutil.RunGitFlow(t, dir, "config", "add", "base", "staging", "main", "--auto-update=false"); err != nil {
+		t.Fatalf("config add base staging failed: %v\nOutput: %s", err, out)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "edit", "base", "staging", "--auto-update=true")
+	if err != nil {
+		t.Fatalf("config edit base --auto-update=true failed: %v\nOutput: %s", err, out)
+	}
+
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.staging.autoUpdate"); v != "true" {
+		t.Errorf("Expected local staging.autoUpdate=true, got %q\nOutput: %s", v, out)
+	}
+}
+
+// TestConfigEditTopicTagFalseShadowsGlobalTrue covers scenario 7: an explicit
+// local false must shadow a true inherited from the global config scope.
+// Steps:
+// 1. Isolates the global and system git config through the subprocess env
+// 2. Sets up a test repository and initializes git-flow with defaults
+// 3. Unsets the local release.tag key and sets gitflow.branch.release.tag=true globally
+// 4. Runs 'config edit topic release --tag=false'
+// 5. Verifies the local read is "false" and the merged read is "false" too
+func TestConfigEditTopicTagFalseShadowsGlobalTrue(t *testing.T) {
+	t.Parallel()
+	// Isolate global AND system config through the subprocess env so no ambient
+	// gitflow.* key can leak in, and nothing touches the developer's real config.
+	env := []string{
+		"GIT_CONFIG_GLOBAL=" + filepath.Join(t.TempDir(), "global-gitconfig"),
+		"GIT_CONFIG_SYSTEM=" + os.DevNull,
+	}
+
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := runGitFlowWithEnv(t, dir, env, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+	if out, err := testutil.RunGitWithEnv(t, dir, env, "config", "--local", "--unset", "gitflow.branch.release.tag"); err != nil {
+		t.Fatalf("Failed to unset local release.tag: %v\nOutput: %s", err, out)
+	}
+	if out, err := testutil.RunGitWithEnv(t, dir, env, "config", "--global", "gitflow.branch.release.tag", "true"); err != nil {
+		t.Fatalf("Failed to set global release.tag: %v\nOutput: %s", err, out)
+	}
+
+	out, err := runGitFlowWithEnv(t, dir, env, "config", "edit", "topic", "release", "--tag=false")
+	if err != nil {
+		t.Fatalf("config edit topic --tag=false failed: %v\nOutput: %s", err, out)
+	}
+
+	local, err := testutil.RunGitWithEnv(t, dir, env, "config", "--local", "--get", "gitflow.branch.release.tag")
+	if err != nil {
+		t.Fatalf("Failed to read local release.tag: %v\nOutput: %s", err, local)
+	}
+	if v := strings.TrimSpace(local); v != "false" {
+		t.Errorf("Expected local release.tag=false, got %q\nOutput: %s", v, out)
+	}
+
+	merged, err := testutil.RunGitWithEnv(t, dir, env, "config", "--get", "gitflow.branch.release.tag")
+	if err != nil {
+		t.Fatalf("Failed to read merged release.tag: %v\nOutput: %s", err, merged)
+	}
+	if v := strings.TrimSpace(merged); v != "false" {
+		t.Errorf("Expected the local false to shadow the global true, got merged %q\nOutput: %s", v, out)
+	}
+}
+
+// TestConfigAddTopicWritesExplicitTagFalse covers scenario 12: 'config add' still
+// treats an omitted boolean as false, and now writes that false explicitly.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Runs 'config add topic docs develop' without --tag
+// 3. Verifies local gitflow.branch.docs.tag is the explicit string "false"
+func TestConfigAddTopicWritesExplicitTagFalse(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "add", "topic", "docs", "develop")
+	if err != nil {
+		t.Fatalf("config add topic docs failed: %v\nOutput: %s", err, out)
+	}
+
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.docs.tag"); v != "false" {
+		t.Errorf("Expected local docs.tag=false written explicitly, got %q\nOutput: %s", v, out)
+	}
+}
+
+// TestConfigEditTopicBareTagFlagSetsTrue covers scenario 13: the bare --tag form
+// (no =value) counts as a supplied true.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults (feature does not tag)
+// 2. Runs 'config edit topic feature --tag'
+// 3. Verifies local gitflow.branch.feature.tag is "true"
+func TestConfigEditTopicBareTagFlagSetsTrue(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "edit", "topic", "feature", "--tag")
+	if err != nil {
+		t.Fatalf("config edit topic --tag failed: %v\nOutput: %s", err, out)
+	}
+
+	if v := testutil.GitConfigValue(t, dir, "gitflow.branch.feature.tag"); v != "true" {
+		t.Errorf("Expected bare --tag to set feature.tag=true, got %q\nOutput: %s", v, out)
+	}
+}
+
+// TestConfigEditTopicPreservesOtherBranchTypeTags covers scenario 14: an edit
+// targeting one branch type must leave every other branch type's tag intact.
+// The writer rewrites all branches on every save, so the blast radius reaches
+// well beyond the edited branch.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Runs 'config edit topic feature --prefix=feat/'
+// 3. Verifies local release.tag and hotfix.tag are "true"
+// 4. Verifies local feature.tag, main.tag and develop.tag are "false"
+func TestConfigEditTopicPreservesOtherBranchTypeTags(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+
+	out, err := testutil.RunGitFlow(t, dir, "config", "edit", "topic", "feature", "--prefix=feat/")
+	if err != nil {
+		t.Fatalf("config edit topic --prefix=feat/ failed: %v\nOutput: %s", err, out)
+	}
+
+	for _, branch := range []string{"release", "hotfix"} {
+		if v := testutil.GitConfigValue(t, dir, "gitflow.branch."+branch+".tag"); v != "true" {
+			t.Errorf("Expected local %s.tag=true after an unrelated edit, got %q\nOutput: %s", branch, v, out)
+		}
+	}
+	for _, branch := range []string{"feature", "main", "develop"} {
+		if v := testutil.GitConfigValue(t, dir, "gitflow.branch."+branch+".tag"); v != "false" {
+			t.Errorf("Expected local %s.tag=false after an unrelated edit, got %q\nOutput: %s", branch, v, out)
+		}
+	}
 }
 
 // mustOpenRepo opens a git.Repo handle for dir, failing the test on error.

--- a/test/cmd/finish_tags_test.go
+++ b/test/cmd/finish_tags_test.go
@@ -269,6 +269,57 @@ func TestFinishReleaseWithNoTag(t *testing.T) {
 	}
 }
 
+// TestFinishReleaseNoTagAfterConfigEditTagFalse covers scenario 11: clearing the
+// tag setting via 'config edit topic release --tag=false' must take effect at
+// finish, not just in the stored configuration.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Runs 'config edit topic release --tag=false'
+// 3. Creates a release branch and commits a file on it
+// 4. Runs 'release finish 1.0.0'
+// 5. Verifies the repository has no tags at all
+func TestFinishReleaseNoTagAfterConfigEditTagFalse(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	output, err := testutil.RunGitFlow(t, dir, "init", "--defaults")
+	if err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+
+	output, err = testutil.RunGitFlow(t, dir, "config", "edit", "topic", "release", "--tag=false")
+	if err != nil {
+		t.Fatalf("Failed to clear the release tag setting: %v\nOutput: %s", err, output)
+	}
+
+	output, err = testutil.RunGitFlow(t, dir, "release", "start", "1.0.0")
+	if err != nil {
+		t.Fatalf("Failed to create release branch: %v\nOutput: %s", err, output)
+	}
+
+	testutil.WriteFile(t, dir, "release.txt", "release content")
+	if _, err := testutil.RunGit(t, dir, "add", "release.txt"); err != nil {
+		t.Fatalf("Failed to add file: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", "Add release file"); err != nil {
+		t.Fatalf("Failed to commit file: %v", err)
+	}
+
+	output, err = testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0")
+	if err != nil {
+		t.Fatalf("Failed to finish release branch: %v\nOutput: %s", err, output)
+	}
+
+	tags, err := testutil.RunGit(t, dir, "tag", "--list")
+	if err != nil {
+		t.Fatalf("Failed to list tags: %v", err)
+	}
+	if strings.TrimSpace(tags) != "" {
+		t.Errorf("Expected no tag to be created after --tag=false, got tags: %q\nOutput: %s", strings.TrimSpace(tags), output)
+	}
+}
+
 // TestFinishReleaseWithMessageFile tests finishing a release branch using a message file.
 // Steps:
 // 1. Sets up a test repository and initializes git-flow


### PR DESCRIPTION
Fixes two coupled defects that made boolean flags on `git flow config edit` unreliable: `--tag=false` was a silent no-op, and omitting `--auto-update` silently cleared an existing `autoUpdate=true`.

The invariant is now the one the string flags already follow: on `config edit`, an omitted boolean flag preserves the stored value and a supplied one replaces it, in either direction. Two changes get there. `SaveConfigWithScope` in `internal/config/config.go` now serializes `gitflow.branch.<name>.tag` unconditionally via `strconv.FormatBool` instead of only when true, mirroring how `autoUpdate` was already written — writing an explicit `false` rather than unsetting the key matters because configuration is read with `git config --get-regexp`, which merges the system, global and local scopes, so a local `false` has to be present to shadow a `true` inherited from an outer scope. In `cmd/config.go`, a small `changedBoolPtr` helper returns `nil` when a flag was not passed, and `*bool` is threaded through the two `config edit` command paths so the executors assign only when the pointer is non-nil. The two fixes have to land together: repairing the writer alone would have converted the silent no-op into a second instance of the data loss, where `config edit topic release --prefix=rel/` silently stops tagging releases. `config add` is deliberately untouched — there an omitted boolean legitimately means false for a branch type being created.

Resolves #184

## Remarks

- Because the writer now always writes `gitflow.branch.*.tag`, a repository whose `.gitflow` was written by an older version will have `git flow config status` report drift on the `*.tag` keys and exit 6 until `git flow config sync` runs, which self-heals. This is documented in `docs/gitflow-config.5.md`.
- `tag` and `autoUpdate` are the only booleans in the branch configuration, so the "do other write-only-when-true booleans need the same treatment" question from the report resolves to these two.
- A pre-existing failure mode for hand-authored `.gitflow` files with duplicate keys was left alone: it already affects `autoUpdate` today and belongs in its own issue covering both keys.
- 14 test scenarios cover the spec's 12. Eight of them fail against a binary built from `origin/main`, which was verified explicitly rather than assumed; two more pass on `main` only because the first defect masked the second, and become regression guards.

**Review focus:**
- `internal/config/config.go` - the unconditional `tag` write and its blast radius across init, shared `.gitflow`, and `config sync`
- `cmd/config.go` - `changedBoolPtr` and the `*bool` threading, including the bare `--tag` form
- `test/cmd/config_test.go` - scenario 7, which uses an isolated `GIT_CONFIG_GLOBAL` to prove the explicit `false` shadows an inherited `true`