### PR TITLE
feat(worktree): Add the git flow worktree command

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -28,12 +28,19 @@ git-flow-next/
 │   ├── checkout.go        # Branch checkout functionality
 │   ├── delete.go          # Branch deletion
 │   ├── rename.go          # Branch renaming
+│   ├── worktree.go        # Worktree management by branch name
 │   └── overview.go        # Repository overview
 ├── internal/              # Internal packages (not exported)
 │   ├── config/           # Git configuration management
 │   │   └── config.go     # Branch type definitions, config loading
 │   ├── git/              # Git command wrapper
-│   │   └── repo.go       # Git operations with error handling
+│   │   ├── repo.go       # Git operations with error handling
+│   │   └── worktree.go   # Worktree add/remove/list/prune/detach
+│   ├── worktree/         # Worktree path templates and provenance markers
+│   │   ├── path.go       # gitflow.worktreePath expansion
+│   │   └── provenance.go # Markers recording which worktrees git-flow created
+│   ├── navigate/         # GIT_FLOW_CD_FILE destination channel
+│   │   └── cdfile.go     # Hand a destination directory to the calling shell
 │   ├── mergestate/       # Merge conflict state persistence
 │   │   └── mergestate.go # State management for multi-step operations
 │   ├── hooks/            # Client-side hook execution
@@ -513,6 +520,13 @@ git flow update <branch> --rebase  # Force rebase strategy
 git flow rebase                    # Shorthand for: git flow <type> update --rebase
 git flow update                    # Shorthand for: git flow <type> update
 git flow finish                    # Shorthand for: git flow <type> finish
+
+# Worktree operations (addressed by full branch name)
+git flow worktree add <branch>
+git flow worktree remove <branch>
+git flow worktree list
+git flow worktree prune
+git flow worktree path <branch>
 
 # Overview
 git flow overview

--- a/CODE_REFERENCE.md
+++ b/CODE_REFERENCE.md
@@ -180,6 +180,7 @@ Layer 2 controls *how commands execute* (operational knobs). Not all options hav
 | `init.go` | Initialize git-flow |
 | `config.go` | Manage configuration |
 | `overview.go` | Show git-flow status |
+| `worktree.go` | Manage worktrees by branch name (add/remove/list/prune/path) |
 | `version.go` | Display version |
 | `shorthand.go` | Quick commands (work on current branch) |
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -32,6 +32,9 @@ Many command options intentionally have no Layer 1 equivalent — they exist onl
 | `gitflow.initialized` | Marks repository as git-flow initialized | `false` | `true` |
 | `gitflow.origin` | Remote name to use for operations | `origin` | `upstream` |
 | `gitflow.remote` | Alias for `gitflow.origin` | `origin` | `upstream` |
+| `gitflow.worktreePath` | Path template for a branch's worktree. Supports `{{ repo }}`, `{{ branch }}`, `{{ branchName }}`, `{{ topicType }}` (spaced or unspaced), expands a leading `~`, resolves a relative template against the main worktree root, and always yields an absolute path | `../{{ repo }}-worktrees/{{ branch }}` | `~/worktrees/{{ topicType }}/{{ branchName }}` |
+
+`gitflow.worktree.<branch>.managed` is **not** a setting: it is repository-local state git-flow writes when it creates a worktree, so later commands can tell its own worktrees from the user's. It is excluded from the shared-config set and never reaches a committed `.gitflow`. See [git-flow-worktree(1)](docs/git-flow-worktree.1.md).
 
 ## Branch Type Configuration (Layer 1)
 

--- a/cmd/worktree.go
+++ b/cmd/worktree.go
@@ -1,0 +1,495 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gittower/git-flow-next/internal/config"
+	"github.com/gittower/git-flow-next/internal/errors"
+	"github.com/gittower/git-flow-next/internal/git"
+	"github.com/gittower/git-flow-next/internal/navigate"
+	"github.com/gittower/git-flow-next/internal/worktree"
+	"github.com/spf13/cobra"
+)
+
+// unmanagedTag marks a worktree git-flow did not create, the distinction that
+// decides what the cleanup commands may remove.
+const unmanagedTag = "(unmanaged)"
+
+// detachedBranchLabel stands in for the branch column of a worktree whose HEAD is
+// not on a branch.
+const detachedBranchLabel = "(detached)"
+
+var worktreeCmd = &cobra.Command{
+	Use:   "worktree",
+	Short: "Manage worktrees for branches",
+	Long: `Manage git worktrees by branch name.
+
+Worktrees are addressed by their full branch name (e.g. feature/user-auth), not
+by topic type plus short name. Paths are computed from the gitflow.worktreePath
+template unless --path overrides them.
+
+git-flow records the worktrees it creates, so 'worktree list' can tell them apart
+from worktrees created with plain 'git worktree add'.`,
+	Example: `  git flow worktree add feature/user-auth
+  git flow worktree list
+  git flow worktree remove feature/user-auth
+  git flow worktree prune
+  git flow worktree path feature/user-auth`,
+}
+
+var worktreeAddCmd = &cobra.Command{
+	Use:   "add <branch>",
+	Short: "Create a worktree for an existing branch",
+	Long: `Create a worktree for an existing branch at the computed path.
+
+The branch must exist and must not be checked out in another worktree. Parent
+directories of the computed path are created as needed.`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		path, _ := cmd.Flags().GetString("path")
+		noCD, _ := cmd.Flags().GetBool("no-cd")
+		WorktreeAddCommand(args[0], path, noCD)
+	},
+}
+
+var worktreeRemoveCmd = &cobra.Command{
+	Use:   "remove <branch>",
+	Short: "Remove the worktree of a branch, keeping the branch",
+	Long: `Remove the worktree that has the given branch checked out.
+
+The branch itself is kept. Removal refuses a worktree with uncommitted or
+untracked changes unless --force is given, and never removes the main worktree.
+Because the command names its target explicitly, it removes the worktree whatever
+its origin.`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		force, _ := cmd.Flags().GetBool("force")
+		noCD, _ := cmd.Flags().GetBool("no-cd")
+		WorktreeRemoveCommand(args[0], force, noCD)
+	},
+}
+
+var worktreeListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List linked worktrees",
+	Long: `List the linked worktrees of this repository with their branch and path.
+
+The main worktree is excluded. Worktrees git-flow did not create are tagged
+(unmanaged); a worktree whose HEAD is detached shows (detached) instead of a
+branch name.`,
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		WorktreeListCommand()
+	},
+}
+
+var worktreePruneCmd = &cobra.Command{
+	Use:   "prune",
+	Short: "Drop admin entries whose worktree directories are gone",
+	Long: `Drop the administrative entries of worktrees whose directories no longer exist.
+
+Provenance markers whose branch has no live worktree are dropped as well, so they
+never outlive what they describe.`,
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		WorktreePruneCommand()
+	},
+}
+
+var worktreePathCmd = &cobra.Command{
+	Use:   "path <branch>",
+	Short: "Print the computed worktree path for a branch",
+	Long: `Print the path the gitflow.worktreePath template computes for a branch.
+
+Nothing is created and nothing is changed.`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		WorktreePathCommand(args[0])
+	},
+}
+
+// WorktreeAddCommand is the implementation of 'git flow worktree add'.
+func WorktreeAddCommand(branch string, path string, noCD bool) {
+	runWorktreeCommand(func(repo *git.Repo) error {
+		return executeWorktreeAdd(repo, branch, path, noCD)
+	})
+}
+
+// WorktreeRemoveCommand is the implementation of 'git flow worktree remove'.
+func WorktreeRemoveCommand(branch string, force bool, noCD bool) {
+	runWorktreeCommand(func(repo *git.Repo) error {
+		return executeWorktreeRemove(repo, branch, force, noCD)
+	})
+}
+
+// WorktreeListCommand is the implementation of 'git flow worktree list'.
+func WorktreeListCommand() {
+	runWorktreeCommand(executeWorktreeList)
+}
+
+// WorktreePruneCommand is the implementation of 'git flow worktree prune'.
+func WorktreePruneCommand() {
+	runWorktreeCommand(executeWorktreePrune)
+}
+
+// WorktreePathCommand is the implementation of 'git flow worktree path'.
+func WorktreePathCommand(branch string) {
+	runWorktreeCommand(func(repo *git.Repo) error {
+		return executeWorktreePath(repo, branch)
+	})
+}
+
+// runWorktreeCommand opens the invocation repository, runs one subcommand, and
+// maps a typed git-flow error to its exit code. The five subcommands share it
+// rather than repeating the wrapper five times.
+func runWorktreeCommand(run func(repo *git.Repo) error) {
+	repo := mustOpenRepo()
+	if err := run(repo); err != nil {
+		exitCode := errors.ExitCodeGitError
+		if flowErr, ok := err.(errors.Error); ok {
+			exitCode = flowErr.ExitCode()
+		}
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(int(exitCode))
+	}
+}
+
+// requireInitialized fails unless git-flow is initialized in the repository.
+// Every worktree subcommand gates on it, including the read-only ones, so an
+// uninitialized repository never sees half a command work.
+func requireInitialized(repo *git.Repo) error {
+	initialized, err := config.IsInitialized(repo)
+	if err != nil {
+		return &errors.GitError{Operation: "check if git-flow is initialized", Err: err}
+	}
+	if !initialized {
+		return &errors.NotInitializedError{}
+	}
+	return nil
+}
+
+// loadWorktreeConfig gates on initialization and loads the configuration the
+// path template expands against.
+func loadWorktreeConfig(repo *git.Repo) (*config.Config, error) {
+	if err := requireInitialized(repo); err != nil {
+		return nil, err
+	}
+	cfg, err := config.Load(repo)
+	if err != nil {
+		return nil, &errors.GitError{Operation: "load configuration", Err: err}
+	}
+	return cfg, nil
+}
+
+// executeWorktreeAdd creates a worktree for an existing branch.
+func executeWorktreeAdd(repo *git.Repo, branch string, pathFlag string, noCD bool) error {
+	cfg, err := loadWorktreeConfig(repo)
+	if err != nil {
+		return err
+	}
+
+	if err := repo.BranchExists(branch); err != nil {
+		return &errors.LocalBranchNotFoundError{BranchName: branch}
+	}
+
+	// A branch can be checked out in only one worktree, so refuse before git
+	// does — and distinguish "it is in the main worktree" from "it already has a
+	// worktree", which are different problems for the user.
+	existing, err := repo.WorktreeForBranch(branch)
+	if err != nil {
+		return &errors.GitError{Operation: "look up worktree for branch", Err: err}
+	}
+	if existing != nil {
+		if existing.Main {
+			return &errors.BranchCheckedOutElsewhereError{Branch: branch, Path: existing.Path}
+		}
+		return &errors.WorktreeExistsError{Branch: branch, Path: existing.Path}
+	}
+
+	target, err := resolveWorktreeTarget(cfg, repo, branch, pathFlag)
+	if err != nil {
+		return err
+	}
+	if occupied, err := pathIsOccupied(target); err != nil {
+		return &errors.GitError{Operation: "inspect target path", Err: err}
+	} else if occupied {
+		return &errors.WorktreePathOccupiedError{Path: target}
+	}
+
+	// A branch name with slashes computes a nested path, whose intermediate
+	// directories have to exist first.
+	if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+		return &errors.GitError{Operation: "create worktree parent directory", Err: err}
+	}
+	if err := repo.AddWorktree(target, branch); err != nil {
+		return &errors.GitError{Operation: "add worktree", Err: err}
+	}
+
+	// A missing marker only means later cleanup leaves this worktree alone, so a
+	// failure here warns rather than failing an operation that already succeeded.
+	if err := worktree.MarkManaged(repo, branch); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
+	}
+
+	fmt.Printf("Created worktree for branch '%s' at %s\n", branch, target)
+	fmt.Printf("To switch to it: cd %s\n", target)
+
+	if !noCD {
+		// Written only now, after the worktree exists.
+		if err := navigate.WriteDestination(target); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
+		}
+	}
+	return nil
+}
+
+// executeWorktreeRemove removes the worktree holding a branch, keeping the branch.
+func executeWorktreeRemove(repo *git.Repo, branch string, force bool, noCD bool) error {
+	if err := requireInitialized(repo); err != nil {
+		return err
+	}
+
+	mainWorkTree, err := repo.MainWorkTree()
+	if err != nil {
+		return &errors.GitError{Operation: "resolve the main worktree", Err: err}
+	}
+
+	entry, err := repo.WorktreeForBranch(branch)
+	if err != nil {
+		return &errors.GitError{Operation: "look up worktree for branch", Err: err}
+	}
+	// The main-worktree refusal comes first: naming the branch checked out there
+	// is a mistake worth its own message, not a "nothing to remove".
+	if entry != nil && entry.Main {
+		return &errors.MainWorktreeError{Operation: "remove", Path: entry.Path}
+	}
+	if entry == nil {
+		return &errors.WorktreeNotFoundError{Branch: branch}
+	}
+
+	directoryExists := true
+	if _, statErr := os.Stat(entry.Path); os.IsNotExist(statErr) {
+		directoryExists = false
+	}
+
+	// A directory that is already gone has nothing to lose, so it counts as clean
+	// and the dirty check is skipped rather than failing on a missing worktree.
+	if !force && directoryExists {
+		dirty, err := repo.WorktreeHasChanges(entry.Path)
+		if err != nil {
+			return &errors.GitError{Operation: "check worktree for changes", Err: err}
+		}
+		if dirty {
+			return &errors.WorktreeDirtyError{Branch: branch, Path: entry.Path}
+		}
+	}
+
+	// Decide everything that depends on the current directory BEFORE the removal
+	// deletes it: whether the user is standing inside the target, and where the
+	// destination file is.
+	strandedUser := false
+	if cwd, err := os.Getwd(); err == nil {
+		strandedUser = git.IsWithin(cwd, entry.Path)
+	}
+	destinationFile := ""
+	if !noCD && strandedUser {
+		destinationFile = navigate.DestinationFile()
+	}
+
+	// Once the worktree is gone, every git command bound to it fails, so switch
+	// to a handle on the main worktree first.
+	opRepo := repo
+	if !git.SamePath(repo.WorkTree(), mainWorkTree) {
+		opRepo, err = git.Open(mainWorkTree)
+		if err != nil {
+			return &errors.GitError{Operation: "open the main worktree", Err: err}
+		}
+	}
+
+	if err := opRepo.RemoveWorktree(entry.Path, force); err != nil {
+		if !directoryExists {
+			return &errors.GitError{
+				Operation: "remove worktree",
+				Err:       fmt.Errorf("%w (the directory is already gone; 'git flow worktree prune' drops stale entries)", err),
+			}
+		}
+		return &errors.GitError{Operation: "remove worktree", Err: err}
+	}
+
+	if err := worktree.ClearMarker(opRepo, branch); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
+	}
+
+	// Written only now, after the removal succeeded, and only when the user would
+	// otherwise be left in a deleted directory.
+	if destinationFile != "" {
+		if err := navigate.WriteDestinationTo(destinationFile, mainWorkTree); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
+		}
+	}
+
+	fmt.Printf("Removed worktree for branch '%s' at %s\n", branch, entry.Path)
+	return nil
+}
+
+// executeWorktreeList prints one row per linked worktree.
+func executeWorktreeList(repo *git.Repo) error {
+	if err := requireInitialized(repo); err != nil {
+		return err
+	}
+
+	entries, err := repo.ListWorktrees()
+	if err != nil {
+		return &errors.GitError{Operation: "list worktrees", Err: err}
+	}
+
+	type row struct {
+		branch string
+		path   string
+		tag    string
+	}
+	var rows []row
+	width := 0
+	for _, entry := range entries {
+		if entry.Main {
+			continue
+		}
+		r := row{branch: entry.Branch, path: entry.Path}
+		if entry.Branch == "" {
+			// A detached worktree has no branch to key provenance on, so it can
+			// only be reported as unmanaged.
+			r.branch = detachedBranchLabel
+			r.tag = unmanagedTag
+		} else if !worktree.IsManaged(repo, entry.Branch) {
+			r.tag = unmanagedTag
+		}
+		if len(r.branch) > width {
+			width = len(r.branch)
+		}
+		rows = append(rows, r)
+	}
+
+	if len(rows) == 0 {
+		fmt.Println("No linked worktrees found")
+		return nil
+	}
+
+	for _, r := range rows {
+		line := fmt.Sprintf("%-*s  %s", width, r.branch, r.path)
+		if r.tag != "" {
+			line += "  " + r.tag
+		}
+		fmt.Println(line)
+	}
+	return nil
+}
+
+// executeWorktreePrune drops stale admin entries and the markers left behind.
+func executeWorktreePrune(repo *git.Repo) error {
+	if err := requireInitialized(repo); err != nil {
+		return err
+	}
+
+	before, err := repo.ListWorktrees()
+	if err != nil {
+		return &errors.GitError{Operation: "list worktrees", Err: err}
+	}
+	if err := repo.PruneWorktrees(); err != nil {
+		return &errors.GitError{Operation: "prune worktrees", Err: err}
+	}
+	after, err := repo.ListWorktrees()
+	if err != nil {
+		return &errors.GitError{Operation: "list worktrees", Err: err}
+	}
+	if err := worktree.SweepMarkers(repo); err != nil {
+		return &errors.GitError{Operation: "sweep worktree provenance markers", Err: err}
+	}
+
+	remaining := make(map[string]bool, len(after))
+	for _, entry := range after {
+		remaining[entry.Path] = true
+	}
+	pruned := 0
+	for _, entry := range before {
+		if !remaining[entry.Path] {
+			fmt.Printf("Pruned worktree entry at %s\n", entry.Path)
+			pruned++
+		}
+	}
+	if pruned == 0 {
+		fmt.Println("No stale worktree entries found")
+	}
+	return nil
+}
+
+// executeWorktreePath prints the computed path for a branch and nothing else.
+func executeWorktreePath(repo *git.Repo, branch string) error {
+	cfg, err := loadWorktreeConfig(repo)
+	if err != nil {
+		return err
+	}
+	path, err := worktree.ComputePath(cfg, repo, branch)
+	if err != nil {
+		return &errors.GitError{Operation: "compute worktree path", Err: err}
+	}
+	fmt.Println(path)
+	return nil
+}
+
+// resolveWorktreeTarget returns the absolute path the worktree belongs at: the
+// --path value when given, otherwise the computed one.
+//
+// A relative --path resolves against the INVOCATION directory, which is what a
+// hand-typed path means, while a relative gitflow.worktreePath template resolves
+// against the main worktree root. The asymmetry is deliberate: a template is a
+// repository-wide setting, a typed path is one command's argument.
+func resolveWorktreeTarget(cfg *config.Config, repo *git.Repo, branch string, pathFlag string) (string, error) {
+	if strings.TrimSpace(pathFlag) != "" {
+		return normalizeInvocationPath(pathFlag), nil
+	}
+	path, err := worktree.ComputePath(cfg, repo, branch)
+	if err != nil {
+		return "", &errors.GitError{Operation: "compute worktree path", Err: err}
+	}
+	return path, nil
+}
+
+// pathIsOccupied reports whether something is already in the way at path. An
+// empty directory is not in the way — git itself accepts one — but a file or a
+// directory with content is.
+func pathIsOccupied(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if !info.IsDir() {
+		return true, nil
+	}
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false, err
+	}
+	return len(entries) > 0, nil
+}
+
+func init() {
+	worktreeAddCmd.Flags().String("path", "", "Create the worktree at this path instead of the computed one")
+	worktreeAddCmd.Flags().Bool("no-cd", false, "Do not write a navigation destination for the calling shell")
+
+	worktreeRemoveCmd.Flags().Bool("force", false, "Remove even with uncommitted or untracked changes")
+	worktreeRemoveCmd.Flags().Bool("no-cd", false, "Do not write a navigation destination for the calling shell")
+
+	worktreeCmd.AddCommand(worktreeAddCmd)
+	worktreeCmd.AddCommand(worktreeRemoveCmd)
+	worktreeCmd.AddCommand(worktreeListCmd)
+	worktreeCmd.AddCommand(worktreePruneCmd)
+	worktreeCmd.AddCommand(worktreePathCmd)
+
+	rootCmd.AddCommand(worktreeCmd)
+}

--- a/cmd/worktree.go
+++ b/cmd/worktree.go
@@ -270,8 +270,14 @@ func executeWorktreeRemove(repo *git.Repo, branch string, force bool, noCD bool)
 		return &errors.WorktreeNotFoundError{Branch: branch}
 	}
 
+	// Anything other than a missing directory — an unreadable parent, most likely —
+	// is surfaced here rather than being read as "the directory is there", which
+	// would only fail further down with a message about something else.
 	directoryExists := true
-	if _, statErr := os.Stat(entry.Path); os.IsNotExist(statErr) {
+	if _, statErr := os.Stat(entry.Path); statErr != nil {
+		if !os.IsNotExist(statErr) {
+			return &errors.GitError{Operation: "inspect the worktree directory", Err: statErr}
+		}
 		directoryExists = false
 	}
 

--- a/cmd/worktree.go
+++ b/cmd/worktree.go
@@ -290,6 +290,10 @@ func executeWorktreeRemove(repo *git.Repo, branch string, force bool, noCD bool)
 	// Decide everything that depends on the current directory BEFORE the removal
 	// deletes it: whether the user is standing inside the target, and where the
 	// destination file is.
+	// A failing Getwd means the current directory is already unreadable or gone,
+	// so treat the user as not standing inside the target: writing a destination
+	// on a guess would move a shell that never asked to be moved, while not
+	// writing one costs at most a manual cd.
 	strandedUser := false
 	if cwd, err := os.Getwd(); err == nil {
 		strandedUser = git.IsWithin(cwd, entry.Path)
@@ -447,8 +451,10 @@ func executeWorktreePath(repo *git.Repo, branch string) error {
 // against the main worktree root. The asymmetry is deliberate: a template is a
 // repository-wide setting, a typed path is one command's argument.
 func resolveWorktreeTarget(cfg *config.Config, repo *git.Repo, branch string, pathFlag string) (string, error) {
-	if strings.TrimSpace(pathFlag) != "" {
-		return normalizeInvocationPath(pathFlag), nil
+	// Use the TRIMMED value, the same one the emptiness test looks at: surrounding
+	// whitespace in a hand-typed path is a typo, not a directory name.
+	if trimmed := strings.TrimSpace(pathFlag); trimmed != "" {
+		return normalizeInvocationPath(trimmed), nil
 	}
 	path, err := worktree.ComputePath(cfg, repo, branch)
 	if err != nil {

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ This directory contains comprehensive manpage-style documentation for all git-fl
 - **git-flow-init.1.md** - Repository initialization and workflow setup
 - **git-flow-config.1.md** - Configuration management commands  
 - **git-flow-integrate.1.md** - Integrate a base branch into its parent
+- **git-flow-worktree.1.md** - Worktree management for branches
 - **git-flow-feature.1.md** - Feature branch management
 - **git-flow-release.1.md** - Release branch management
 - **git-flow-hotfix.1.md** - Hotfix branch management

--- a/docs/git-flow-worktree.1.md
+++ b/docs/git-flow-worktree.1.md
@@ -55,13 +55,13 @@ git-flow records the worktrees it creates by writing a provenance marker in Git 
 ## ENVIRONMENT
 
 **GIT_FLOW_CD_FILE**
-: When set to a writable path, a command that navigates writes its absolute destination there. git-flow runs as a subprocess and cannot change its parent shell's working directory, so the shell wrapper points this variable at a temporary file for the invocation and changes directory when the file is non-empty. The variable is an input git-flow reads, never one it sets, which is why it is not a Git config key: it describes one invocation's calling environment, not a repository preference.
+: When set to a writable path, a command that navigates writes its absolute destination there. git-flow runs as a subprocess and cannot change its parent shell's working directory, so this variable is how a caller asks for that destination in a form it can act on: point the variable at a file, run the command, then read the file and change directory yourself. The variable is an input git-flow reads, never one it sets, which is why it is not a Git config key: it describes one invocation's calling environment, not a repository preference.
 
 : **add** writes the new worktree's path once it exists. **remove** writes only when it would otherwise strand the user: if the current directory is inside the worktree being removed, it writes the main worktree's path, so the shell is never left in a deleted directory. Run from anywhere else, **remove** writes nothing.
 
 : The destination is written **only after** the operation it follows has succeeded, so a refused or failed command leaves the file empty. **--no-cd** suppresses the write even when the variable is set. A failure to write the destination is **not fatal**: the operation still succeeds and a warning is printed to standard error.
 
-: When the variable is unset — no wrapper, a script, CI — nothing is written and the command prints the human `cd` hint it would print anyway. Nothing machine-readable goes to standard output, so a user without the wrapper never sees a protocol line.
+: When the variable is unset — an ordinary shell, a script, CI — nothing is written and the command prints the human `cd` hint it would print anyway. Nothing machine-readable ever goes to standard output, so a caller that does not use the channel never sees a protocol line.
 
 ## EXAMPLES
 
@@ -84,7 +84,7 @@ List the linked worktrees:
 ```bash
 $ git flow worktree list
 feature/user-auth  /home/you/my-project-worktrees/feature/user-auth
-feature/api-v2     /home/you/elsewhere/api-v2                        (unmanaged)
+feature/api-v2     /home/you/elsewhere/api-v2  (unmanaged)
 ```
 
 Remove a worktree, keeping the branch:
@@ -107,6 +107,14 @@ Change the path template for this repository:
 git config gitflow.worktreePath '../{{ repo }}-worktrees/{{ branch }}'
 git config gitflow.worktreePath '~/worktrees/{{ topicType }}/{{ branchName }}'
 ```
+
+## CONFIGURATION
+
+**gitflow.worktreePath**
+: Template for the path of a branch's worktree. Supports **{{ repo }}** (the main worktree's directory name), **{{ branch }}** (the full branch name), **{{ branchName }}** (the branch without its topic prefix) and **{{ topicType }}** (the topic branch type, empty for a non-topic branch), in the spaced (`{{ branch }}`) and unspaced (`{{branch}}`) form alike. A leading `~` expands to the home directory; a relative template resolves against the main worktree root. Defaults to `../{{ repo }}-worktrees/{{ branch }}`. See **gitflow-config**(5).
+
+**gitflow.worktree.*branch*.managed**
+: The provenance marker **add** writes and **remove** clears. This is repository-local state written by git-flow, not a setting to configure by hand: it is what **list** reads to decide whether a worktree is tagged `(unmanaged)`. It is read from and written to **local** config only, and is excluded from the shared-config set, so it never reaches a committed `.gitflow`.
 
 ## EXIT STATUS
 
@@ -134,9 +142,10 @@ git config gitflow.worktreePath '~/worktrees/{{ topicType }}/{{ branchName }}'
 
 ## NOTES
 
-- **Requires Git 2.17 or newer.** `git worktree remove` and `git worktree move` were added in 2.17; the older operations this command builds on go back further, but the command as a whole needs 2.17. There is no runtime version check — on an older Git you see Git's own error.
+- **Requires Git 2.17 or newer.** `git worktree remove`, which **remove** builds on, was added in 2.17; the other operations used here go back further, but the command as a whole needs 2.17. There is no runtime version check — on an older Git you see Git's own error.
 - A relative **--path** is invocation-directory-relative, while a relative **gitflow.worktreePath** template is main-worktree-relative. See **OPTIONS**.
 - Provenance comes from the marker only, never from the shape of the path.
 - The main worktree is never removed and never detached.
 - A **--path** inside the repository work tree is allowed, matching Git's own behavior; the worktree simply shows up as an untracked directory.
+- An existing **empty** directory is accepted as the target of **add**, again matching Git's own behavior; only a file or a directory with content in it counts as occupied and is refused.
 - A worktree whose directory is already gone counts as clean, so **remove** does not demand **--force** for it.

--- a/docs/git-flow-worktree.1.md
+++ b/docs/git-flow-worktree.1.md
@@ -1,0 +1,142 @@
+# GIT-FLOW-WORKTREE(1)
+
+## NAME
+
+git-flow-worktree - Manage worktrees for branches
+
+## SYNOPSIS
+
+**git-flow worktree add** *branch* [**--path** *path*] [**--no-cd**]
+
+**git-flow worktree remove** *branch* [**--force**] [**--no-cd**]
+
+**git-flow worktree list**
+
+**git-flow worktree prune**
+
+**git-flow worktree path** *branch*
+
+## DESCRIPTION
+
+Manage Git worktrees by branch name, independently of the branch lifecycle.
+
+Subcommands address worktrees by **full branch name** (e.g. `feature/user-auth`), not by topic type plus short name. Paths are computed from the **gitflow.worktreePath** template unless **--path** overrides them, and the computed path is always absolute.
+
+git-flow records the worktrees it creates by writing a provenance marker in Git config, so **list** can tell them apart from worktrees created with plain **git worktree add**. Provenance is never inferred by comparing a worktree's path against the template: **--path** and any later change to the template both break that correspondence.
+
+## SUBCOMMANDS
+
+**add** *branch*
+: Create a worktree for an existing branch at the computed path (or at **--path**). Intermediate directories of a nested path such as `feature/user-auth` are created. The branch must exist and must not be checked out in another worktree — Git allows a branch in only one worktree at a time. Writes the provenance marker for the branch.
+
+**remove** *branch*
+: Remove the worktree that has *branch* checked out. The branch itself is kept. Removal refuses a worktree with uncommitted or untracked changes unless **--force** is given, and never removes the main worktree. Because the command names its target explicitly, it removes the worktree whatever its origin — an unmanaged worktree is removed just like a git-flow-created one. Clears the provenance marker.
+
+**list**
+: List the linked worktrees with their branch and path, one row each. The main worktree is excluded. A worktree git-flow did not create is tagged `(unmanaged)`; a worktree whose HEAD is detached shows `(detached)` in place of a branch name and is reported as unmanaged, since there is no branch to key provenance on. A stale entry — one whose directory was deleted by hand — is listed as-is until **prune** runs. Prints `No linked worktrees found` when there are none.
+
+**prune**
+: Drop the administrative entries of worktrees whose directories no longer exist, then drop every provenance marker whose branch has no live worktree, so markers never outlive what they describe. A worktree that is still live but detached from its branch keeps its directory and loses its marker.
+
+**path** *branch*
+: Print the path the template computes for *branch* and nothing else. Creates nothing and changes nothing.
+
+## OPTIONS
+
+**--path** *path*
+: Create the worktree at *path* instead of the computed one (**add** only). A relative value resolves against the **invocation directory** — the directory the command was run from — which is what a hand-typed path means. Note the deliberate asymmetry with a relative **gitflow.worktreePath** template, which resolves against the main worktree root because it is a repository-wide setting rather than one command's argument.
+
+**--force**
+: Remove a worktree even when it has uncommitted or untracked changes, discarding them (**remove** only).
+
+**--no-cd**
+: Do not write a navigation destination for the calling shell, even when **GIT_FLOW_CD_FILE** is set (**add** and **remove**).
+
+## ENVIRONMENT
+
+**GIT_FLOW_CD_FILE**
+: When set to a writable path, a command that navigates writes its absolute destination there. git-flow runs as a subprocess and cannot change its parent shell's working directory, so the shell wrapper points this variable at a temporary file for the invocation and changes directory when the file is non-empty. The variable is an input git-flow reads, never one it sets, which is why it is not a Git config key: it describes one invocation's calling environment, not a repository preference.
+
+: **add** writes the new worktree's path once it exists. **remove** writes only when it would otherwise strand the user: if the current directory is inside the worktree being removed, it writes the main worktree's path, so the shell is never left in a deleted directory. Run from anywhere else, **remove** writes nothing.
+
+: The destination is written **only after** the operation it follows has succeeded, so a refused or failed command leaves the file empty. **--no-cd** suppresses the write even when the variable is set. A failure to write the destination is **not fatal**: the operation still succeeds and a warning is printed to standard error.
+
+: When the variable is unset — no wrapper, a script, CI — nothing is written and the command prints the human `cd` hint it would print anyway. Nothing machine-readable goes to standard output, so a user without the wrapper never sees a protocol line.
+
+## EXAMPLES
+
+Create a worktree for an existing branch:
+```bash
+git flow worktree add feature/user-auth
+```
+
+Create it somewhere else:
+```bash
+git flow worktree add feature/user-auth --path ../review-copy
+```
+
+See where a branch's worktree would go, without creating it:
+```bash
+git flow worktree path feature/user-auth
+```
+
+List the linked worktrees:
+```bash
+$ git flow worktree list
+feature/user-auth  /home/you/my-project-worktrees/feature/user-auth
+feature/api-v2     /home/you/elsewhere/api-v2                        (unmanaged)
+```
+
+Remove a worktree, keeping the branch:
+```bash
+git flow worktree remove feature/user-auth
+```
+
+Remove one with uncommitted changes:
+```bash
+git flow worktree remove feature/user-auth --force
+```
+
+Clean up after deleting a worktree directory by hand:
+```bash
+git flow worktree prune
+```
+
+Change the path template for this repository:
+```bash
+git config gitflow.worktreePath '../{{ repo }}-worktrees/{{ branch }}'
+git config gitflow.worktreePath '~/worktrees/{{ topicType }}/{{ branchName }}'
+```
+
+## EXIT STATUS
+
+**0**
+: Success
+
+**1**
+: git-flow is not initialized in this repository
+
+**3**
+: A Git operation failed
+
+**4**
+: A worktree for the branch already exists
+
+**5**
+: The branch does not exist, or has no worktree to remove
+
+**6**
+: A refusal: the target path is occupied, the branch is checked out in another worktree, the target is the main worktree, or the worktree has uncommitted or untracked changes
+
+## SEE ALSO
+
+**git-flow**(1), **gitflow-config**(5), **git-worktree**(1)
+
+## NOTES
+
+- **Requires Git 2.17 or newer.** `git worktree remove` and `git worktree move` were added in 2.17; the older operations this command builds on go back further, but the command as a whole needs 2.17. There is no runtime version check — on an older Git you see Git's own error.
+- A relative **--path** is invocation-directory-relative, while a relative **gitflow.worktreePath** template is main-worktree-relative. See **OPTIONS**.
+- Provenance comes from the marker only, never from the shape of the path.
+- The main worktree is never removed and never detached.
+- A **--path** inside the repository work tree is allowed, matching Git's own behavior; the worktree simply shows up as an untracked directory.
+- A worktree whose directory is already gone counts as clean, so **remove** does not demand **--force** for it.

--- a/docs/git-flow.1.md
+++ b/docs/git-flow.1.md
@@ -38,6 +38,9 @@ This implementation maintains compatibility with existing git-flow repositories 
 **integrate** [*branch*]
 : Integrate a base branch into its parent (e.g. develop into main). See **git-flow-integrate**(1).
 
+**worktree**
+: Manage worktrees for branches: add, remove, list, prune, and print the computed path. See **git-flow-worktree**(1).
+
 **version**
 : Show version information. Prints `<version> (git-flow-next)`, so tooling that parses the first whitespace-separated token reads a bare version number.
 
@@ -147,7 +150,7 @@ git flow config add topic bugfix develop --prefix=bug/
 
 ## SEE ALSO
 
-**git-flow-init**(1), **git-flow-config**(1), **git-flow-completion**(1), **git-flow-start**(1), **git-flow-finish**(1), **git-flow-integrate**(1), **git-flow-update**(1), **git-flow-delete**(1), **git-flow-track**(1), **gitflow-config**(5), **git**(1)
+**git-flow-init**(1), **git-flow-config**(1), **git-flow-completion**(1), **git-flow-start**(1), **git-flow-finish**(1), **git-flow-integrate**(1), **git-flow-update**(1), **git-flow-delete**(1), **git-flow-track**(1), **git-flow-worktree**(1), **gitflow-config**(5), **git**(1)
 
 ## AUTHORS
 

--- a/docs/gitflow-config.5.md
+++ b/docs/gitflow-config.5.md
@@ -860,8 +860,9 @@ Create and manage **.gitflow** with:
 
 A **gitflow.*** key is *shared-managed* — copied between **.gitflow** and local config — unless it is:
 
-- a **gitflow.shared.*** control key (see below), or
-- per-branch runtime metadata **gitflow.branch.<branch>.base** (the start point recorded for a started topic branch).
+- a **gitflow.shared.*** control key (see below),
+- per-branch runtime metadata **gitflow.branch.<branch>.base** (the start point recorded for a started topic branch), or
+- a worktree provenance marker **gitflow.worktree.<branch>.managed** (repository-local state recording which worktrees git-flow created — see **git-flow-worktree**(1)).
 
 **gitflow.version** and **gitflow.initialized** are shared-managed. Keys outside the **gitflow.*** namespace (for example **core.*** or **alias.***) are never copied, even if present in **.gitflow**. Copying preserves multi-value keys (such as **gitflow.<type>.publish.push-option**) and their order.
 
@@ -887,7 +888,7 @@ Activation never runs for **git flow init** itself, in a bare repository or outs
 
 ## SEE ALSO
 
-**git-flow**(1), **git-flow-config**(1), **git-flow-init**(1), **git-config**(1), **gitignore**(5)
+**git-flow**(1), **git-flow-config**(1), **git-flow-init**(1), **git-flow-worktree**(1), **git-config**(1), **gitignore**(5)
 
 ## NOTES
 

--- a/docs/gitflow-config.5.md
+++ b/docs/gitflow-config.5.md
@@ -131,6 +131,26 @@ git config gitflow.path.hooks .githooks
 git config --global gitflow.path.hooks .githooks
 ```
 
+**gitflow.worktreePath**
+: Template for the path of a branch's worktree, used by **git-flow-worktree**(1). Supports the variables **{{ repo }}** (the main worktree's directory name), **{{ branch }}** (the full branch name), **{{ branchName }}** (the branch without its topic prefix), and **{{ topicType }}** (the topic branch type, empty for a non-topic branch), in both the spaced (`{{ branch }}`) and unspaced (`{{branch}}`) form. A leading `~` expands to the user's home directory. A relative template resolves against the **main worktree root**, not the current worktree, so the answer does not change when a command runs from inside a linked worktree. The computed path is always absolute, uses the host's path separators, and a branch name containing a slash produces nested directories.
+: *Default*: `../{{ repo }}-worktrees/{{ branch }}`
+
+```bash
+# Sibling directory of the repository (the default)
+git config gitflow.worktreePath '../{{ repo }}-worktrees/{{ branch }}'
+
+# One directory per topic type under a home-rooted tree
+git config gitflow.worktreePath '~/worktrees/{{ topicType }}/{{ branchName }}'
+
+# Global default for all repositories
+git config --global gitflow.worktreePath '~/worktrees/{{ repo }}/{{ branch }}'
+```
+
+### Worktree provenance: state, not settings
+
+**gitflow.worktree.*branch*.managed**
+: Set to `true` when git-flow creates a worktree for *branch*, and cleared when git-flow removes it. This is **repository-local state written by git-flow, not a setting users configure**: it records which worktrees git-flow created so later commands can clean up their own and leave the user's alone. It is excluded from the shared-config set, so it is never copied into a committed `.gitflow`, never reported as configuration drift, and never removed by `git flow config sync`. `gitflow.worktreePath`, being a genuine setting, is unaffected by that exclusion and can be shared with the team.
+
 ## BRANCH CONFIGURATION
 
 Branch configuration uses the pattern: **gitflow.branch.*name*.*property***

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ Comprehensive manpage-style documentation for git-flow-next commands and configu
 | **git-flow config** | Manage configuration | [git-flow-config(1)](git-flow-config.1.md) |
 | **git-flow overview** | Repository status | [git-flow-overview(1)](git-flow-overview.1.md) |
 | **git-flow integrate** | Integrate a base branch into its parent | [git-flow-integrate(1)](git-flow-integrate.1.md) |
+| **git-flow worktree** | Manage worktrees for branches | [git-flow-worktree(1)](git-flow-worktree.1.md) |
 | **git-flow completion** | Generate shell completion scripts | [git-flow-completion(1)](git-flow-completion.1.md) |
 
 ## Topic Branch Commands

--- a/internal/config/shared.go
+++ b/internal/config/shared.go
@@ -64,14 +64,24 @@ func parseConfigEntries(lines []string) []configEntry {
 //
 // A key is shared-managed iff it is under gitflow. AND is not a gitflow.shared.*
 // control key AND is not per-branch runtime metadata (gitflow.branch.<name>.base,
-// written by Repo.SetBaseBranch). gitflow.version and gitflow.initialized are
-// shared-managed. Everything outside gitflow.* (core.*, alias.*, …) is not.
+// written by Repo.SetBaseBranch) AND is not worktree provenance state
+// (gitflow.worktree.<branch>.managed). gitflow.version and gitflow.initialized
+// are shared-managed. Everything outside gitflow.* (core.*, alias.*, …) is not.
 func IsSharedManagedKey(key string) bool {
 	k := strings.ToLower(key)
 	if !strings.HasPrefix(k, "gitflow.") {
 		return false
 	}
 	if strings.HasPrefix(k, "gitflow.shared.") {
+		return false
+	}
+	// Worktree provenance: gitflow.worktree.<actual-branch>.managed, written by
+	// git-flow when it creates a worktree. It is machine-local state describing
+	// this checkout, not a setting a team shares — copying it into .gitflow would
+	// publish one developer's worktree layout and make it read as drift for
+	// everyone else. The trailing dot matters: gitflow.worktreePath IS a setting
+	// and stays shared-managed.
+	if strings.HasPrefix(k, "gitflow.worktree.") {
 		return false
 	}
 	// Per-branch runtime metadata: gitflow.branch.<actual-branch>.base. The

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -598,6 +598,93 @@ func (e *RepositoryCreationDeclinedError) ExitCode() ExitCode {
 	return ExitCodeGitError
 }
 
+// WorktreeExistsError indicates a worktree for the branch already exists. It
+// mirrors BranchExistsError's "this already exists" exit code.
+type WorktreeExistsError struct {
+	Branch string
+	Path   string
+}
+
+func (e *WorktreeExistsError) Error() string {
+	return fmt.Sprintf("a worktree for branch '%s' already exists at %s", e.Branch, e.Path)
+}
+
+func (e *WorktreeExistsError) ExitCode() ExitCode {
+	return ExitCodeBranchExists
+}
+
+// WorktreePathOccupiedError indicates the target path exists but is not a
+// worktree, so creating one there would collide with unrelated content.
+type WorktreePathOccupiedError struct {
+	Path string
+}
+
+func (e *WorktreePathOccupiedError) Error() string {
+	return fmt.Sprintf("path %s is occupied by an existing directory; move it aside or pass --path to choose another location", e.Path)
+}
+
+func (e *WorktreePathOccupiedError) ExitCode() ExitCode {
+	return ExitCodeValidationError
+}
+
+// BranchCheckedOutElsewhereError indicates the branch is already checked out in
+// another worktree. Git allows a branch in only one worktree at a time.
+type BranchCheckedOutElsewhereError struct {
+	Branch string
+	Path   string
+}
+
+func (e *BranchCheckedOutElsewhereError) Error() string {
+	return fmt.Sprintf("branch '%s' is already checked out at %s; a branch cannot be checked out in two worktrees", e.Branch, e.Path)
+}
+
+func (e *BranchCheckedOutElsewhereError) ExitCode() ExitCode {
+	return ExitCodeValidationError
+}
+
+// WorktreeNotFoundError indicates no worktree holds the given branch.
+type WorktreeNotFoundError struct {
+	Branch string
+}
+
+func (e *WorktreeNotFoundError) Error() string {
+	return fmt.Sprintf("there is no worktree for branch '%s'", e.Branch)
+}
+
+func (e *WorktreeNotFoundError) ExitCode() ExitCode {
+	return ExitCodeBranchNotFound
+}
+
+// MainWorktreeError indicates an operation was aimed at the main worktree, which
+// git-flow never removes or detaches.
+type MainWorktreeError struct {
+	Operation string
+	Path      string
+}
+
+func (e *MainWorktreeError) Error() string {
+	return fmt.Sprintf("refusing to %s the main worktree at %s: git-flow never removes or detaches the main worktree", e.Operation, e.Path)
+}
+
+func (e *MainWorktreeError) ExitCode() ExitCode {
+	return ExitCodeValidationError
+}
+
+// WorktreeDirtyError indicates a worktree has uncommitted or untracked changes
+// that removal would discard.
+type WorktreeDirtyError struct {
+	Branch string
+	Path   string
+}
+
+func (e *WorktreeDirtyError) Error() string {
+	return fmt.Sprintf("worktree for branch '%s' at %s has uncommitted or untracked changes; commit them or pass --force to discard them", e.Branch, e.Path)
+}
+
+func (e *WorktreeDirtyError) ExitCode() ExitCode {
+	return ExitCodeValidationError
+}
+
 // MissingUserIdentityError indicates git user.name/user.email are not configured
 type MissingUserIdentityError struct{}
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -614,13 +614,15 @@ func (e *WorktreeExistsError) ExitCode() ExitCode {
 }
 
 // WorktreePathOccupiedError indicates the target path exists but is not a
-// worktree, so creating one there would collide with unrelated content.
+// worktree, so creating one there would collide with unrelated content. The
+// occupant is either a file or a directory with content in it; an existing empty
+// directory is accepted as a target and never reaches this error.
 type WorktreePathOccupiedError struct {
 	Path string
 }
 
 func (e *WorktreePathOccupiedError) Error() string {
-	return fmt.Sprintf("path %s is occupied by an existing directory; move it aside or pass --path to choose another location", e.Path)
+	return fmt.Sprintf("path %s already exists and is not empty; move it aside or pass --path to choose another location", e.Path)
 }
 
 func (e *WorktreePathOccupiedError) ExitCode() ExitCode {

--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -31,6 +31,22 @@ func (r *Repo) GetConfig(key string) (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
+// GetConfigLocal gets a Git config value from the repository's LOCAL config only
+// (.git/config), ignoring global and system scope.
+//
+// Use it for repository-local state git-flow writes itself rather than for
+// settings users configure: the matching write (SetConfig) and removal
+// (UnsetConfigIfPresent) are both local-scoped, so a merged read would report a
+// global or system value that those two can never manage — see
+// UnsetConfigIfPresent for the same asymmetry stated from the write side.
+func (r *Repo) GetConfigLocal(key string) (string, error) {
+	output, err := r.gitCmd("config", "--local", "--get", key).Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get local git config %s: %w", key, err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
 // HasUserIdentity reports whether both user.name and user.email are configured
 // and non-empty in git's merged/effective config (local > global > system),
 // matching what `git commit` would see. It returns false without error when a

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -67,6 +67,30 @@ func (r *Repo) GitDir() string { return r.gitDir }
 // directory (the main .git), shared across linked worktrees.
 func (r *Repo) CommonGitDir() string { return r.commonGitDir }
 
+// MainWorkTree returns the absolute path to the repository's MAIN work-tree
+// root, which is not necessarily this handle's.
+//
+// WorkTree() reports the worktree the command was invoked from — a linked
+// worktree when the user is standing in one. Several decisions must anchor on
+// the main worktree instead: a relative gitflow.worktreePath template resolves
+// against it, and removing the worktree the user is inside hands them back to
+// it. Git always lists the main worktree first, so the first porcelain record
+// answers this; a repository whose worktree list cannot be parsed falls back to
+// the parent of the common git dir, which is the main work-tree root of any
+// non-bare repository.
+func (r *Repo) MainWorkTree() (string, error) {
+	entries, err := r.ListWorktrees()
+	if err != nil {
+		return "", err
+	}
+	for _, entry := range entries {
+		if entry.Main {
+			return entry.Path, nil
+		}
+	}
+	return filepath.Dir(r.commonGitDir), nil
+}
+
 // gitCmd builds a git command bound to this repository's work tree.
 func (r *Repo) gitCmd(args ...string) *exec.Cmd {
 	return gitCommand(r.workTree, args...)

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"fmt"
+	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -105,7 +106,7 @@ func (r *Repo) WorktreeForBranch(branch string) (*WorktreeEntry, error) {
 func (r *Repo) AddWorktree(path string, branch string) error {
 	output, err := r.gitCmd("worktree", "add", path, branch).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to add worktree at %s: %s", path, strings.TrimSpace(string(output)))
+		return fmt.Errorf("failed to add worktree at %s: %s: %w", path, strings.TrimSpace(string(output)), err)
 	}
 	return nil
 }
@@ -126,7 +127,7 @@ func (r *Repo) RemoveWorktree(path string, force bool) error {
 
 	output, err := r.gitCmd(args...).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to remove worktree at %s: %s", path, strings.TrimSpace(string(output)))
+		return fmt.Errorf("failed to remove worktree at %s: %s: %w", path, strings.TrimSpace(string(output)), err)
 	}
 	return nil
 }
@@ -135,7 +136,7 @@ func (r *Repo) RemoveWorktree(path string, force bool) error {
 func (r *Repo) PruneWorktrees() error {
 	output, err := r.gitCmd("worktree", "prune").CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to prune worktrees: %s", strings.TrimSpace(string(output)))
+		return fmt.Errorf("failed to prune worktrees: %s: %w", strings.TrimSpace(string(output)), err)
 	}
 	return nil
 }
@@ -151,7 +152,7 @@ func (r *Repo) DetachWorktree(path string) error {
 
 	output, err := gitCommand(path, "checkout", "--detach").CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to detach worktree at %s: %s", path, strings.TrimSpace(string(output)))
+		return fmt.Errorf("failed to detach worktree at %s: %s: %w", path, strings.TrimSpace(string(output)), err)
 	}
 	return nil
 }
@@ -160,12 +161,28 @@ func (r *Repo) DetachWorktree(path string) error {
 // untracked changes. It runs `git status --porcelain` with path as the working
 // directory — not this handle's work tree — so it answers for the worktree being
 // asked about rather than the one the command was invoked from.
+//
+// Only stdout is parsed. CombinedOutput would fold a stray git warning into the
+// porcelain the dirty check reads, so a clean worktree could report changes; git's
+// stderr is instead recovered from the failure for the error message.
 func (r *Repo) WorktreeHasChanges(path string) (bool, error) {
 	output, err := gitCommand(path, "status", "--porcelain").Output()
 	if err != nil {
+		if detail := stderrOf(err); detail != "" {
+			return false, fmt.Errorf("failed to check status of worktree at %s: %s: %w", path, detail, err)
+		}
 		return false, fmt.Errorf("failed to check status of worktree at %s: %w", path, err)
 	}
 	return strings.TrimSpace(string(output)) != "", nil
+}
+
+// stderrOf returns the trimmed stderr a failed command wrote, which Output()
+// records on the *exec.ExitError. It is empty for any other failure.
+func stderrOf(err error) string {
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return strings.TrimSpace(string(exitErr.Stderr))
+	}
+	return ""
 }
 
 // refuseMainWorktree returns an error when path is the repository's main

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -1,0 +1,231 @@
+package git
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// WorktreeEntry is one record of `git worktree list --porcelain`: a worktree
+// registered with the repository, whether it is the main one or a linked one.
+type WorktreeEntry struct {
+	// Path is the absolute path of the worktree as git records it.
+	Path string
+	// Branch is the short branch name checked out there, empty when detached.
+	Branch string
+	// Head is the commit the worktree points at.
+	Head string
+	// Detached reports a HEAD that is not on a branch.
+	Detached bool
+	// Bare reports a bare main repository (which has no work tree).
+	Bare bool
+	// Main reports the main worktree, which git always lists first.
+	Main bool
+}
+
+// ListWorktrees returns every worktree registered with the repository, the main
+// one first.
+//
+// It parses `git worktree list --porcelain`: blank-line-separated records whose
+// lines are `worktree <abs-path>`, `HEAD <sha>`, and then either
+// `branch refs/heads/<name>` or `detached`, plus `bare` for a bare main
+// repository. Any other line is ignored on purpose — git adds annotations over
+// time (`locked`, `prunable`, …) and depending on them would tie git-flow to a
+// git newer than the documented 2.17+ floor. Stale entries are therefore
+// reported like any other until `git worktree prune` runs.
+func (r *Repo) ListWorktrees() ([]WorktreeEntry, error) {
+	output, err := r.gitCmd("worktree", "list", "--porcelain").Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list worktrees: %w", err)
+	}
+	return parseWorktreePorcelain(string(output)), nil
+}
+
+// parseWorktreePorcelain turns porcelain output into entries. A record starts at
+// each `worktree ` line, so no blank-line bookkeeping is needed.
+func parseWorktreePorcelain(output string) []WorktreeEntry {
+	var entries []WorktreeEntry
+	var current *WorktreeEntry
+
+	flush := func() {
+		if current != nil {
+			entries = append(entries, *current)
+			current = nil
+		}
+	}
+
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimRight(line, "\r")
+		switch {
+		case strings.HasPrefix(line, "worktree "):
+			flush()
+			current = &WorktreeEntry{
+				Path: filepath.Clean(strings.TrimPrefix(line, "worktree ")),
+				Main: len(entries) == 0,
+			}
+		case current == nil:
+			// Anything before the first record header is not ours to interpret.
+			continue
+		case strings.HasPrefix(line, "HEAD "):
+			current.Head = strings.TrimPrefix(line, "HEAD ")
+		case strings.HasPrefix(line, "branch "):
+			current.Branch = strings.TrimPrefix(strings.TrimPrefix(line, "branch "), "refs/heads/")
+		case line == "detached":
+			current.Detached = true
+		case line == "bare":
+			current.Bare = true
+		}
+	}
+	flush()
+
+	return entries
+}
+
+// WorktreeForBranch returns the worktree that has branch checked out, or
+// (nil, nil) when no worktree holds it. The branch match is exact and
+// case-sensitive; the returned entry may be the main worktree, which callers
+// distinguish through its Main field.
+func (r *Repo) WorktreeForBranch(branch string) (*WorktreeEntry, error) {
+	entries, err := r.ListWorktrees()
+	if err != nil {
+		return nil, err
+	}
+	for i := range entries {
+		if entries[i].Branch == branch {
+			return &entries[i], nil
+		}
+	}
+	return nil, nil
+}
+
+// AddWorktree creates a linked worktree at path with branch checked out. The
+// branch must exist and must not be checked out anywhere else; callers are
+// expected to have verified both, so a failure here is reported with git's own
+// output (git writes progress to stderr even when it fails).
+func (r *Repo) AddWorktree(path string, branch string) error {
+	output, err := r.gitCmd("worktree", "add", path, branch).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to add worktree at %s: %s", path, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// RemoveWorktree removes the linked worktree at path, refusing the main worktree
+// before invoking git at all. force passes --force, which git requires for a
+// worktree with uncommitted or untracked changes.
+func (r *Repo) RemoveWorktree(path string, force bool) error {
+	if err := r.refuseMainWorktree(path, "remove"); err != nil {
+		return err
+	}
+
+	args := []string{"worktree", "remove"}
+	if force {
+		args = append(args, "--force")
+	}
+	args = append(args, path)
+
+	output, err := r.gitCmd(args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to remove worktree at %s: %s", path, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// PruneWorktrees drops the admin entries of worktrees whose directories are gone.
+func (r *Repo) PruneWorktrees() error {
+	output, err := r.gitCmd("worktree", "prune").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to prune worktrees: %s", strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// DetachWorktree detaches the HEAD of the worktree at path from its branch,
+// leaving the tree and any uncommitted work untouched and freeing the branch for
+// checkout elsewhere. It refuses the main worktree. `checkout --detach` is used
+// rather than `switch --detach`, which needs git 2.23.
+func (r *Repo) DetachWorktree(path string) error {
+	if err := r.refuseMainWorktree(path, "detach"); err != nil {
+		return err
+	}
+
+	output, err := gitCommand(path, "checkout", "--detach").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to detach worktree at %s: %s", path, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// WorktreeHasChanges reports whether the worktree at path has uncommitted or
+// untracked changes. It runs `git status --porcelain` with path as the working
+// directory — not this handle's work tree — so it answers for the worktree being
+// asked about rather than the one the command was invoked from.
+func (r *Repo) WorktreeHasChanges(path string) (bool, error) {
+	output, err := gitCommand(path, "status", "--porcelain").Output()
+	if err != nil {
+		return false, fmt.Errorf("failed to check status of worktree at %s: %w", path, err)
+	}
+	return strings.TrimSpace(string(output)) != "", nil
+}
+
+// refuseMainWorktree returns an error when path is the repository's main
+// worktree. The main worktree holds the repository itself, so removing or
+// detaching it is never what the user meant.
+func (r *Repo) refuseMainWorktree(path string, operation string) error {
+	mainWorkTree, err := r.MainWorkTree()
+	if err != nil {
+		return err
+	}
+	if SamePath(path, mainWorkTree) {
+		return fmt.Errorf("refusing to %s the main worktree at %s", operation, mainWorkTree)
+	}
+	return nil
+}
+
+// SamePath reports whether two paths denote the same location, resolving
+// symlinks on BOTH sides. This matters on macOS, where a temporary directory is
+// reached through /var while git records the real /private/var path.
+func SamePath(a, b string) bool {
+	return resolvePath(a) == resolvePath(b)
+}
+
+// IsWithin reports whether child is parent or lives underneath it, comparing on
+// a separator boundary so /a/foobar is not treated as being inside /a/foo. Both
+// sides are symlink-resolved.
+func IsWithin(child, parent string) bool {
+	c, p := resolvePath(child), resolvePath(parent)
+	if c == p {
+		return true
+	}
+	return strings.HasPrefix(c, p+string(filepath.Separator))
+}
+
+// resolvePath returns an absolute, symlink-resolved form of p, tolerating a path
+// that does not exist: filepath.EvalSymlinks fails outright on a missing path, so
+// the deepest existing ancestor is resolved and the remainder appended. Paths
+// under comparison here routinely do not exist yet (a computed worktree path) or
+// no longer exist (a stale worktree entry).
+func resolvePath(p string) string {
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		abs = filepath.Clean(p)
+	}
+
+	current := abs
+	remainder := ""
+	for {
+		resolved, err := filepath.EvalSymlinks(current)
+		if err == nil {
+			if remainder == "" {
+				return filepath.Clean(resolved)
+			}
+			return filepath.Join(resolved, remainder)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return abs
+		}
+		remainder = filepath.Join(filepath.Base(current), remainder)
+		current = parent
+	}
+}

--- a/internal/navigate/cdfile.go
+++ b/internal/navigate/cdfile.go
@@ -1,0 +1,65 @@
+// Package navigate implements the channel git-flow uses to hand a destination
+// directory back to the calling shell.
+//
+// git-flow runs as a subprocess and cannot change its parent shell's working
+// directory. A command that would move the user therefore writes its destination
+// to the file named by GIT_FLOW_CD_FILE, and the shell wrapper changes directory
+// when that file is non-empty. The variable is an input git-flow reads, never one
+// it sets: it describes one invocation's calling environment, not a repository
+// preference, which is why it is not a git config key.
+package navigate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// EnvVar names the environment variable holding the destination file.
+const EnvVar = "GIT_FLOW_CD_FILE"
+
+// DestinationFile returns the absolute path of the file to write the destination
+// to, or "" when the channel is not in use.
+//
+// Resolve this BEFORE an operation that may delete the current working directory
+// (removing the worktree the user is standing in): a relative destination can
+// only be made absolute while that directory still exists.
+func DestinationFile() string {
+	file := strings.TrimSpace(os.Getenv(EnvVar))
+	if file == "" {
+		return ""
+	}
+	if abs, err := filepath.Abs(file); err == nil {
+		return abs
+	}
+	return file
+}
+
+// WriteDestination writes path as the destination for the calling shell. It is a
+// no-op when the channel is not in use.
+//
+// Call it only AFTER the operation it follows has succeeded, so a refused or
+// failed command leaves the file empty.
+func WriteDestination(path string) error {
+	return WriteDestinationTo(DestinationFile(), path)
+}
+
+// WriteDestinationTo writes path to a destination file resolved earlier by
+// DestinationFile. An empty file argument is a no-op, so callers need no
+// conditional of their own.
+func WriteDestinationTo(file string, path string) error {
+	if file == "" {
+		return nil
+	}
+
+	destination := path
+	if abs, err := filepath.Abs(path); err == nil {
+		destination = abs
+	}
+
+	if err := os.WriteFile(file, []byte(destination+"\n"), 0644); err != nil {
+		return fmt.Errorf("failed to write navigation destination to %s: %w", file, err)
+	}
+	return nil
+}

--- a/internal/navigate/cdfile.go
+++ b/internal/navigate/cdfile.go
@@ -3,10 +3,10 @@
 //
 // git-flow runs as a subprocess and cannot change its parent shell's working
 // directory. A command that would move the user therefore writes its destination
-// to the file named by GIT_FLOW_CD_FILE, and the shell wrapper changes directory
-// when that file is non-empty. The variable is an input git-flow reads, never one
-// it sets: it describes one invocation's calling environment, not a repository
-// preference, which is why it is not a git config key.
+// to the file named by GIT_FLOW_CD_FILE, leaving the caller that set the variable
+// to read the file and change directory itself. The variable is an input git-flow
+// reads, never one it sets: it describes one invocation's calling environment,
+// not a repository preference, which is why it is not a git config key.
 package navigate
 
 import (

--- a/internal/worktree/path.go
+++ b/internal/worktree/path.go
@@ -133,13 +133,21 @@ func splitTopicBranch(cfg *config.Config, branch string) (topicType string, bran
 	return topicType, branchName
 }
 
-// tildeRest reports whether path is home-rooted ("~" or "~/…") and returns the
-// part after the tilde. A "~user" form is deliberately not expanded: git-flow
-// has no portable way to resolve another user's home, and leaving it alone is
-// better than silently rooting it in the current user's home.
+// tildeRest reports whether path is home-rooted ("~" or "~" followed by a host
+// path separator) and returns the part after the tilde. os.IsPathSeparator does
+// the separator test so a Windows user can write '~\wt\{{ branch }}' and get the
+// same expansion as '~/wt/{{ branch }}', while on Unix a backslash stays what it
+// is there — an ordinary character in a filename.
+//
+// A "~user" form is deliberately not expanded: git-flow has no portable way to
+// resolve another user's home, and leaving it alone is better than silently
+// rooting it in the current user's home.
 func tildeRest(path string) (rest string, ok bool) {
-	if path != "~" && !strings.HasPrefix(path, "~/") {
+	if path == "~" {
+		return "", true
+	}
+	if len(path) < 2 || path[0] != '~' || !os.IsPathSeparator(path[1]) {
 		return "", false
 	}
-	return strings.TrimPrefix(strings.TrimPrefix(path, "~"), "/"), true
+	return path[2:], true
 }

--- a/internal/worktree/path.go
+++ b/internal/worktree/path.go
@@ -1,0 +1,144 @@
+// Package worktree computes where a branch's worktree belongs and records which
+// worktrees git-flow created.
+package worktree
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/gittower/git-flow-next/internal/config"
+	"github.com/gittower/git-flow-next/internal/git"
+)
+
+// DefaultTemplate is the path template used when gitflow.worktreePath is unset
+// or empty: a sibling directory of the repository, one subdirectory per branch.
+const DefaultTemplate = "../{{ repo }}-worktrees/{{ branch }}"
+
+// TemplateConfigKey is the git config key holding the path template.
+const TemplateConfigKey = "gitflow.worktreePath"
+
+// placeholderPattern matches {{ name }} and {{name}} alike, so both brace forms
+// expand identically. This is deliberately not internal/util's %b/%p placeholder
+// syntax, which serves hook and tag-message expansion.
+var placeholderPattern = regexp.MustCompile(`\{\{\s*(\w+)\s*\}\}`)
+
+// ComputePath returns the absolute path where branch's worktree belongs,
+// according to the gitflow.worktreePath template.
+//
+// The template supports {{ repo }} (the main worktree's directory name),
+// {{ branch }} (the full branch name), {{ branchName }} (the branch without its
+// topic prefix), and {{ topicType }} (the topic branch type, empty for a
+// non-topic branch). A leading ~ expands to the user's home directory; a
+// relative template resolves against the MAIN worktree root, not the current
+// one. The result is always absolute and uses host path separators.
+//
+// It has no side effects: nothing is created, not even parent directories.
+func ComputePath(cfg *config.Config, repo *git.Repo, branch string) (string, error) {
+	if strings.TrimSpace(branch) == "" {
+		return "", fmt.Errorf("branch name must not be empty")
+	}
+
+	mainWorkTree, err := repo.MainWorkTree()
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve the main worktree: %w", err)
+	}
+
+	topicType, branchName := splitTopicBranch(cfg, branch)
+	expanded := placeholderPattern.ReplaceAllStringFunc(resolveTemplate(cfg, repo), func(match string) string {
+		switch placeholderPattern.FindStringSubmatch(match)[1] {
+		case "repo":
+			return filepath.Base(mainWorkTree)
+		case "branch":
+			return branch
+		case "branchName":
+			return branchName
+		case "topicType":
+			return topicType
+		default:
+			// Unknown variables are left verbatim rather than silently dropped,
+			// so a typo shows up in the path instead of vanishing.
+			return match
+		}
+	})
+
+	// An empty {{ topicType }} leaves a doubled or trailing separator behind;
+	// filepath.Join and filepath.Clean both collapse it.
+	if rest, ok := tildeRest(expanded); ok {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to expand '~' in path template: %w", err)
+		}
+		return filepath.Join(home, filepath.FromSlash(rest)), nil
+	}
+
+	path := filepath.FromSlash(expanded)
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path), nil
+	}
+	return filepath.Join(mainWorkTree, path), nil
+}
+
+// resolveTemplate returns the configured path template, or DefaultTemplate when
+// it is unset or empty.
+//
+// The key is read case-insensitively on purpose: a direct `git config --get`
+// honors the camelCase spelling, but git lowercases variable names in
+// --get-regexp output, so the same key arrives in cfg.CommandConfig as
+// "gitflow.worktreepath". Falling back to a case-insensitive scan of the loaded
+// config keeps both spellings working.
+func resolveTemplate(cfg *config.Config, repo *git.Repo) string {
+	if value, err := repo.GetConfig(TemplateConfigKey); err == nil && strings.TrimSpace(value) != "" {
+		return strings.TrimSpace(value)
+	}
+	if cfg != nil {
+		for key, value := range cfg.CommandConfig {
+			if strings.EqualFold(key, TemplateConfigKey) && strings.TrimSpace(value) != "" {
+				return strings.TrimSpace(value)
+			}
+		}
+	}
+	return DefaultTemplate
+}
+
+// splitTopicBranch reports the topic branch type whose prefix matches branch and
+// the branch name with that prefix removed. A non-topic branch yields an empty
+// type and the branch name unchanged. The longest matching prefix wins (with the
+// type name as a tie-break) so nested prefixes resolve deterministically.
+func splitTopicBranch(cfg *config.Config, branch string) (topicType string, branchName string) {
+	branchName = branch
+	if cfg == nil {
+		return "", branchName
+	}
+
+	longest := 0
+	for name, branchConfig := range cfg.Branches {
+		if branchConfig.Type != string(config.BranchTypeTopic) || branchConfig.Prefix == "" {
+			continue
+		}
+		if !strings.HasPrefix(branch, branchConfig.Prefix) {
+			continue
+		}
+		length := len(branchConfig.Prefix)
+		if length < longest || (length == longest && name >= topicType) {
+			continue
+		}
+		longest = length
+		topicType = name
+		branchName = strings.TrimPrefix(branch, branchConfig.Prefix)
+	}
+	return topicType, branchName
+}
+
+// tildeRest reports whether path is home-rooted ("~" or "~/…") and returns the
+// part after the tilde. A "~user" form is deliberately not expanded: git-flow
+// has no portable way to resolve another user's home, and leaving it alone is
+// better than silently rooting it in the current user's home.
+func tildeRest(path string) (rest string, ok bool) {
+	if path != "~" && !strings.HasPrefix(path, "~/") {
+		return "", false
+	}
+	return strings.TrimPrefix(strings.TrimPrefix(path, "~"), "/"), true
+}

--- a/internal/worktree/path.go
+++ b/internal/worktree/path.go
@@ -64,8 +64,6 @@ func ComputePath(cfg *config.Config, repo *git.Repo, branch string) (string, err
 		}
 	})
 
-	// An empty {{ topicType }} leaves a doubled or trailing separator behind;
-	// filepath.Join and filepath.Clean both collapse it.
 	if rest, ok := tildeRest(expanded); ok {
 		home, err := os.UserHomeDir()
 		if err != nil {
@@ -74,6 +72,9 @@ func ComputePath(cfg *config.Config, repo *git.Repo, branch string) (string, err
 		return filepath.Join(home, filepath.FromSlash(rest)), nil
 	}
 
+	// Each of the three returns below normalizes the expanded template: an empty
+	// {{ topicType }} leaves a doubled or trailing separator behind, and
+	// filepath.Join and filepath.Clean both collapse it.
 	path := filepath.FromSlash(expanded)
 	if filepath.IsAbs(path) {
 		return filepath.Clean(path), nil

--- a/internal/worktree/provenance.go
+++ b/internal/worktree/provenance.go
@@ -44,8 +44,14 @@ func MarkManaged(repo *git.Repo, branch string) error {
 // Provenance is never inferred by comparing a worktree's path against the
 // template: --path and any later change to gitflow.worktreePath both break that
 // correspondence.
+//
+// The read is LOCAL-scoped, matching MarkManaged, ClearMarker and ListMarkers.
+// Reading merged config would let a stray global or system
+// gitflow.worktree.<branch>.managed make a hand-made worktree report as
+// git-flow's — and since clearing only touches local scope, that marker could
+// never be cleared, so the cleanup commands would delete the user's own worktree.
 func IsManaged(repo *git.Repo, branch string) bool {
-	value, err := repo.GetConfig(MarkerKey(branch))
+	value, err := repo.GetConfigLocal(MarkerKey(branch))
 	return err == nil && config.ParseBool(value)
 }
 

--- a/internal/worktree/provenance.go
+++ b/internal/worktree/provenance.go
@@ -1,0 +1,117 @@
+package worktree
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/gittower/git-flow-next/internal/config"
+	"github.com/gittower/git-flow-next/internal/git"
+)
+
+// markerKeyPrefix and markerKeySuffix bracket the branch name in a provenance
+// marker key. Git treats everything between the first and last dot as the
+// subsection, so a branch name containing slashes or dots survives round-tripping
+// and keeps its case.
+const (
+	markerKeyPrefix = "gitflow.worktree."
+	markerKeySuffix = ".managed"
+)
+
+// markerKeyPattern matches a marker key and captures its branch name. Git
+// lowercases the section and the final key in --get-regexp output but preserves
+// the subsection, so only the branch name carries the author's casing.
+var markerKeyPattern = regexp.MustCompile(`^gitflow\.worktree\.(.+)\.managed$`)
+
+// MarkerKey returns the git config key that records git-flow as the creator of
+// branch's worktree.
+func MarkerKey(branch string) string {
+	return markerKeyPrefix + branch + markerKeySuffix
+}
+
+// MarkManaged records that git-flow created the worktree for branch. The marker
+// is repository-local state, never a user setting: it is excluded from the
+// shared-config set so it can never reach a committed .gitflow.
+func MarkManaged(repo *git.Repo, branch string) error {
+	if err := repo.SetConfig(MarkerKey(branch), "true"); err != nil {
+		return fmt.Errorf("failed to record worktree provenance for '%s': %w", branch, err)
+	}
+	return nil
+}
+
+// IsManaged reports whether git-flow created the worktree for branch.
+//
+// Provenance is never inferred by comparing a worktree's path against the
+// template: --path and any later change to gitflow.worktreePath both break that
+// correspondence.
+func IsManaged(repo *git.Repo, branch string) bool {
+	value, err := repo.GetConfig(MarkerKey(branch))
+	return err == nil && config.ParseBool(value)
+}
+
+// ClearMarker drops branch's provenance marker, tolerating an absent key.
+func ClearMarker(repo *git.Repo, branch string) error {
+	if err := repo.UnsetConfigIfPresent(MarkerKey(branch)); err != nil {
+		return fmt.Errorf("failed to clear worktree provenance for '%s': %w", branch, err)
+	}
+	return nil
+}
+
+// ListMarkers returns the branch names that carry a provenance marker, read from
+// local config only — the scope markers are written to.
+func ListMarkers(repo *git.Repo) ([]string, error) {
+	lines, err := repo.GetConfigLocalRegexpLines(`^gitflow\.worktree\..*\.managed$`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list worktree provenance markers: %w", err)
+	}
+
+	var branches []string
+	seen := map[string]bool{}
+	for _, line := range lines {
+		key := strings.SplitN(strings.TrimSpace(line), " ", 2)[0]
+		match := markerKeyPattern.FindStringSubmatch(key)
+		if match == nil || seen[match[1]] {
+			continue
+		}
+		seen[match[1]] = true
+		branches = append(branches, match[1])
+	}
+	return branches, nil
+}
+
+// SweepMarkers drops every marker whose branch has no live worktree, so markers
+// never outlive what they describe. Call it after PruneWorktrees, once the stale
+// admin entries are gone.
+//
+// The sweep is keyed on the BRANCH, not the worktree path, so a worktree that
+// was detached from its branch also loses its marker even though its directory
+// survives. That fails safe: a branch-keyed marker that outlived the detach
+// could later be inherited by a worktree the user created by hand for the same
+// branch, and the cleanup commands would then delete their work. The worst case
+// this way round is a git-flow-created worktree being left alone.
+func SweepMarkers(repo *git.Repo) error {
+	entries, err := repo.ListWorktrees()
+	if err != nil {
+		return err
+	}
+	live := make(map[string]bool, len(entries))
+	for _, entry := range entries {
+		if entry.Branch != "" {
+			live[entry.Branch] = true
+		}
+	}
+
+	markers, err := ListMarkers(repo)
+	if err != nil {
+		return err
+	}
+	for _, branch := range markers {
+		if live[branch] {
+			continue
+		}
+		if err := ClearMarker(repo, branch); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/test/cmd/worktree_test.go
+++ b/test/cmd/worktree_test.go
@@ -924,14 +924,18 @@ func TestWorktreeRemoveWithoutWorktree(t *testing.T) {
 // TestWorktreeRemoveRefusesMainWorktree covers scenario 16: the main worktree is
 // never removed, and that refusal beats the "nothing to remove" path.
 // Steps:
-// 1. Sets up a repository with main checked out in the main worktree
-// 2. Runs 'git flow worktree remove main'
-// 3. Verifies exit code 6 and a message about the main worktree
-// 4. Verifies the repository directory still exists and is a worktree
+//  1. Sets up a repository and checks out main in the main worktree
+//     ('git flow init' leaves develop checked out, so this is explicit)
+//  2. Runs 'git flow worktree remove main'
+//  3. Verifies exit code 6 and a message about the main worktree
+//  4. Verifies the repository directory still exists and is a worktree
 func TestWorktreeRemoveRefusesMainWorktree(t *testing.T) {
 	t.Parallel()
 	dir := initWorktreeRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
+	if out, err := testutil.RunGit(t, dir, "checkout", "main"); err != nil {
+		t.Fatalf("Failed to check out main: %v\nOutput: %s", err, out)
+	}
 
 	output, err := testutil.RunGitFlow(t, dir, "worktree", "remove", "main")
 	if got := worktreeExitCode(err); got != 6 {

--- a/test/cmd/worktree_test.go
+++ b/test/cmd/worktree_test.go
@@ -1,0 +1,1613 @@
+package cmd_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// worktreeExitCode returns the process exit code carried by a testutil.ExitError,
+// 0 for a nil error, or -1 for any other error type.
+func worktreeExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	if ee, ok := err.(*testutil.ExitError); ok {
+		return ee.ExitCode
+	}
+	return -1
+}
+
+// worktreeRootFor returns the directory the default path template puts worktrees
+// in: a sibling of the repository named "<repo>-worktrees". It lives OUTSIDE the
+// test repository, so testutil.CleanupTestRepo (a plain RemoveAll of the repo
+// directory) never touches it — every test that creates a worktree at the
+// computed path must remove this root itself.
+func worktreeRootFor(dir string) string {
+	return dir + "-worktrees"
+}
+
+// computedWorktreePath returns the path the default template
+// (../{{ repo }}-worktrees/{{ branch }}) computes for branch in the repository at
+// dir. The repository root is symlink-resolved because git reports the resolved
+// form, and the (possibly not yet created) remainder is appended with Join —
+// filepath.EvalSymlinks fails on a path that does not exist, so it must never be
+// applied to the leaf.
+func computedWorktreePath(t *testing.T, dir string, branch string) string {
+	t.Helper()
+	root := testutil.EvalPath(t, dir)
+	return filepath.Join(filepath.Dir(root), filepath.Base(root)+"-worktrees", filepath.FromSlash(branch))
+}
+
+// initWorktreeRepo creates a temporary repository with git-flow initialized to
+// its defaults.
+func initWorktreeRepo(t *testing.T) string {
+	t.Helper()
+	dir := testutil.SetupTestRepo(t)
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		testutil.CleanupTestRepo(t, dir)
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+	return dir
+}
+
+// addWorktree runs 'git flow worktree add <branch>' and returns the computed path
+// the worktree was created at.
+func addWorktree(t *testing.T, dir string, branch string) string {
+	t.Helper()
+	if out, err := testutil.RunGitFlow(t, dir, "worktree", "add", branch); err != nil {
+		t.Fatalf("Failed to add worktree for %s: %v\nOutput: %s", branch, err, out)
+	}
+	return computedWorktreePath(t, dir, branch)
+}
+
+// createFreeBranch creates branch off main without checking it out, so a worktree
+// can be added for it.
+func createFreeBranch(t *testing.T, dir string, branch string) {
+	t.Helper()
+	if out, err := testutil.RunGit(t, dir, "branch", branch, "main"); err != nil {
+		t.Fatalf("Failed to create branch %s: %v\nOutput: %s", branch, err, out)
+	}
+}
+
+// cdFilePath creates an empty file in a temporary directory and returns its path,
+// for use as GIT_FLOW_CD_FILE. Zero length is the pre-state every navigation
+// assertion compares against.
+func cdFilePath(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "cd-destination")
+	if err := os.WriteFile(path, nil, 0644); err != nil {
+		t.Fatalf("Failed to create CD file: %v", err)
+	}
+	return path
+}
+
+// cdEnv builds the subprocess environment that points GIT_FLOW_CD_FILE at path.
+func cdEnv(path string) []string {
+	return []string{"GIT_FLOW_CD_FILE=" + path}
+}
+
+// readCDFile returns the trimmed content of the navigation destination file.
+func readCDFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed to read CD file %s: %v", path, err)
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// assertCDFileEmpty fails the test unless the navigation destination file is
+// still zero-length.
+func assertCDFileEmpty(t *testing.T, path string) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Failed to stat CD file %s: %v", path, err)
+	}
+	if info.Size() != 0 {
+		t.Errorf("Expected CD file to stay empty, got %q", readCDFile(t, path))
+	}
+}
+
+// worktreeRows splits 'git flow worktree list' output into its non-empty rows.
+func worktreeRows(output string) []string {
+	var rows []string
+	for _, line := range strings.Split(output, "\n") {
+		if strings.TrimSpace(line) != "" {
+			rows = append(rows, strings.TrimSpace(line))
+		}
+	}
+	return rows
+}
+
+// gitWorktreeList returns the raw output of 'git worktree list' for the repo.
+func gitWorktreeList(t *testing.T, dir string) string {
+	t.Helper()
+	out, err := testutil.RunGit(t, dir, "worktree", "list")
+	if err != nil {
+		t.Fatalf("git worktree list failed: %v\nOutput: %s", err, out)
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Group A — path computation (CLI level)
+// ---------------------------------------------------------------------------
+
+// TestWorktreePathDefaultTemplate covers scenario 1: the default template
+// resolves to an absolute sibling directory of the repository.
+// Steps:
+// 1. Sets up a repository with git-flow defaults and a feature/user-auth branch
+// 2. Leaves gitflow.worktreePath unset
+// 3. Runs 'git flow worktree path feature/user-auth'
+// 4. Verifies stdout is exactly <repoParent>/<repo>-worktrees/feature/user-auth
+func TestWorktreePathDefaultTemplate(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	createFreeBranch(t, dir, "feature/user-auth")
+
+	stdout, stderr, err := testutil.RunGitFlowStreams(t, dir, "worktree", "path", "feature/user-auth")
+	if err != nil {
+		t.Fatalf("worktree path failed: %v\nStderr: %s", err, stderr)
+	}
+
+	want := computedWorktreePath(t, dir, "feature/user-auth") + "\n"
+	if stdout != want {
+		t.Errorf("Expected stdout %q, got %q", want, stdout)
+	}
+}
+
+// TestWorktreePathTildeTemplateWithBranchName covers scenario 2: a ~-rooted
+// template expands to the home directory and {{ branchName }} drops the prefix.
+// Steps:
+// 1. Sets gitflow.worktreePath to '~/wt/{{ branchName }}' (camelCase key on purpose)
+// 2. Creates branch feature/user-auth
+// 3. Runs 'git flow worktree path feature/user-auth' with HOME overridden
+// 4. Verifies the output is <HOME>/wt/user-auth, compared against the raw HOME value
+func TestWorktreePathTildeTemplateWithBranchName(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	createFreeBranch(t, dir, "feature/user-auth")
+
+	if out, err := testutil.RunGit(t, dir, "config", "gitflow.worktreePath", "~/wt/{{ branchName }}"); err != nil {
+		t.Fatalf("Failed to set gitflow.worktreePath: %v\nOutput: %s", err, out)
+	}
+
+	home := t.TempDir()
+	output, err := testutil.RunGitFlowWithEnv(t, dir, []string{"HOME=" + home}, "worktree", "path", "feature/user-auth")
+	if err != nil {
+		t.Fatalf("worktree path failed: %v\nOutput: %s", err, output)
+	}
+
+	// os.UserHomeDir returns the HOME string verbatim, so the expectation is
+	// deliberately NOT symlink-resolved on either side.
+	want := filepath.Join(home, "wt", "user-auth")
+	if got := strings.TrimSpace(output); got != want {
+		t.Errorf("Expected path %q, got %q", want, got)
+	}
+}
+
+// TestWorktreePathTopicTypeAndUnspacedForms covers scenario 3: {{ topicType }}
+// expands to the topic branch type and unspaced placeholders behave identically.
+// Steps:
+// 1. Sets gitflow.worktreePath to '../wt/{{topicType}}/{{ branch }}'
+// 2. Runs 'git flow worktree path feature/user-auth'
+// 3. Verifies the result is <repoParent>/wt/feature/feature/user-auth
+// 4. Repeats with the spaced/unspaced forms swapped and requires identical output
+func TestWorktreePathTopicTypeAndUnspacedForms(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	createFreeBranch(t, dir, "feature/user-auth")
+
+	if out, err := testutil.RunGit(t, dir, "config", "gitflow.worktreePath", "../wt/{{topicType}}/{{ branch }}"); err != nil {
+		t.Fatalf("Failed to set gitflow.worktreePath: %v\nOutput: %s", err, out)
+	}
+
+	unspaced, err := testutil.RunGitFlow(t, dir, "worktree", "path", "feature/user-auth")
+	if err != nil {
+		t.Fatalf("worktree path failed: %v\nOutput: %s", err, unspaced)
+	}
+
+	repoParent := filepath.Dir(testutil.EvalPath(t, dir))
+	want := filepath.Join(repoParent, "wt", "feature", "feature", "user-auth")
+	if got := strings.TrimSpace(unspaced); got != want {
+		t.Errorf("Expected path %q, got %q", want, got)
+	}
+
+	if out, err := testutil.RunGit(t, dir, "config", "gitflow.worktreePath", "../wt/{{ topicType }}/{{branch}}"); err != nil {
+		t.Fatalf("Failed to set gitflow.worktreePath: %v\nOutput: %s", err, out)
+	}
+	spaced, err := testutil.RunGitFlow(t, dir, "worktree", "path", "feature/user-auth")
+	if err != nil {
+		t.Fatalf("worktree path failed: %v\nOutput: %s", err, spaced)
+	}
+	if spaced != unspaced {
+		t.Errorf("Expected spaced and unspaced templates to expand identically, got %q vs %q", spaced, unspaced)
+	}
+}
+
+// TestWorktreePathHasNoSideEffects covers scenario 20: 'worktree path' prints
+// only, and creates nothing.
+// Steps:
+// 1. Sets up a repository with a feature/x branch and no worktree
+// 2. Runs 'git flow worktree path feature/x'
+// 3. Verifies the printed path and its parent do not exist
+// 4. Verifies git worktree list shows only the main worktree and no marker was written
+func TestWorktreePathHasNoSideEffects(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "path", "feature/x")
+	if err != nil {
+		t.Fatalf("worktree path failed: %v\nOutput: %s", err, output)
+	}
+	printed := strings.TrimSpace(output)
+
+	if _, err := os.Stat(printed); !os.IsNotExist(err) {
+		t.Errorf("Expected printed path %q not to exist", printed)
+	}
+	if _, err := os.Stat(filepath.Dir(printed)); !os.IsNotExist(err) {
+		t.Errorf("Expected parent of printed path %q not to exist", filepath.Dir(printed))
+	}
+	if rows := strings.Count(strings.TrimSpace(gitWorktreeList(t, dir)), "\n"); rows != 0 {
+		t.Errorf("Expected only the main worktree, got: %s", gitWorktreeList(t, dir))
+	}
+	if testutil.GitConfigExists(t, dir, "gitflow.worktree.feature/x.managed") {
+		t.Error("Expected no managed marker after 'worktree path'")
+	}
+}
+
+// TestWorktreePathEmptyTemplateFallsBackToDefault verifies an empty
+// gitflow.worktreePath falls back to the default template rather than resolving
+// to the main worktree root.
+// Steps:
+// 1. Sets gitflow.worktreePath to the empty string
+// 2. Runs 'git flow worktree path feature/x'
+// 3. Verifies the output equals the default-template result
+func TestWorktreePathEmptyTemplateFallsBackToDefault(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	createFreeBranch(t, dir, "feature/x")
+
+	if out, err := testutil.RunGit(t, dir, "config", "gitflow.worktreePath", ""); err != nil {
+		t.Fatalf("Failed to set gitflow.worktreePath: %v\nOutput: %s", err, out)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "path", "feature/x")
+	if err != nil {
+		t.Fatalf("worktree path failed: %v\nOutput: %s", err, output)
+	}
+
+	want := computedWorktreePath(t, dir, "feature/x")
+	if got := strings.TrimSpace(output); got != want {
+		t.Errorf("Expected empty template to fall back to %q, got %q", want, got)
+	}
+}
+
+// TestWorktreePathNonTopicBranchCollapsesSeparator verifies that an empty
+// {{ topicType }} expansion collapses the separator it leaves behind.
+// Steps:
+// 1. Sets gitflow.worktreePath to '../wt/{{ topicType }}/{{ branch }}'
+// 2. Runs 'git flow worktree path main' (main is not a topic branch)
+// 3. Verifies the result is <repoParent>/wt/main with no doubled separator
+func TestWorktreePathNonTopicBranchCollapsesSeparator(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if out, err := testutil.RunGit(t, dir, "config", "gitflow.worktreePath", "../wt/{{ topicType }}/{{ branch }}"); err != nil {
+		t.Fatalf("Failed to set gitflow.worktreePath: %v\nOutput: %s", err, out)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "path", "main")
+	if err != nil {
+		t.Fatalf("worktree path failed: %v\nOutput: %s", err, output)
+	}
+
+	want := filepath.Join(filepath.Dir(testutil.EvalPath(t, dir)), "wt", "main")
+	if got := strings.TrimSpace(output); got != want {
+		t.Errorf("Expected %q, got %q", want, got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Group A — the initialization gate, on every subcommand
+// ---------------------------------------------------------------------------
+
+// TestWorktreePathRequiresInitialization verifies 'worktree path' refuses to run
+// in a repository where git-flow was never initialized.
+// Steps:
+// 1. Sets up a plain git repository without running 'git flow init'
+// 2. Runs 'git flow worktree path main'
+// 3. Verifies exit code 1 and a not-initialized message
+func TestWorktreePathRequiresInitialization(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "path", "main")
+	if got := worktreeExitCode(err); got != 1 {
+		t.Fatalf("Expected exit code 1, got %d\nOutput: %s", got, output)
+	}
+	if !strings.Contains(output, "not initialized") {
+		t.Errorf("Expected a not-initialized message, got: %s", output)
+	}
+}
+
+// TestWorktreeAddRequiresInitialization verifies 'worktree add' refuses to run in
+// an uninitialized repository and mutates nothing.
+// Steps:
+// 1. Sets up a plain git repository with a feature/x branch, no 'git flow init'
+// 2. Runs 'git flow worktree add feature/x'
+// 3. Verifies exit code 1
+// 4. Verifies no worktree was created and no gitflow.worktree.* key was written
+func TestWorktreeAddRequiresInitialization(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "add", "feature/x")
+	if got := worktreeExitCode(err); got != 1 {
+		t.Fatalf("Expected exit code 1, got %d\nOutput: %s", got, output)
+	}
+	if _, err := os.Stat(worktreeRootFor(dir)); !os.IsNotExist(err) {
+		t.Errorf("Expected no worktree root at %q", worktreeRootFor(dir))
+	}
+	if testutil.GitConfigHasPrefix(t, dir, "gitflow.worktree.") {
+		t.Error("Expected no gitflow.worktree.* key to be written")
+	}
+}
+
+// TestWorktreeRemoveRequiresInitialization verifies 'worktree remove' refuses to
+// run in an uninitialized repository.
+// Steps:
+// 1. Sets up a plain git repository with a feature/x branch, no 'git flow init'
+// 2. Runs 'git flow worktree remove feature/x'
+// 3. Verifies exit code 1 and a not-initialized message
+func TestWorktreeRemoveRequiresInitialization(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	createFreeBranch(t, dir, "feature/x")
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "remove", "feature/x")
+	if got := worktreeExitCode(err); got != 1 {
+		t.Fatalf("Expected exit code 1, got %d\nOutput: %s", got, output)
+	}
+	if !strings.Contains(output, "not initialized") {
+		t.Errorf("Expected a not-initialized message, got: %s", output)
+	}
+}
+
+// TestWorktreeListRequiresInitialization verifies 'worktree list' refuses to run
+// in an uninitialized repository.
+// Steps:
+// 1. Sets up a plain git repository without running 'git flow init'
+// 2. Runs 'git flow worktree list'
+// 3. Verifies exit code 1 and a not-initialized message
+func TestWorktreeListRequiresInitialization(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "list")
+	if got := worktreeExitCode(err); got != 1 {
+		t.Fatalf("Expected exit code 1, got %d\nOutput: %s", got, output)
+	}
+	if !strings.Contains(output, "not initialized") {
+		t.Errorf("Expected a not-initialized message, got: %s", output)
+	}
+}
+
+// TestWorktreePruneRequiresInitialization verifies 'worktree prune' refuses to
+// run in an uninitialized repository and leaves stale admin entries alone.
+// Steps:
+// 1. Sets up a plain git repository, adds a worktree by hand and deletes its directory
+// 2. Runs 'git flow worktree prune'
+// 3. Verifies exit code 1
+// 4. Verifies the stale admin entry is still listed by git worktree list
+func TestWorktreePruneRequiresInitialization(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	stale := filepath.Join(t.TempDir(), "stale-worktree")
+	if out, err := testutil.RunGit(t, dir, "worktree", "add", stale, "-b", "stale-branch"); err != nil {
+		t.Fatalf("Failed to create worktree: %v\nOutput: %s", err, out)
+	}
+	if err := os.RemoveAll(stale); err != nil {
+		t.Fatalf("Failed to delete worktree directory: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "prune")
+	if got := worktreeExitCode(err); got != 1 {
+		t.Fatalf("Expected exit code 1, got %d\nOutput: %s", got, output)
+	}
+	if !strings.Contains(gitWorktreeList(t, dir), "stale-branch") {
+		t.Error("Expected the stale admin entry to survive a refused prune")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Group C — worktree add
+// ---------------------------------------------------------------------------
+
+// TestWorktreeAddCreatesWorktree covers scenario 4: add creates the worktree at
+// the computed path.
+// Steps:
+// 1. Sets up a repository, runs 'git flow feature start x' and checks out main
+// 2. Runs 'git flow worktree add feature/x'
+// 3. Verifies the computed (nested) path exists and contains a .git file
+// 4. Verifies git worktree list reports the path with [feature/x]
+func TestWorktreeAddCreatesWorktree(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "add", "feature/x")
+	if err != nil {
+		t.Fatalf("worktree add failed: %v\nOutput: %s", err, output)
+	}
+
+	wtPath := computedWorktreePath(t, dir, "feature/x")
+	info, err := os.Stat(wtPath)
+	if err != nil || !info.IsDir() {
+		t.Fatalf("Expected worktree directory at %q: %v", wtPath, err)
+	}
+	if _, err := os.Stat(filepath.Join(wtPath, ".git")); err != nil {
+		t.Errorf("Expected a .git file inside the worktree: %v", err)
+	}
+
+	list := gitWorktreeList(t, dir)
+	if !strings.Contains(list, wtPath) || !strings.Contains(list, "[feature/x]") {
+		t.Errorf("Expected git worktree list to show %q with [feature/x], got: %s", wtPath, list)
+	}
+}
+
+// TestWorktreeAddWritesManagedMarker covers scenario 5: add records provenance.
+// Steps:
+// 1. Sets up a repository with a free feature/x branch
+// 2. Runs 'git flow worktree add feature/x'
+// 3. Verifies gitflow.worktree.feature/x.managed is true in local config
+func TestWorktreeAddWritesManagedMarker(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+
+	addWorktree(t, dir, "feature/x")
+
+	if v := testutil.GitConfigValue(t, dir, "gitflow.worktree.feature/x.managed"); v != "true" {
+		t.Errorf("Expected gitflow.worktree.feature/x.managed=true, got %q", v)
+	}
+}
+
+// TestWorktreeAddWithCustomPath covers scenario 6: --path overrides the template.
+// Steps:
+// 1. Sets up a repository with a free feature/x branch
+// 2. Runs 'git flow worktree add feature/x --path ./wt-custom-add'
+// 3. Verifies the worktree exists at the custom path and not at the computed path
+// 4. Verifies the provenance marker is written the same way
+func TestWorktreeAddWithCustomPath(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "add", "feature/x", "--path", "./wt-custom-add")
+	if err != nil {
+		t.Fatalf("worktree add --path failed: %v\nOutput: %s", err, output)
+	}
+
+	custom := filepath.Join(testutil.EvalPath(t, dir), "wt-custom-add")
+	if info, err := os.Stat(custom); err != nil || !info.IsDir() {
+		t.Fatalf("Expected worktree at %q: %v", custom, err)
+	}
+	if _, err := os.Stat(computedWorktreePath(t, dir, "feature/x")); !os.IsNotExist(err) {
+		t.Error("Expected the computed template path not to be used when --path is given")
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.worktree.feature/x.managed"); v != "true" {
+		t.Errorf("Expected gitflow.worktree.feature/x.managed=true, got %q", v)
+	}
+}
+
+// TestWorktreeAddNonExistentBranch covers scenario 7: add refuses an unknown branch.
+// Steps:
+// 1. Sets up a repository with git-flow defaults
+// 2. Runs 'git flow worktree add feature/nope'
+// 3. Verifies exit code 5 and an error naming the branch
+// 4. Verifies nothing was created and no marker was written
+func TestWorktreeAddNonExistentBranch(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "add", "feature/nope")
+	if got := worktreeExitCode(err); got != 5 {
+		t.Fatalf("Expected exit code 5, got %d\nOutput: %s", got, output)
+	}
+	if !strings.Contains(output, "feature/nope") {
+		t.Errorf("Expected the error to name the branch, got: %s", output)
+	}
+	if _, err := os.Stat(computedWorktreePath(t, dir, "feature/nope")); !os.IsNotExist(err) {
+		t.Error("Expected no worktree directory to be created")
+	}
+	if testutil.GitConfigHasPrefix(t, dir, "gitflow.worktree.") {
+		t.Error("Expected no gitflow.worktree.* key to be written")
+	}
+}
+
+// TestWorktreeAddWhenWorktreeAlreadyExists covers scenario 8: add refuses when a
+// worktree for the branch already exists.
+// Steps:
+// 1. Sets up a repository and adds a worktree for feature/x
+// 2. Runs 'git flow worktree add feature/x' a second time
+// 3. Verifies exit code 4 and a message naming the branch and the existing path
+// 4. Verifies the first worktree is untouched and no worktree was added
+func TestWorktreeAddWhenWorktreeAlreadyExists(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+
+	wtPath := addWorktree(t, dir, "feature/x")
+	before := gitWorktreeList(t, dir)
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "add", "feature/x")
+	if got := worktreeExitCode(err); got != 4 {
+		t.Fatalf("Expected exit code 4, got %d\nOutput: %s", got, output)
+	}
+	if !strings.Contains(output, "feature/x") || !strings.Contains(output, wtPath) {
+		t.Errorf("Expected the error to name the branch and existing path, got: %s", output)
+	}
+	if info, err := os.Stat(wtPath); err != nil || !info.IsDir() {
+		t.Errorf("Expected the existing worktree to be untouched: %v", err)
+	}
+	if after := gitWorktreeList(t, dir); after != before {
+		t.Errorf("Expected the worktree list to be unchanged.\nBefore: %s\nAfter: %s", before, after)
+	}
+}
+
+// TestWorktreeAddTargetPathOccupied covers scenario 9: add refuses when the
+// target path is an unrelated directory.
+// Steps:
+// 1. Creates the computed path as a plain directory containing a file
+// 2. Runs 'git flow worktree add feature/x'
+// 3. Verifies exit code 6 and a message naming the occupied path
+// 4. Verifies the directory contents are unchanged, no worktree registered, no marker
+func TestWorktreeAddTargetPathOccupied(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+
+	wtPath := computedWorktreePath(t, dir, "feature/x")
+	if err := os.MkdirAll(wtPath, 0755); err != nil {
+		t.Fatalf("Failed to create occupying directory: %v", err)
+	}
+	occupant := filepath.Join(wtPath, "occupant.txt")
+	if err := os.WriteFile(occupant, []byte("mine"), 0644); err != nil {
+		t.Fatalf("Failed to write occupying file: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "add", "feature/x")
+	if got := worktreeExitCode(err); got != 6 {
+		t.Fatalf("Expected exit code 6, got %d\nOutput: %s", got, output)
+	}
+	if !strings.Contains(output, wtPath) {
+		t.Errorf("Expected the error to name the occupied path, got: %s", output)
+	}
+	content, err := os.ReadFile(occupant)
+	if err != nil || string(content) != "mine" {
+		t.Errorf("Expected the occupying file to be untouched, got %q (%v)", string(content), err)
+	}
+	if strings.Contains(gitWorktreeList(t, dir), "feature/x") {
+		t.Error("Expected no worktree to be registered for feature/x")
+	}
+	if testutil.GitConfigHasPrefix(t, dir, "gitflow.worktree.") {
+		t.Error("Expected no gitflow.worktree.* key to be written")
+	}
+}
+
+// TestWorktreeAddBranchCheckedOutInMainWorktree covers scenario 10: add refuses a
+// branch that is checked out in the main worktree.
+// Steps:
+// 1. Runs 'git flow feature start x', leaving feature/x checked out in the main worktree
+// 2. Runs 'git flow worktree add feature/x'
+// 3. Verifies exit code 6 and a message naming the main worktree
+// 4. Verifies no directory was left behind and no marker was written
+func TestWorktreeAddBranchCheckedOutInMainWorktree(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "start", "x"); err != nil {
+		t.Fatalf("feature start failed: %v\nOutput: %s", err, out)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "add", "feature/x")
+	if got := worktreeExitCode(err); got != 6 {
+		t.Fatalf("Expected exit code 6, got %d\nOutput: %s", got, output)
+	}
+	if !strings.Contains(output, testutil.EvalPath(t, dir)) {
+		t.Errorf("Expected the error to name the main worktree, got: %s", output)
+	}
+	if _, err := os.Stat(computedWorktreePath(t, dir, "feature/x")); !os.IsNotExist(err) {
+		t.Error("Expected no partial worktree directory to be left behind")
+	}
+	if testutil.GitConfigHasPrefix(t, dir, "gitflow.worktree.") {
+		t.Error("Expected no gitflow.worktree.* key to be written")
+	}
+}
+
+// TestWorktreeAddRelativePathResolvesAgainstInvocationDir verifies a relative
+// --path resolves against the invocation directory, not the main worktree root.
+// Steps:
+// 1. Creates subdirectory <repo>/sub and a free feature/x branch
+// 2. Runs 'git flow worktree add feature/x --path ../custom' from <repo>/sub
+// 3. Verifies the worktree lands at <repo>/custom
+// 4. Verifies it did NOT land at <repoParent>/custom
+func TestWorktreeAddRelativePathResolvesAgainstInvocationDir(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	createFreeBranch(t, dir, "feature/x")
+
+	sub := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(sub, 0755); err != nil {
+		t.Fatalf("Failed to create subdirectory: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, sub, "worktree", "add", "feature/x", "--path", "../custom")
+	if err != nil {
+		t.Fatalf("worktree add --path failed: %v\nOutput: %s", err, output)
+	}
+
+	repoRoot := testutil.EvalPath(t, dir)
+	inRepo := filepath.Join(repoRoot, "custom")
+	outsideRepo := filepath.Join(filepath.Dir(repoRoot), "custom")
+	defer os.RemoveAll(outsideRepo)
+
+	if info, err := os.Stat(inRepo); err != nil || !info.IsDir() {
+		t.Errorf("Expected worktree at the invocation-relative path %q: %v", inRepo, err)
+	}
+	if _, err := os.Stat(outsideRepo); !os.IsNotExist(err) {
+		t.Errorf("Expected no worktree at the main-worktree-relative path %q", outsideRepo)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Group D — worktree remove
+// ---------------------------------------------------------------------------
+
+// TestWorktreeRemoveCleanWorktree covers scenario 11: remove drops a clean worktree.
+// Steps:
+// 1. Adds a worktree for feature/x through git-flow (marker present)
+// 2. Runs 'git flow worktree remove feature/x'
+// 3. Verifies the directory and admin entry are gone and the marker is cleared
+// 4. Verifies the branch feature/x still exists
+func TestWorktreeRemoveCleanWorktree(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := addWorktree(t, dir, "feature/x")
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "remove", "feature/x")
+	if err != nil {
+		t.Fatalf("worktree remove failed: %v\nOutput: %s", err, output)
+	}
+
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Errorf("Expected worktree directory %q to be gone", wtPath)
+	}
+	if strings.Contains(gitWorktreeList(t, dir), wtPath) {
+		t.Error("Expected the admin entry to be gone")
+	}
+	if testutil.GitConfigExists(t, dir, "gitflow.worktree.feature/x.managed") {
+		t.Error("Expected the managed marker to be cleared")
+	}
+	if !testutil.BranchExists(t, dir, "feature/x") {
+		t.Error("Expected branch feature/x to survive worktree removal")
+	}
+}
+
+// TestWorktreeRemoveRefusesUncommittedChanges covers scenario 12a: remove refuses
+// a worktree with modified tracked files.
+// Steps:
+// 1. Adds a worktree for feature/x and modifies a tracked file inside it
+// 2. Runs 'git flow worktree remove feature/x'
+// 3. Verifies exit code 6 and a message mentioning --force
+// 4. Verifies the directory, the modification, and the marker all survive
+func TestWorktreeRemoveRefusesUncommittedChanges(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := addWorktree(t, dir, "feature/x")
+
+	if err := os.WriteFile(filepath.Join(wtPath, "README.md"), []byte("modified"), 0644); err != nil {
+		t.Fatalf("Failed to modify tracked file: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "remove", "feature/x")
+	if got := worktreeExitCode(err); got != 6 {
+		t.Fatalf("Expected exit code 6, got %d\nOutput: %s", got, output)
+	}
+	if !strings.Contains(output, "--force") {
+		t.Errorf("Expected the refusal to mention --force, got: %s", output)
+	}
+	content, err := os.ReadFile(filepath.Join(wtPath, "README.md"))
+	if err != nil || string(content) != "modified" {
+		t.Errorf("Expected the modification to survive, got %q (%v)", string(content), err)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.worktree.feature/x.managed"); v != "true" {
+		t.Errorf("Expected the marker to survive a refusal, got %q", v)
+	}
+}
+
+// TestWorktreeRemoveForceWithUncommittedChanges covers scenario 12b: --force
+// removes a worktree with modified tracked files.
+// Steps:
+// 1. Adds a worktree for feature/x and modifies a tracked file inside it
+// 2. Runs 'git flow worktree remove feature/x --force'
+// 3. Verifies exit code 0 and that the directory is gone
+// 4. Verifies the marker is cleared and the branch is retained
+func TestWorktreeRemoveForceWithUncommittedChanges(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := addWorktree(t, dir, "feature/x")
+
+	if err := os.WriteFile(filepath.Join(wtPath, "README.md"), []byte("modified"), 0644); err != nil {
+		t.Fatalf("Failed to modify tracked file: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "remove", "feature/x", "--force")
+	if err != nil {
+		t.Fatalf("worktree remove --force failed: %v\nOutput: %s", err, output)
+	}
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Errorf("Expected worktree directory %q to be gone", wtPath)
+	}
+	if testutil.GitConfigExists(t, dir, "gitflow.worktree.feature/x.managed") {
+		t.Error("Expected the managed marker to be cleared")
+	}
+	if !testutil.BranchExists(t, dir, "feature/x") {
+		t.Error("Expected branch feature/x to survive worktree removal")
+	}
+}
+
+// TestWorktreeRemoveRefusesUntrackedFiles covers scenario 13a: the dirty check
+// covers untracked files, not just tracked modifications.
+// Steps:
+// 1. Adds a worktree for feature/x and writes a new untracked file inside it
+// 2. Runs 'git flow worktree remove feature/x'
+// 3. Verifies exit code 6 and a refusal message
+// 4. Verifies the worktree and the untracked file survive
+func TestWorktreeRemoveRefusesUntrackedFiles(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := addWorktree(t, dir, "feature/x")
+
+	untracked := filepath.Join(wtPath, "scratch.txt")
+	if err := os.WriteFile(untracked, []byte("scratch"), 0644); err != nil {
+		t.Fatalf("Failed to write untracked file: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "remove", "feature/x")
+	if got := worktreeExitCode(err); got != 6 {
+		t.Fatalf("Expected exit code 6, got %d\nOutput: %s", got, output)
+	}
+	if !strings.Contains(output, "--force") {
+		t.Errorf("Expected the refusal to mention --force, got: %s", output)
+	}
+	if _, err := os.Stat(untracked); err != nil {
+		t.Errorf("Expected the untracked file to survive: %v", err)
+	}
+}
+
+// TestWorktreeRemoveForceWithUntrackedFiles covers scenario 13b: --force removes
+// a worktree that only holds untracked files.
+// Steps:
+// 1. Adds a worktree for feature/x and writes a new untracked file inside it
+// 2. Runs 'git flow worktree remove feature/x --force'
+// 3. Verifies exit code 0 and that the directory is gone
+// 4. Verifies the marker is cleared
+func TestWorktreeRemoveForceWithUntrackedFiles(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := addWorktree(t, dir, "feature/x")
+
+	if err := os.WriteFile(filepath.Join(wtPath, "scratch.txt"), []byte("scratch"), 0644); err != nil {
+		t.Fatalf("Failed to write untracked file: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "remove", "feature/x", "--force")
+	if err != nil {
+		t.Fatalf("worktree remove --force failed: %v\nOutput: %s", err, output)
+	}
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Errorf("Expected worktree directory %q to be gone", wtPath)
+	}
+	if testutil.GitConfigExists(t, dir, "gitflow.worktree.feature/x.managed") {
+		t.Error("Expected the managed marker to be cleared")
+	}
+}
+
+// TestWorktreeRemoveUnmanagedWorktree covers scenario 14: remove ignores
+// provenance for an explicitly named target.
+// Steps:
+// 1. Creates a worktree for feature/x with plain 'git worktree add' (no marker)
+// 2. Runs 'git flow worktree remove feature/x'
+// 3. Verifies exit code 0 and that the worktree is gone
+// 4. Verifies the branch is retained
+func TestWorktreeRemoveUnmanagedWorktree(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	createFreeBranch(t, dir, "feature/x")
+
+	wtPath := filepath.Join(t.TempDir(), "handmade")
+	if out, err := testutil.RunGit(t, dir, "worktree", "add", wtPath, "feature/x"); err != nil {
+		t.Fatalf("git worktree add failed: %v\nOutput: %s", err, out)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "remove", "feature/x")
+	if err != nil {
+		t.Fatalf("worktree remove failed: %v\nOutput: %s", err, output)
+	}
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Errorf("Expected the hand-made worktree %q to be removed", wtPath)
+	}
+	if !testutil.BranchExists(t, dir, "feature/x") {
+		t.Error("Expected branch feature/x to survive worktree removal")
+	}
+}
+
+// TestWorktreeRemoveWithoutWorktree covers scenario 15: remove errors when the
+// branch has no worktree.
+// Steps:
+// 1. Creates branch feature/x with no worktree anywhere
+// 2. Runs 'git flow worktree remove feature/x'
+// 3. Verifies exit code 5 and a "no worktree" message
+// 4. Verifies the branch is untouched
+func TestWorktreeRemoveWithoutWorktree(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	createFreeBranch(t, dir, "feature/x")
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "remove", "feature/x")
+	if got := worktreeExitCode(err); got != 5 {
+		t.Fatalf("Expected exit code 5, got %d\nOutput: %s", got, output)
+	}
+	if !strings.Contains(output, "no worktree") {
+		t.Errorf("Expected a 'no worktree' message, got: %s", output)
+	}
+	if !testutil.BranchExists(t, dir, "feature/x") {
+		t.Error("Expected branch feature/x to be untouched")
+	}
+}
+
+// TestWorktreeRemoveRefusesMainWorktree covers scenario 16: the main worktree is
+// never removed, and that refusal beats the "nothing to remove" path.
+// Steps:
+// 1. Sets up a repository with main checked out in the main worktree
+// 2. Runs 'git flow worktree remove main'
+// 3. Verifies exit code 6 and a message about the main worktree
+// 4. Verifies the repository directory still exists and is a worktree
+func TestWorktreeRemoveRefusesMainWorktree(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "remove", "main")
+	if got := worktreeExitCode(err); got != 6 {
+		t.Fatalf("Expected exit code 6, got %d\nOutput: %s", got, output)
+	}
+	if !strings.Contains(output, "main worktree") {
+		t.Errorf("Expected a main-worktree refusal, got: %s", output)
+	}
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		t.Fatalf("Expected the repository directory to survive: %v", err)
+	}
+	if !strings.Contains(gitWorktreeList(t, dir), testutil.EvalPath(t, dir)) {
+		t.Error("Expected the main worktree to still be listed")
+	}
+}
+
+// TestWorktreeRemoveStaleEntry verifies remove succeeds against a stale admin
+// entry whose directory was deleted by hand — a missing directory counts as clean.
+// Steps:
+// 1. Adds a worktree for feature/x, then deletes its directory with os.RemoveAll
+// 2. Runs 'git flow worktree remove feature/x' without --force
+// 3. Verifies exit code 0 and that the admin entry is gone
+// 4. Verifies the marker is cleared and the branch is retained
+func TestWorktreeRemoveStaleEntry(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := addWorktree(t, dir, "feature/x")
+
+	if err := os.RemoveAll(wtPath); err != nil {
+		t.Fatalf("Failed to delete worktree directory: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "remove", "feature/x")
+	if err != nil {
+		t.Fatalf("worktree remove on a stale entry failed: %v\nOutput: %s", err, output)
+	}
+	if strings.Contains(gitWorktreeList(t, dir), wtPath) {
+		t.Error("Expected the stale admin entry to be gone")
+	}
+	if testutil.GitConfigExists(t, dir, "gitflow.worktree.feature/x.managed") {
+		t.Error("Expected the managed marker to be cleared")
+	}
+	if !testutil.BranchExists(t, dir, "feature/x") {
+		t.Error("Expected branch feature/x to survive")
+	}
+}
+
+// TestWorktreeRemoveNoCDFlagLeavesFileEmpty verifies --no-cd suppresses the
+// navigation write even when removing the worktree the command runs in.
+// Steps:
+// 1. Adds a worktree for feature/x and creates an empty GIT_FLOW_CD_FILE
+// 2. Runs 'git flow worktree remove feature/x --no-cd' from inside that worktree
+// 3. Verifies exit code 0 and that the worktree is removed
+// 4. Verifies the CD file is still zero-length
+func TestWorktreeRemoveNoCDFlagLeavesFileEmpty(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := addWorktree(t, dir, "feature/x")
+	cdFile := cdFilePath(t)
+
+	output, err := testutil.RunGitFlowWithEnv(t, wtPath, cdEnv(cdFile), "worktree", "remove", "feature/x", "--no-cd")
+	if err != nil {
+		t.Fatalf("worktree remove --no-cd failed: %v\nOutput: %s", err, output)
+	}
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Errorf("Expected worktree directory %q to be gone", wtPath)
+	}
+	assertCDFileEmpty(t, cdFile)
+}
+
+// ---------------------------------------------------------------------------
+// Group E — worktree list
+// ---------------------------------------------------------------------------
+
+// TestWorktreeListShowsLinkedWorktrees covers scenario 17: list shows every
+// linked worktree and excludes the main one.
+// Steps:
+// 1. Adds worktrees for feature/a and feature/b through git-flow
+// 2. Runs 'git flow worktree list'
+// 3. Verifies exactly two rows, each carrying its branch and absolute path
+// 4. Verifies no row is the main worktree (neither its path nor its branch)
+func TestWorktreeListShowsLinkedWorktrees(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/a")
+	createFreeBranch(t, dir, "feature/b")
+	pathA := addWorktree(t, dir, "feature/a")
+	pathB := addWorktree(t, dir, "feature/b")
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "list")
+	if err != nil {
+		t.Fatalf("worktree list failed: %v\nOutput: %s", err, output)
+	}
+
+	rows := worktreeRows(output)
+	if len(rows) != 2 {
+		t.Fatalf("Expected exactly two rows, got %d: %s", len(rows), output)
+	}
+
+	mainRoot := testutil.EvalPath(t, dir)
+	seen := map[string]string{}
+	for _, row := range rows {
+		fields := strings.Fields(row)
+		if len(fields) < 2 {
+			t.Fatalf("Expected a branch and a path in row %q", row)
+		}
+		branch, path := fields[0], fields[1]
+		// Compare the path FIELD for equality: the default template nests
+		// worktrees under a sibling directory whose name has the main worktree
+		// root as a literal prefix, so a substring check is unsatisfiable.
+		if path == mainRoot {
+			t.Errorf("Expected the main worktree to be excluded, got row %q", row)
+		}
+		if branch == "main" {
+			t.Errorf("Expected the main worktree's branch to be excluded, got row %q", row)
+		}
+		seen[branch] = path
+	}
+	if seen["feature/a"] != pathA {
+		t.Errorf("Expected feature/a at %q, got %q", pathA, seen["feature/a"])
+	}
+	if seen["feature/b"] != pathB {
+		t.Errorf("Expected feature/b at %q, got %q", pathB, seen["feature/b"])
+	}
+}
+
+// TestWorktreeListTagsUnmanagedWorktree covers scenario 18: provenance comes from
+// the marker only, never from the path shape.
+// Steps:
+// 1. Adds feature/a through git-flow (marker written)
+// 2. Adds feature/b by hand at the path the template WOULD compute (no marker)
+// 3. Runs 'git flow worktree list'
+// 4. Verifies the feature/b row is tagged (unmanaged) and the feature/a row is not
+func TestWorktreeListTagsUnmanagedWorktree(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/a")
+	createFreeBranch(t, dir, "feature/b")
+	addWorktree(t, dir, "feature/a")
+
+	// Deliberately template-shaped, so only the missing marker can make it read
+	// as unmanaged.
+	handmade := computedWorktreePath(t, dir, "feature/b")
+	if out, err := testutil.RunGit(t, dir, "worktree", "add", handmade, "feature/b"); err != nil {
+		t.Fatalf("git worktree add failed: %v\nOutput: %s", err, out)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "list")
+	if err != nil {
+		t.Fatalf("worktree list failed: %v\nOutput: %s", err, output)
+	}
+
+	for _, row := range worktreeRows(output) {
+		fields := strings.Fields(row)
+		switch fields[0] {
+		case "feature/a":
+			if strings.Contains(row, "(unmanaged)") {
+				t.Errorf("Expected the git-flow-created worktree to carry no tag, got %q", row)
+			}
+		case "feature/b":
+			if !strings.HasSuffix(row, "(unmanaged)") {
+				t.Errorf("Expected the hand-made worktree to be tagged (unmanaged), got %q", row)
+			}
+		default:
+			t.Errorf("Unexpected row %q", row)
+		}
+	}
+}
+
+// TestWorktreeListShowsDetachedWorktree verifies a detached worktree is still
+// listed, with (detached) in the branch column.
+// Steps:
+// 1. Adds a worktree for feature/x and detaches its HEAD
+// 2. Runs 'git flow worktree list'
+// 3. Verifies the worktree is still listed with its path unchanged
+// 4. Verifies its branch column reads (detached)
+func TestWorktreeListShowsDetachedWorktree(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := addWorktree(t, dir, "feature/x")
+
+	if out, err := testutil.RunGit(t, wtPath, "checkout", "--detach"); err != nil {
+		t.Fatalf("Failed to detach worktree HEAD: %v\nOutput: %s", err, out)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "list")
+	if err != nil {
+		t.Fatalf("worktree list failed: %v\nOutput: %s", err, output)
+	}
+
+	rows := worktreeRows(output)
+	if len(rows) != 1 {
+		t.Fatalf("Expected exactly one row, got %d: %s", len(rows), output)
+	}
+	fields := strings.Fields(rows[0])
+	if fields[0] != "(detached)" {
+		t.Errorf("Expected the branch column to read (detached), got %q", rows[0])
+	}
+	if fields[1] != wtPath {
+		t.Errorf("Expected the path column to stay %q, got %q", wtPath, fields[1])
+	}
+}
+
+// TestWorktreeListShowsStaleWorktreeUntilPrune verifies a stale entry is listed
+// as-is until prune runs.
+// Steps:
+// 1. Adds a worktree for feature/x, then deletes its directory
+// 2. Runs 'git flow worktree list' and verifies the entry is still shown
+// 3. Runs 'git flow worktree prune'
+// 4. Runs 'git flow worktree list' again and verifies the entry is gone
+func TestWorktreeListShowsStaleWorktreeUntilPrune(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := addWorktree(t, dir, "feature/x")
+
+	if err := os.RemoveAll(wtPath); err != nil {
+		t.Fatalf("Failed to delete worktree directory: %v", err)
+	}
+
+	before, err := testutil.RunGitFlow(t, dir, "worktree", "list")
+	if err != nil {
+		t.Fatalf("worktree list failed: %v\nOutput: %s", err, before)
+	}
+	if !strings.Contains(before, wtPath) || !strings.Contains(before, "feature/x") {
+		t.Errorf("Expected the stale entry to still be listed, got: %s", before)
+	}
+
+	if out, err := testutil.RunGitFlow(t, dir, "worktree", "prune"); err != nil {
+		t.Fatalf("worktree prune failed: %v\nOutput: %s", err, out)
+	}
+
+	after, err := testutil.RunGitFlow(t, dir, "worktree", "list")
+	if err != nil {
+		t.Fatalf("worktree list failed: %v\nOutput: %s", err, after)
+	}
+	if strings.Contains(after, wtPath) {
+		t.Errorf("Expected the stale entry to be gone after prune, got: %s", after)
+	}
+}
+
+// TestWorktreeListWithNoLinkedWorktrees verifies the empty listing message.
+// Steps:
+// 1. Sets up a repository with git-flow defaults and no linked worktrees
+// 2. Runs 'git flow worktree list'
+// 3. Verifies exit code 0
+// 4. Verifies the single line 'No linked worktrees found'
+func TestWorktreeListWithNoLinkedWorktrees(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "list")
+	if err != nil {
+		t.Fatalf("worktree list failed: %v\nOutput: %s", err, output)
+	}
+	if strings.TrimSpace(output) != "No linked worktrees found" {
+		t.Errorf("Expected 'No linked worktrees found', got: %s", output)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Group F — worktree prune
+// ---------------------------------------------------------------------------
+
+// TestWorktreePruneRemovesStaleEntryAndMarker covers scenario 19: prune drops the
+// stale admin entry and its marker, and only its marker.
+// Steps:
+// 1. Adds worktrees for feature/x and feature/keep, then deletes feature/x's directory
+// 2. Runs 'git flow worktree prune'
+// 3. Verifies the stale entry and gitflow.worktree.feature/x.managed are gone
+// 4. Verifies the live worktree's marker is still present
+func TestWorktreePruneRemovesStaleEntryAndMarker(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	createFreeBranch(t, dir, "feature/keep")
+	wtPath := addWorktree(t, dir, "feature/x")
+	addWorktree(t, dir, "feature/keep")
+
+	if err := os.RemoveAll(wtPath); err != nil {
+		t.Fatalf("Failed to delete worktree directory: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "prune")
+	if err != nil {
+		t.Fatalf("worktree prune failed: %v\nOutput: %s", err, output)
+	}
+
+	if strings.Contains(gitWorktreeList(t, dir), wtPath) {
+		t.Error("Expected the stale admin entry to be pruned")
+	}
+	if testutil.GitConfigExists(t, dir, "gitflow.worktree.feature/x.managed") {
+		t.Error("Expected the stale marker to be swept")
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.worktree.feature/keep.managed"); v != "true" {
+		t.Errorf("Expected the live worktree's marker to survive, got %q", v)
+	}
+}
+
+// TestWorktreePruneDropsMarkerAfterDetach verifies the sweep is keyed on the
+// branch: a live-but-detached worktree keeps its directory and loses its marker.
+// Steps:
+// 1. Adds a worktree for feature/x and detaches its HEAD
+// 2. Runs 'git flow worktree prune'
+// 3. Verifies the directory and admin entry survive but the marker is dropped
+// 4. Verifies 'worktree list' now reports the row as (detached) … (unmanaged)
+func TestWorktreePruneDropsMarkerAfterDetach(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := addWorktree(t, dir, "feature/x")
+
+	if out, err := testutil.RunGit(t, wtPath, "checkout", "--detach"); err != nil {
+		t.Fatalf("Failed to detach worktree HEAD: %v\nOutput: %s", err, out)
+	}
+
+	if out, err := testutil.RunGitFlow(t, dir, "worktree", "prune"); err != nil {
+		t.Fatalf("worktree prune failed: %v\nOutput: %s", err, out)
+	}
+
+	if info, err := os.Stat(wtPath); err != nil || !info.IsDir() {
+		t.Fatalf("Expected the live worktree directory to survive prune: %v", err)
+	}
+	if !strings.Contains(gitWorktreeList(t, dir), wtPath) {
+		t.Error("Expected the live admin entry to survive prune")
+	}
+	if testutil.GitConfigExists(t, dir, "gitflow.worktree.feature/x.managed") {
+		t.Error("Expected the marker of a branch with no live worktree to be dropped")
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "list")
+	if err != nil {
+		t.Fatalf("worktree list failed: %v\nOutput: %s", err, output)
+	}
+	rows := worktreeRows(output)
+	if len(rows) != 1 {
+		t.Fatalf("Expected exactly one row, got %d: %s", len(rows), output)
+	}
+	if !strings.HasPrefix(rows[0], "(detached)") || !strings.HasSuffix(rows[0], "(unmanaged)") {
+		t.Errorf("Expected a '(detached) … (unmanaged)' row, got %q", rows[0])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Group H — the GIT_FLOW_CD_FILE navigation channel
+// ---------------------------------------------------------------------------
+
+// TestWorktreeAddWritesCDFile covers scenario 23: add hands back the new path.
+// Steps:
+// 1. Creates an empty GIT_FLOW_CD_FILE and a free feature/x branch
+// 2. Runs 'git flow worktree add feature/x' with the variable set
+// 3. Verifies exit code 0
+// 4. Verifies the file holds the absolute path of the created worktree
+func TestWorktreeAddWritesCDFile(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	cdFile := cdFilePath(t)
+
+	output, err := testutil.RunGitFlowWithEnv(t, dir, cdEnv(cdFile), "worktree", "add", "feature/x")
+	if err != nil {
+		t.Fatalf("worktree add failed: %v\nOutput: %s", err, output)
+	}
+
+	want := computedWorktreePath(t, dir, "feature/x")
+	if got := readCDFile(t, cdFile); got != want {
+		t.Errorf("Expected CD file to hold %q, got %q", want, got)
+	}
+}
+
+// TestWorktreeAddWithoutCDFileEnv covers scenario 24: with the variable unset the
+// command prints exactly its confirmation and cd hint, and writes no file.
+// Steps:
+// 1. Chooses a CD file path but deliberately does NOT pass GIT_FLOW_CD_FILE
+// 2. Runs 'git flow worktree add feature/x' with the channel explicitly empty
+// 3. Verifies stdout equals exactly the confirmation and cd hint lines
+// 4. Verifies the chosen file was never created
+func TestWorktreeAddWithoutCDFileEnv(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+
+	unused := filepath.Join(t.TempDir(), "never-written")
+
+	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, nil, "worktree", "add", "feature/x")
+	if err != nil {
+		t.Fatalf("worktree add failed: %v\nStderr: %s", err, stderr)
+	}
+
+	wtPath := computedWorktreePath(t, dir, "feature/x")
+	want := "Created worktree for branch 'feature/x' at " + wtPath + "\n" +
+		"To switch to it: cd " + wtPath + "\n"
+	if stdout != want {
+		t.Errorf("Expected stdout %q, got %q", want, stdout)
+	}
+	if _, err := os.Stat(unused); !os.IsNotExist(err) {
+		t.Errorf("Expected no CD file to be created at %q", unused)
+	}
+}
+
+// TestWorktreeAddNoCDFlagLeavesFileEmpty covers scenario 25: --no-cd suppresses
+// the write even when the variable is set.
+// Steps:
+// 1. Creates an empty GIT_FLOW_CD_FILE and a free feature/x branch
+// 2. Runs 'git flow worktree add feature/x --no-cd' with the variable set
+// 3. Verifies exit code 0 and that the worktree was created
+// 4. Verifies the CD file is still zero-length
+func TestWorktreeAddNoCDFlagLeavesFileEmpty(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	cdFile := cdFilePath(t)
+
+	output, err := testutil.RunGitFlowWithEnv(t, dir, cdEnv(cdFile), "worktree", "add", "feature/x", "--no-cd")
+	if err != nil {
+		t.Fatalf("worktree add --no-cd failed: %v\nOutput: %s", err, output)
+	}
+	if _, err := os.Stat(computedWorktreePath(t, dir, "feature/x")); err != nil {
+		t.Errorf("Expected the worktree to be created: %v", err)
+	}
+	assertCDFileEmpty(t, cdFile)
+}
+
+// TestWorktreeAddCustomPathWritesCDFile covers scenario 26: --path wins in the
+// navigation channel too.
+// Steps:
+// 1. Creates an empty GIT_FLOW_CD_FILE and a free feature/x branch
+// 2. Runs 'git flow worktree add feature/x --path ./wt-custom-cd' with the variable set
+// 3. Verifies the file holds the absolute form of the custom path
+// 4. Verifies it does not hold the computed template path
+func TestWorktreeAddCustomPathWritesCDFile(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	cdFile := cdFilePath(t)
+
+	output, err := testutil.RunGitFlowWithEnv(t, dir, cdEnv(cdFile), "worktree", "add", "feature/x", "--path", "./wt-custom-cd")
+	if err != nil {
+		t.Fatalf("worktree add --path failed: %v\nOutput: %s", err, output)
+	}
+
+	want := filepath.Join(testutil.EvalPath(t, dir), "wt-custom-cd")
+	got := readCDFile(t, cdFile)
+	if got != want {
+		t.Errorf("Expected CD file to hold %q, got %q", want, got)
+	}
+	if got == computedWorktreePath(t, dir, "feature/x") {
+		t.Error("Expected the CD file to hold the --path destination, not the computed path")
+	}
+}
+
+// TestWorktreeAddFailureLeavesCDFileEmpty covers scenario 27: a failed add writes
+// nothing and reports on stderr.
+// Steps:
+// 1. Creates an empty GIT_FLOW_CD_FILE
+// 2. Runs 'git flow worktree add feature/nope' for a branch that does not exist
+// 3. Verifies exit code 5, an error on stderr, and empty stdout
+// 4. Verifies the CD file is still zero-length
+func TestWorktreeAddFailureLeavesCDFileEmpty(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	cdFile := cdFilePath(t)
+
+	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "worktree", "add", "feature/nope")
+	if got := worktreeExitCode(err); got != 5 {
+		t.Fatalf("Expected exit code 5, got %d\nStdout: %s\nStderr: %s", got, stdout, stderr)
+	}
+	if !strings.Contains(stderr, "feature/nope") {
+		t.Errorf("Expected the error on stderr, got: %s", stderr)
+	}
+	if stdout != "" {
+		t.Errorf("Expected empty stdout, got %q", stdout)
+	}
+	assertCDFileEmpty(t, cdFile)
+}
+
+// TestWorktreeRemoveFromInsideWritesMainWorktreePath covers scenario 28: removing
+// the worktree the user is standing in hands back the main worktree.
+// Steps:
+// 1. Adds a worktree for feature/x and creates an empty GIT_FLOW_CD_FILE
+// 2. Runs 'git flow worktree remove feature/x' from inside that worktree
+// 3. Verifies exit code 0 and that the worktree is gone
+// 4. Verifies the CD file holds the main worktree root
+func TestWorktreeRemoveFromInsideWritesMainWorktreePath(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := addWorktree(t, dir, "feature/x")
+	cdFile := cdFilePath(t)
+
+	output, err := testutil.RunGitFlowWithEnv(t, wtPath, cdEnv(cdFile), "worktree", "remove", "feature/x")
+	if err != nil {
+		t.Fatalf("worktree remove failed: %v\nOutput: %s", err, output)
+	}
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Errorf("Expected worktree directory %q to be gone", wtPath)
+	}
+	// Both sides symlink-resolved: git reports /private/var on macOS while the
+	// temp dir is /var.
+	want := testutil.EvalPath(t, dir)
+	if got := readCDFile(t, cdFile); got != want {
+		t.Errorf("Expected CD file to hold the main worktree %q, got %q", want, got)
+	}
+}
+
+// TestWorktreeRemoveFromOutsideLeavesCDFileEmpty covers scenario 29: removing a
+// worktree the user is not inside writes nothing.
+// Steps:
+// 1. Adds a worktree for feature/x and creates an empty GIT_FLOW_CD_FILE
+// 2. Runs 'git flow worktree remove feature/x' from the main worktree
+// 3. Verifies exit code 0 and that the worktree is removed
+// 4. Verifies the CD file is still zero-length
+func TestWorktreeRemoveFromOutsideLeavesCDFileEmpty(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := addWorktree(t, dir, "feature/x")
+	cdFile := cdFilePath(t)
+
+	output, err := testutil.RunGitFlowWithEnv(t, dir, cdEnv(cdFile), "worktree", "remove", "feature/x")
+	if err != nil {
+		t.Fatalf("worktree remove failed: %v\nOutput: %s", err, output)
+	}
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Errorf("Expected worktree directory %q to be gone", wtPath)
+	}
+	assertCDFileEmpty(t, cdFile)
+}
+
+// TestWorktreeRemoveRefusedLeavesCDFileEmpty covers scenario 30: a refused
+// removal writes no destination, even from inside the target.
+// Steps:
+// 1. Adds a worktree for feature/x and modifies a tracked file inside it
+// 2. Runs 'git flow worktree remove feature/x' from inside it, variable set
+// 3. Verifies exit code 6 and that the worktree still exists
+// 4. Verifies the CD file is still zero-length
+func TestWorktreeRemoveRefusedLeavesCDFileEmpty(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := addWorktree(t, dir, "feature/x")
+	cdFile := cdFilePath(t)
+
+	if err := os.WriteFile(filepath.Join(wtPath, "README.md"), []byte("modified"), 0644); err != nil {
+		t.Fatalf("Failed to modify tracked file: %v", err)
+	}
+
+	output, err := testutil.RunGitFlowWithEnv(t, wtPath, cdEnv(cdFile), "worktree", "remove", "feature/x")
+	if got := worktreeExitCode(err); got != 6 {
+		t.Fatalf("Expected exit code 6, got %d\nOutput: %s", got, output)
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Errorf("Expected the worktree to survive a refusal: %v", err)
+	}
+	assertCDFileEmpty(t, cdFile)
+}
+
+// TestWorktreeAddWithUnwritableCDFileWarns covers scenario 31: an unwritable
+// destination warns but does not fail the operation.
+// Steps:
+// 1. Points GIT_FLOW_CD_FILE at an existing DIRECTORY, which can never be written as a file
+// 2. Runs 'git flow worktree add feature/x'
+// 3. Verifies exit code 0, the worktree exists, and the marker is written
+// 4. Verifies stderr carries a Warning naming the destination and stdout still carries the hint
+func TestWorktreeAddWithUnwritableCDFileWarns(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+
+	// A directory destination fails with EISDIR on every platform and for every
+	// user, unlike a 0500 directory (root-exempt, ACL-dependent, Windows-skipped).
+	destination := t.TempDir()
+
+	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(destination), "worktree", "add", "feature/x")
+	if err != nil {
+		t.Fatalf("Expected worktree add to succeed, got %v\nStderr: %s", err, stderr)
+	}
+
+	wtPath := computedWorktreePath(t, dir, "feature/x")
+	if info, err := os.Stat(wtPath); err != nil || !info.IsDir() {
+		t.Fatalf("Expected the worktree to be created: %v", err)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.worktree.feature/x.managed"); v != "true" {
+		t.Errorf("Expected the marker to be written, got %q", v)
+	}
+	if !strings.Contains(stderr, "Warning:") || !strings.Contains(stderr, destination) {
+		t.Errorf("Expected a Warning naming %q on stderr, got: %s", destination, stderr)
+	}
+	if !strings.Contains(stdout, "Created worktree for branch 'feature/x'") ||
+		!strings.Contains(stdout, "cd "+wtPath) {
+		t.Errorf("Expected the confirmation and cd hint on stdout, got: %s", stdout)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Group I — shared-config regression
+// ---------------------------------------------------------------------------
+
+// TestWorktreeMarkerNotCopiedToSharedConfig verifies the provenance marker is
+// machine-local: it never reaches .gitflow, never reads as drift, and is never
+// deleted by a sync.
+// Steps:
+// 1. Runs 'git flow init --shared --defaults' and adds a worktree for feature/x
+// 2. Verifies .gitflow carries no worktree. line and 'config status' exits 0
+// 3. Runs 'git flow config sync'
+// 4. Verifies the local marker survived and 'config status' still exits 0
+func TestWorktreeMarkerNotCopiedToSharedConfig(t *testing.T) {
+	t.Parallel()
+	dir := initSharedDefaults(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	addWorktree(t, dir, "feature/x")
+
+	shared, err := os.ReadFile(testutil.SharedConfigPath(dir))
+	if err != nil {
+		t.Fatalf("Failed to read .gitflow: %v", err)
+	}
+	if strings.Contains(string(shared), "worktree.") {
+		t.Errorf("Expected no worktree marker in .gitflow, got:\n%s", string(shared))
+	}
+
+	// A wrongly shared-managed marker present locally but absent from .gitflow
+	// reads as drift — this is what catches a missing carve-out.
+	if out, err := testutil.RunGitFlow(t, dir, "config", "status"); err != nil {
+		t.Fatalf("Expected 'config status' to report no drift, got %v\nOutput: %s", err, out)
+	}
+
+	if out, err := testutil.RunGitFlow(t, dir, "config", "sync"); err != nil {
+		t.Fatalf("config sync failed: %v\nOutput: %s", err, out)
+	}
+
+	// sync removes local shared-managed keys absent from .gitflow, so a broken
+	// carve-out destroys the marker here rather than publishing it.
+	if v := testutil.GitConfigValue(t, dir, "gitflow.worktree.feature/x.managed"); v != "true" {
+		t.Errorf("Expected the marker to survive 'config sync', got %q", v)
+	}
+	if out, err := testutil.RunGitFlow(t, dir, "config", "status"); err != nil {
+		t.Fatalf("Expected 'config status' to report no drift after sync, got %v\nOutput: %s", err, out)
+	}
+}

--- a/test/cmd/worktree_test.go
+++ b/test/cmd/worktree_test.go
@@ -1115,6 +1115,54 @@ func TestWorktreeListTagsUnmanagedWorktree(t *testing.T) {
 	}
 }
 
+// TestWorktreeListIgnoresGlobalScopedMarker verifies the provenance marker is
+// read from LOCAL config only, the scope it is written to and cleared in. A
+// marker that exists only in global config must not make a hand-made worktree
+// report as git-flow's: clearing only touches local scope, so such a marker could
+// never be removed and the cleanup commands would delete the user's own worktree.
+// Steps:
+// 1. Isolates the global config to a temp file so the real global config is untouched
+// 2. Creates a worktree for feature/b by hand, so no local marker exists
+// 3. Writes gitflow.worktree.feature/b.managed=true in the GLOBAL scope only
+// 4. Verifies no gitflow.worktree.* key exists in local config
+// 5. Runs 'git flow worktree list' and verifies the row is still tagged (unmanaged)
+func TestWorktreeListIgnoresGlobalScopedMarker(t *testing.T) {
+	t.Parallel()
+	// The override is passed through each subprocess env (not the test process
+	// env) so it stays scoped to this test and is safe under parallel execution.
+	env := []string{"GIT_CONFIG_GLOBAL=" + filepath.Join(t.TempDir(), "global-gitconfig")}
+
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/b")
+
+	handmade := computedWorktreePath(t, dir, "feature/b")
+	if out, err := testutil.RunGit(t, dir, "worktree", "add", handmade, "feature/b"); err != nil {
+		t.Fatalf("git worktree add failed: %v\nOutput: %s", err, out)
+	}
+
+	if out, err := testutil.RunGitWithEnv(t, dir, env, "config", "--global", "gitflow.worktree.feature/b.managed", "true"); err != nil {
+		t.Fatalf("Failed to write the global marker: %v\nOutput: %s", err, out)
+	}
+	if testutil.GitConfigHasPrefix(t, dir, "gitflow.worktree.") {
+		t.Fatal("Expected no gitflow.worktree.* key in local config")
+	}
+
+	output, err := testutil.RunGitFlowWithEnv(t, dir, env, "worktree", "list")
+	if err != nil {
+		t.Fatalf("worktree list failed: %v\nOutput: %s", err, output)
+	}
+
+	rows := worktreeRows(output)
+	if len(rows) != 1 {
+		t.Fatalf("Expected exactly one row, got %d: %s", len(rows), output)
+	}
+	if !strings.HasSuffix(rows[0], "(unmanaged)") {
+		t.Errorf("Expected a global-only marker to be ignored and the row tagged (unmanaged), got %q", rows[0])
+	}
+}
+
 // TestWorktreeListShowsDetachedWorktree verifies a detached worktree is still
 // listed, with (detached) in the branch column.
 // Steps:

--- a/test/cmd/worktree_test.go
+++ b/test/cmd/worktree_test.go
@@ -448,7 +448,7 @@ func TestWorktreePruneRequiresInitialization(t *testing.T) {
 // TestWorktreeAddCreatesWorktree covers scenario 4: add creates the worktree at
 // the computed path.
 // Steps:
-// 1. Sets up a repository, runs 'git flow feature start x' and checks out main
+// 1. Sets up a repository and creates feature/x without checking it out
 // 2. Runs 'git flow worktree add feature/x'
 // 3. Verifies the computed (nested) path exists and contains a .git file
 // 4. Verifies git worktree list reports the path with [feature/x]
@@ -626,6 +626,43 @@ func TestWorktreeAddTargetPathOccupied(t *testing.T) {
 	}
 	if testutil.GitConfigHasPrefix(t, dir, "gitflow.worktree.") {
 		t.Error("Expected no gitflow.worktree.* key to be written")
+	}
+}
+
+// TestWorktreeAddIntoExistingEmptyDirectorySucceeds pins the boundary of scenario
+// 9 recorded in decisions.md §12: an existing EMPTY directory is not "occupied"
+// and is accepted as the target, matching plain 'git worktree add'. Without this
+// test a regression to refusing empty directories would pass the whole suite,
+// since the occupancy test above uses a non-empty directory.
+// Steps:
+// 1. Pre-creates the computed path as an empty directory
+// 2. Runs 'git flow worktree add feature/x'
+// 3. Verifies exit code 0 and that the worktree was registered at that path
+// 4. Verifies the provenance marker was written like any other add
+func TestWorktreeAddIntoExistingEmptyDirectorySucceeds(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+
+	wtPath := computedWorktreePath(t, dir, "feature/x")
+	if err := os.MkdirAll(wtPath, 0755); err != nil {
+		t.Fatalf("Failed to create the empty target directory: %v", err)
+	}
+
+	output, err := testutil.RunGitFlow(t, dir, "worktree", "add", "feature/x")
+	if err != nil {
+		t.Fatalf("Expected add into an empty directory to succeed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(gitWorktreeList(t, dir), wtPath) {
+		t.Errorf("Expected a worktree registered at %s, got: %s", wtPath, gitWorktreeList(t, dir))
+	}
+	if _, err := os.Stat(filepath.Join(wtPath, ".git")); err != nil {
+		t.Errorf("Expected the worktree to be checked out into the existing directory: %v", err)
+	}
+	if v := testutil.GitConfigValue(t, dir, "gitflow.worktree.feature/x.managed"); v != "true" {
+		t.Errorf("Expected gitflow.worktree.feature/x.managed=true, got %q", v)
 	}
 }
 
@@ -1098,7 +1135,15 @@ func TestWorktreeListTagsUnmanagedWorktree(t *testing.T) {
 		t.Fatalf("worktree list failed: %v\nOutput: %s", err, output)
 	}
 
-	for _, row := range worktreeRows(output) {
+	// Assert the row count before inspecting rows: without it a regression that
+	// dropped the unmanaged row entirely would leave the loop with nothing to
+	// contradict and the test would pass having asserted nothing.
+	rows := worktreeRows(output)
+	if len(rows) != 2 {
+		t.Fatalf("Expected exactly two rows, got %d: %s", len(rows), output)
+	}
+
+	for _, row := range rows {
 		fields := strings.Fields(row)
 		switch fields[0] {
 		case "feature/a":
@@ -1377,20 +1422,17 @@ func TestWorktreeAddWritesCDFile(t *testing.T) {
 }
 
 // TestWorktreeAddWithoutCDFileEnv covers scenario 24: with the variable unset the
-// command prints exactly its confirmation and cd hint, and writes no file.
+// command prints exactly its confirmation and cd hint, and nothing else.
 // Steps:
-// 1. Chooses a CD file path but deliberately does NOT pass GIT_FLOW_CD_FILE
-// 2. Runs 'git flow worktree add feature/x' with the channel explicitly empty
-// 3. Verifies stdout equals exactly the confirmation and cd hint lines
-// 4. Verifies the chosen file was never created
+// 1. Runs 'git flow worktree add feature/x' with GIT_FLOW_CD_FILE explicitly empty
+// 2. Verifies stdout equals exactly the confirmation and cd hint lines, proving no machine-readable protocol line rides along
+// 3. Verifies stderr is empty, so nothing was diverted there either
 func TestWorktreeAddWithoutCDFileEnv(t *testing.T) {
 	t.Parallel()
 	dir := initWorktreeRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
 	defer os.RemoveAll(worktreeRootFor(dir))
 	createFreeBranch(t, dir, "feature/x")
-
-	unused := filepath.Join(t.TempDir(), "never-written")
 
 	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, nil, "worktree", "add", "feature/x")
 	if err != nil {
@@ -1403,8 +1445,8 @@ func TestWorktreeAddWithoutCDFileEnv(t *testing.T) {
 	if stdout != want {
 		t.Errorf("Expected stdout %q, got %q", want, stdout)
 	}
-	if _, err := os.Stat(unused); !os.IsNotExist(err) {
-		t.Errorf("Expected no CD file to be created at %q", unused)
+	if stderr != "" {
+		t.Errorf("Expected no output on stderr, got %q", stderr)
 	}
 }
 

--- a/test/internal/config/shared_test.go
+++ b/test/internal/config/shared_test.go
@@ -59,6 +59,31 @@ func TestSharedManagedKeyPredicate(t *testing.T) {
 	}
 }
 
+// TestIsSharedManagedKeyExcludesWorktreeMarker verifies the worktree provenance
+// marker is machine-local state and never participates in the shared-managed set,
+// while gitflow.worktreePath stays shared-managed.
+// Steps:
+// 1. Calls config.IsSharedManagedKey on gitflow.worktree.feature/x.managed
+// 2. Repeats with a mixed-case spelling of the same key
+// 3. Verifies both are excluded (false)
+// 4. Verifies gitflow.worktreePath and gitflow.branch.feature.prefix remain included (true)
+func TestIsSharedManagedKeyExcludesWorktreeMarker(t *testing.T) {
+	t.Parallel()
+
+	if config.IsSharedManagedKey("gitflow.worktree.feature/x.managed") {
+		t.Error("expected gitflow.worktree.feature/x.managed to be excluded from the shared-managed set")
+	}
+	if config.IsSharedManagedKey("gitflow.Worktree.feature/x.Managed") {
+		t.Error("expected the mixed-case worktree marker to be excluded from the shared-managed set")
+	}
+	if !config.IsSharedManagedKey("gitflow.worktreePath") {
+		t.Error("expected gitflow.worktreePath to stay shared-managed")
+	}
+	if !config.IsSharedManagedKey("gitflow.branch.feature.prefix") {
+		t.Error("expected gitflow.branch.feature.prefix to stay shared-managed")
+	}
+}
+
 // TestCopySharedToLocalStaleRemovalPreservesLocalOnly covers scenario 39:
 // CopySharedToLocal removes stale managed keys but preserves local-only keys.
 // Steps:

--- a/test/internal/git/worktree_ops_test.go
+++ b/test/internal/git/worktree_ops_test.go
@@ -181,7 +181,15 @@ func TestListWorktreesIgnoresUnknownPorcelainLines(t *testing.T) {
 	if out, err := testutil.RunGit(t, dir, "worktree", "lock", wtPath); err != nil {
 		t.Fatalf("git worktree lock failed: %v\nOutput: %s", err, out)
 	}
-	t.Cleanup(func() { _, _ = testutil.RunGit(t, dir, "worktree", "unlock", wtPath) })
+	// Registered as a defer, not t.Cleanup: defers run LIFO before any t.Cleanup,
+	// so this one runs while the repository still exists, whereas CleanupTestRepo
+	// above (registered first, so it runs last) has by then removed it. That
+	// ordering is what lets the unlock failure be reported rather than discarded.
+	defer func() {
+		if out, err := testutil.RunGit(t, dir, "worktree", "unlock", wtPath); err != nil {
+			t.Errorf("Failed to unlock the worktree: %v\nOutput: %s", err, out)
+		}
+	}()
 
 	entries, err := repo.ListWorktrees()
 	if err != nil {

--- a/test/internal/git/worktree_ops_test.go
+++ b/test/internal/git/worktree_ops_test.go
@@ -1,0 +1,374 @@
+package git_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gittower/git-flow-next/internal/git"
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// setupWorktreeRepo creates a repository with a free branch and a linked
+// worktree for it, created through the repo handle. It returns the handle and
+// the SYMLINK-RESOLVED worktree path, so comparisons against the paths git
+// reports hold on macOS (/var vs /private/var).
+func setupWorktreeRepo(t *testing.T, dir string, branch string) (*git.Repo, string) {
+	t.Helper()
+	if out, err := testutil.RunGit(t, dir, "branch", branch); err != nil {
+		t.Fatalf("Failed to create branch %s: %v\nOutput: %s", branch, err, out)
+	}
+	repo := openRepo(t, dir)
+	wtPath := filepath.Join(t.TempDir(), "linked-worktree")
+	if err := repo.AddWorktree(wtPath, branch); err != nil {
+		t.Fatalf("AddWorktree failed: %v", err)
+	}
+	return repo, testutil.EvalPath(t, wtPath)
+}
+
+// findWorktreeEntry returns the entry whose path matches wtPath, or nil.
+func findWorktreeEntry(entries []git.WorktreeEntry, wtPath string) *git.WorktreeEntry {
+	for i := range entries {
+		if entries[i].Path == wtPath {
+			return &entries[i]
+		}
+	}
+	return nil
+}
+
+// TestDetachWorktreeKeepsChanges covers scenario 21: detaching a worktree's HEAD
+// leaves the tree and its uncommitted work untouched and frees the branch.
+// Steps:
+// 1. Creates a repository with feature/x and a linked worktree for it
+// 2. Modifies a tracked file and adds an untracked file inside the worktree
+// 3. Calls repo.DetachWorktree on the worktree path
+// 4. Verifies HEAD is unchanged and detached, both changes survive, and feature/x can be checked out again
+func TestDetachWorktreeKeepsChanges(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	repo, wtPath := setupWorktreeRepo(t, dir, "feature/x")
+
+	if err := os.WriteFile(filepath.Join(wtPath, "README.md"), []byte("modified"), 0644); err != nil {
+		t.Fatalf("Failed to modify tracked file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(wtPath, "scratch.txt"), []byte("scratch"), 0644); err != nil {
+		t.Fatalf("Failed to write untracked file: %v", err)
+	}
+
+	headBefore, err := testutil.RunGit(t, wtPath, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("Failed to read HEAD: %v", err)
+	}
+
+	if err := repo.DetachWorktree(wtPath); err != nil {
+		t.Fatalf("DetachWorktree failed: %v", err)
+	}
+
+	headAfter, err := testutil.RunGit(t, wtPath, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("Failed to read HEAD after detach: %v", err)
+	}
+	if strings.TrimSpace(headAfter) != strings.TrimSpace(headBefore) {
+		t.Errorf("Expected HEAD to stay at %q, got %q", strings.TrimSpace(headBefore), strings.TrimSpace(headAfter))
+	}
+	if _, err := testutil.RunGit(t, wtPath, "symbolic-ref", "-q", "HEAD"); err == nil {
+		t.Error("Expected HEAD to be detached (symbolic-ref should fail)")
+	}
+	content, err := os.ReadFile(filepath.Join(wtPath, "README.md"))
+	if err != nil || string(content) != "modified" {
+		t.Errorf("Expected the modification to survive, got %q (%v)", string(content), err)
+	}
+	if _, err := os.Stat(filepath.Join(wtPath, "scratch.txt")); err != nil {
+		t.Errorf("Expected the untracked file to survive: %v", err)
+	}
+	if out, err := testutil.RunGit(t, dir, "checkout", "feature/x"); err != nil {
+		t.Errorf("Expected feature/x to be checked out again after detach: %v\nOutput: %s", err, out)
+	}
+}
+
+// TestDetachWorktreeRefusesMainWorktree covers scenario 22: detach never acts on
+// the main worktree.
+// Steps:
+// 1. Creates a repository and resolves its main worktree root
+// 2. Calls repo.DetachWorktree on the main worktree
+// 3. Verifies a non-nil error identifying the main worktree
+// 4. Verifies the main worktree's HEAD is still a symbolic ref on main
+func TestDetachWorktreeRefusesMainWorktree(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	repo := openRepo(t, dir)
+
+	mainWorkTree, err := repo.MainWorkTree()
+	if err != nil {
+		t.Fatalf("MainWorkTree failed: %v", err)
+	}
+
+	err = repo.DetachWorktree(mainWorkTree)
+	if err == nil {
+		t.Fatal("Expected DetachWorktree to refuse the main worktree")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "main worktree") {
+		t.Errorf("Expected the error to identify the main worktree, got: %v", err)
+	}
+
+	ref, err := testutil.RunGit(t, dir, "symbolic-ref", "HEAD")
+	if err != nil {
+		t.Fatalf("Expected the main worktree HEAD to stay symbolic: %v", err)
+	}
+	if strings.TrimSpace(ref) != "refs/heads/main" {
+		t.Errorf("Expected HEAD to stay on refs/heads/main, got %q", strings.TrimSpace(ref))
+	}
+}
+
+// TestListWorktreesParsesPorcelainRecords verifies the porcelain parser returns
+// the main worktree first and a fully populated linked entry.
+// Steps:
+// 1. Creates a repository with feature/x and a linked worktree for it
+// 2. Calls repo.ListWorktrees
+// 3. Verifies the first entry is the main worktree, flagged Main
+// 4. Verifies the linked entry carries Branch feature/x and an absolute path
+func TestListWorktreesParsesPorcelainRecords(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	repo, wtPath := setupWorktreeRepo(t, dir, "feature/x")
+
+	entries, err := repo.ListWorktrees()
+	if err != nil {
+		t.Fatalf("ListWorktrees failed: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("Expected 2 entries, got %d: %+v", len(entries), entries)
+	}
+	if !entries[0].Main {
+		t.Errorf("Expected the first entry to be the main worktree, got %+v", entries[0])
+	}
+	if entries[0].Path != testutil.EvalPath(t, dir) {
+		t.Errorf("Expected the main entry path %q, got %q", testutil.EvalPath(t, dir), entries[0].Path)
+	}
+
+	linked := findWorktreeEntry(entries, wtPath)
+	if linked == nil {
+		t.Fatalf("Expected an entry for %q, got %+v", wtPath, entries)
+	}
+	if linked.Branch != "feature/x" {
+		t.Errorf("Expected Branch feature/x, got %q", linked.Branch)
+	}
+	if !filepath.IsAbs(linked.Path) {
+		t.Errorf("Expected an absolute path, got %q", linked.Path)
+	}
+	if linked.Main {
+		t.Error("Expected the linked entry not to be flagged Main")
+	}
+}
+
+// TestListWorktreesIgnoresUnknownPorcelainLines verifies the parser tolerates
+// annotations it does not know, using a real 'locked' record.
+// Steps:
+// 1. Creates a repository with feature/x and a linked worktree for it
+// 2. Runs 'git worktree lock' so git emits a locked annotation in the porcelain record
+// 3. Calls repo.ListWorktrees
+// 4. Verifies no error and that the entry still parses with its branch and path
+func TestListWorktreesIgnoresUnknownPorcelainLines(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	repo, wtPath := setupWorktreeRepo(t, dir, "feature/x")
+
+	if out, err := testutil.RunGit(t, dir, "worktree", "lock", wtPath); err != nil {
+		t.Fatalf("git worktree lock failed: %v\nOutput: %s", err, out)
+	}
+	t.Cleanup(func() { _, _ = testutil.RunGit(t, dir, "worktree", "unlock", wtPath) })
+
+	entries, err := repo.ListWorktrees()
+	if err != nil {
+		t.Fatalf("ListWorktrees failed on a record with an unknown annotation: %v", err)
+	}
+	linked := findWorktreeEntry(entries, wtPath)
+	if linked == nil {
+		t.Fatalf("Expected an entry for %q, got %+v", wtPath, entries)
+	}
+	if linked.Branch != "feature/x" {
+		t.Errorf("Expected Branch feature/x, got %q", linked.Branch)
+	}
+}
+
+// TestListWorktreesReportsDetachedEntry verifies a detached worktree is reported
+// as detached with no branch.
+// Steps:
+// 1. Creates a repository with feature/x and a linked worktree for it
+// 2. Detaches the worktree's HEAD
+// 3. Calls repo.ListWorktrees
+// 4. Verifies the entry has Detached true and an empty Branch
+func TestListWorktreesReportsDetachedEntry(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	repo, wtPath := setupWorktreeRepo(t, dir, "feature/x")
+
+	if out, err := testutil.RunGit(t, wtPath, "checkout", "--detach"); err != nil {
+		t.Fatalf("Failed to detach worktree HEAD: %v\nOutput: %s", err, out)
+	}
+
+	entries, err := repo.ListWorktrees()
+	if err != nil {
+		t.Fatalf("ListWorktrees failed: %v", err)
+	}
+	linked := findWorktreeEntry(entries, wtPath)
+	if linked == nil {
+		t.Fatalf("Expected an entry for %q, got %+v", wtPath, entries)
+	}
+	if !linked.Detached {
+		t.Error("Expected the entry to be flagged Detached")
+	}
+	if linked.Branch != "" {
+		t.Errorf("Expected an empty Branch for a detached entry, got %q", linked.Branch)
+	}
+}
+
+// TestWorktreeForBranchFindsLinkedWorktree verifies the branch lookup returns the
+// linked worktree holding the branch.
+// Steps:
+// 1. Creates a repository with feature/x and a linked worktree for it
+// 2. Calls repo.WorktreeForBranch("feature/x")
+// 3. Verifies a non-nil entry is returned
+// 4. Verifies its path is the linked worktree and it is not the main worktree
+func TestWorktreeForBranchFindsLinkedWorktree(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	repo, wtPath := setupWorktreeRepo(t, dir, "feature/x")
+
+	entry, err := repo.WorktreeForBranch("feature/x")
+	if err != nil {
+		t.Fatalf("WorktreeForBranch failed: %v", err)
+	}
+	if entry == nil {
+		t.Fatal("Expected an entry for feature/x")
+	}
+	if entry.Path != wtPath {
+		t.Errorf("Expected path %q, got %q", wtPath, entry.Path)
+	}
+	if entry.Main {
+		t.Error("Expected the linked worktree, not the main one")
+	}
+}
+
+// TestWorktreeForBranchReturnsNilForBranchWithoutWorktree verifies that absence
+// is not an error.
+// Steps:
+// 1. Creates a repository with a branch feature/lonely and no worktree for it
+// 2. Calls repo.WorktreeForBranch("feature/lonely")
+// 3. Verifies a nil error is returned
+// 4. Verifies a nil entry is returned
+func TestWorktreeForBranchReturnsNilForBranchWithoutWorktree(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	if out, err := testutil.RunGit(t, dir, "branch", "feature/lonely"); err != nil {
+		t.Fatalf("Failed to create branch: %v\nOutput: %s", err, out)
+	}
+	repo := openRepo(t, dir)
+
+	entry, err := repo.WorktreeForBranch("feature/lonely")
+	if err != nil {
+		t.Fatalf("Expected absence to be reported without an error, got: %v", err)
+	}
+	if entry != nil {
+		t.Errorf("Expected a nil entry, got %+v", entry)
+	}
+}
+
+// TestWorktreeHasChangesDetectsUntrackedFile verifies the dirty check runs
+// against the worktree path and counts untracked files.
+// Steps:
+// 1. Creates a repository with feature/x and a clean linked worktree for it
+// 2. Calls repo.WorktreeHasChanges and expects false
+// 3. Writes an untracked file inside the worktree
+// 4. Calls repo.WorktreeHasChanges again and expects true
+func TestWorktreeHasChangesDetectsUntrackedFile(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	repo, wtPath := setupWorktreeRepo(t, dir, "feature/x")
+
+	dirty, err := repo.WorktreeHasChanges(wtPath)
+	if err != nil {
+		t.Fatalf("WorktreeHasChanges failed: %v", err)
+	}
+	if dirty {
+		t.Error("Expected a freshly created worktree to be clean")
+	}
+
+	if err := os.WriteFile(filepath.Join(wtPath, "scratch.txt"), []byte("scratch"), 0644); err != nil {
+		t.Fatalf("Failed to write untracked file: %v", err)
+	}
+
+	dirty, err = repo.WorktreeHasChanges(wtPath)
+	if err != nil {
+		t.Fatalf("WorktreeHasChanges failed: %v", err)
+	}
+	if !dirty {
+		t.Error("Expected an untracked file to make the worktree dirty")
+	}
+}
+
+// TestRemoveWorktreeRefusesMainWorktree verifies removal refuses the main
+// worktree before invoking git.
+// Steps:
+// 1. Creates a repository and resolves its main worktree root
+// 2. Calls repo.RemoveWorktree on the main worktree without force
+// 3. Verifies a non-nil error identifying the main worktree
+// 4. Verifies the repository directory survives
+func TestRemoveWorktreeRefusesMainWorktree(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	repo := openRepo(t, dir)
+
+	mainWorkTree, err := repo.MainWorkTree()
+	if err != nil {
+		t.Fatalf("MainWorkTree failed: %v", err)
+	}
+
+	if err := repo.RemoveWorktree(mainWorkTree, false); err == nil {
+		t.Fatal("Expected RemoveWorktree to refuse the main worktree")
+	} else if !strings.Contains(strings.ToLower(err.Error()), "main worktree") {
+		t.Errorf("Expected the error to identify the main worktree, got: %v", err)
+	}
+
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		t.Errorf("Expected the repository directory to survive: %v", err)
+	}
+}
+
+// TestMainWorkTreeFromLinkedWorktree verifies a handle opened inside a linked
+// worktree still reports the main worktree root.
+// Steps:
+// 1. Creates a repository with feature/x and a linked worktree for it
+// 2. Opens a repo handle inside the linked worktree
+// 3. Verifies WorkTree() reports the linked worktree
+// 4. Verifies MainWorkTree() reports the main worktree root
+func TestMainWorkTreeFromLinkedWorktree(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	_, wtPath := setupWorktreeRepo(t, dir, "feature/x")
+
+	linkedRepo := openRepo(t, wtPath)
+
+	if got := testutil.EvalPath(t, linkedRepo.WorkTree()); got != testutil.EvalPath(t, wtPath) {
+		t.Errorf("Expected WorkTree() %q, got %q", testutil.EvalPath(t, wtPath), got)
+	}
+
+	mainWorkTree, err := linkedRepo.MainWorkTree()
+	if err != nil {
+		t.Fatalf("MainWorkTree failed: %v", err)
+	}
+	if got := testutil.EvalPath(t, mainWorkTree); got != testutil.EvalPath(t, dir) {
+		t.Errorf("Expected MainWorkTree() %q, got %q", testutil.EvalPath(t, dir), got)
+	}
+}

--- a/test/internal/worktree/main_test.go
+++ b/test/internal/worktree/main_test.go
@@ -1,0 +1,23 @@
+package worktree_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// TestMain builds the git-flow binary before running the worktree path tests,
+// which initialize git-flow via the binary to obtain a realistic configuration.
+// Set GIT_FLOW_PATH to test a specific prebuilt binary instead.
+func TestMain(m *testing.M) {
+	cleanup, err := testutil.BuildGitFlow()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to build git-flow binary: %v\n", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}

--- a/test/internal/worktree/path_test.go
+++ b/test/internal/worktree/path_test.go
@@ -1,0 +1,246 @@
+package worktree_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gittower/git-flow-next/internal/config"
+	"github.com/gittower/git-flow-next/internal/git"
+	"github.com/gittower/git-flow-next/internal/worktree"
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// setupInitializedRepo creates a repository with git-flow initialized to its
+// defaults, so the loaded configuration carries the topic branch types that
+// {{ topicType }} and {{ branchName }} expand against.
+func setupInitializedRepo(t *testing.T) string {
+	t.Helper()
+	dir := testutil.SetupTestRepo(t)
+	if out, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		testutil.CleanupTestRepo(t, dir)
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, out)
+	}
+	return dir
+}
+
+// openConfigured opens a repo handle for dir and loads its git-flow config.
+func openConfigured(t *testing.T, dir string) (*git.Repo, *config.Config) {
+	t.Helper()
+	repo, err := git.Open(dir)
+	if err != nil {
+		t.Fatalf("git.Open(%q) failed: %v", dir, err)
+	}
+	cfg, err := config.Load(repo)
+	if err != nil {
+		t.Fatalf("config.Load failed: %v", err)
+	}
+	return repo, cfg
+}
+
+// setTemplate writes gitflow.worktreePath into the repository's git config.
+func setTemplate(t *testing.T, dir string, template string) {
+	t.Helper()
+	if out, err := testutil.RunGit(t, dir, "config", "gitflow.worktreePath", template); err != nil {
+		t.Fatalf("Failed to set gitflow.worktreePath: %v\nOutput: %s", err, out)
+	}
+}
+
+// TestComputePathDefaultTemplate verifies the default template resolves to an
+// absolute sibling of the repository.
+// Steps:
+// 1. Creates a repository with git-flow defaults and no gitflow.worktreePath
+// 2. Opens a repo handle and loads the configuration
+// 3. Calls worktree.ComputePath for feature/user-auth
+// 4. Verifies the result is <repoParent>/<repo>-worktrees/feature/user-auth
+func TestComputePathDefaultTemplate(t *testing.T) {
+	t.Parallel()
+	dir := setupInitializedRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	repo, cfg := openConfigured(t, dir)
+
+	got, err := worktree.ComputePath(cfg, repo, "feature/user-auth")
+	if err != nil {
+		t.Fatalf("ComputePath failed: %v", err)
+	}
+
+	root := testutil.EvalPath(t, dir)
+	want := filepath.Join(filepath.Dir(root), filepath.Base(root)+"-worktrees", "feature", "user-auth")
+	if got != want {
+		t.Errorf("Expected %q, got %q", want, got)
+	}
+}
+
+// TestComputePathExpandsTilde verifies a leading ~ expands to the home directory.
+// Steps:
+// 1. Creates a repository with git-flow defaults
+// 2. Overrides HOME for the test process (so no t.Parallel)
+// 3. Sets gitflow.worktreePath to '~/wt/{{ branch }}'
+// 4. Verifies ComputePath returns <HOME>/wt/feature/x
+func TestComputePathExpandsTilde(t *testing.T) {
+	dir := setupInitializedRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	setTemplate(t, dir, "~/wt/{{ branch }}")
+	repo, cfg := openConfigured(t, dir)
+
+	got, err := worktree.ComputePath(cfg, repo, "feature/x")
+	if err != nil {
+		t.Fatalf("ComputePath failed: %v", err)
+	}
+
+	want := filepath.Join(home, "wt", "feature", "x")
+	if got != want {
+		t.Errorf("Expected %q, got %q", want, got)
+	}
+}
+
+// TestComputePathUnspacedPlaceholdersMatchSpaced verifies both brace forms expand
+// identically.
+// Steps:
+// 1. Creates a repository with git-flow defaults
+// 2. Computes the path with the spaced template '../wt/{{ topicType }}/{{ branch }}'
+// 3. Computes the path with the unspaced template '../wt/{{topicType}}/{{branch}}'
+// 4. Verifies the two results are byte-identical
+func TestComputePathUnspacedPlaceholdersMatchSpaced(t *testing.T) {
+	t.Parallel()
+	dir := setupInitializedRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	setTemplate(t, dir, "../wt/{{ topicType }}/{{ branch }}")
+	repo, cfg := openConfigured(t, dir)
+	spaced, err := worktree.ComputePath(cfg, repo, "feature/x")
+	if err != nil {
+		t.Fatalf("ComputePath failed: %v", err)
+	}
+
+	setTemplate(t, dir, "../wt/{{topicType}}/{{branch}}")
+	repo, cfg = openConfigured(t, dir)
+	unspaced, err := worktree.ComputePath(cfg, repo, "feature/x")
+	if err != nil {
+		t.Fatalf("ComputePath failed: %v", err)
+	}
+
+	if spaced != unspaced {
+		t.Errorf("Expected identical expansion, got %q (spaced) vs %q (unspaced)", spaced, unspaced)
+	}
+}
+
+// TestComputePathAbsoluteTemplateUsedAsIs verifies an absolute template is not
+// re-rooted against the main worktree.
+// Steps:
+// 1. Creates a repository with git-flow defaults
+// 2. Sets gitflow.worktreePath to an absolute template
+// 3. Calls ComputePath for feature/x
+// 4. Verifies the result is the template's own root, not a path under the repository
+func TestComputePathAbsoluteTemplateUsedAsIs(t *testing.T) {
+	t.Parallel()
+	dir := setupInitializedRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	absRoot := t.TempDir()
+	setTemplate(t, dir, filepath.ToSlash(absRoot)+"/{{ branch }}")
+	repo, cfg := openConfigured(t, dir)
+
+	got, err := worktree.ComputePath(cfg, repo, "feature/x")
+	if err != nil {
+		t.Fatalf("ComputePath failed: %v", err)
+	}
+
+	want := filepath.Join(absRoot, "feature", "x")
+	if got != want {
+		t.Errorf("Expected %q, got %q", want, got)
+	}
+}
+
+// TestComputePathRelativeTemplateResolvesAgainstMainWorkTree verifies a relative
+// template resolves against the MAIN worktree root even when the command runs
+// inside a linked worktree.
+// Steps:
+// 1. Creates a repository with git-flow defaults and a linked worktree on wt-branch
+// 2. Sets gitflow.worktreePath to the relative template '../wt/{{ branch }}'
+// 3. Opens a repo handle INSIDE the linked worktree and calls ComputePath
+// 4. Verifies the result is relative to the main worktree root, not the linked one
+func TestComputePathRelativeTemplateResolvesAgainstMainWorkTree(t *testing.T) {
+	t.Parallel()
+	dir := setupInitializedRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	linked := filepath.Join(t.TempDir(), "linked-worktree")
+	if out, err := testutil.RunGit(t, dir, "worktree", "add", linked, "-b", "wt-branch"); err != nil {
+		t.Fatalf("git worktree add failed: %v\nOutput: %s", err, out)
+	}
+	linked = testutil.EvalPath(t, linked)
+
+	setTemplate(t, dir, "../wt/{{ branch }}")
+	repo, cfg := openConfigured(t, linked)
+
+	got, err := worktree.ComputePath(cfg, repo, "feature/x")
+	if err != nil {
+		t.Fatalf("ComputePath failed: %v", err)
+	}
+
+	mainRoot := testutil.EvalPath(t, dir)
+	want := filepath.Join(filepath.Dir(mainRoot), "wt", "feature", "x")
+	if got != want {
+		t.Errorf("Expected the path to resolve against the main worktree (%q), got %q", want, got)
+	}
+	if got == filepath.Join(filepath.Dir(linked), "wt", "feature", "x") {
+		t.Error("Expected the relative template NOT to resolve against the linked worktree")
+	}
+}
+
+// TestComputePathNestedBranchProducesNestedDirs verifies a slashed branch name
+// yields nested directories using host separators.
+// Steps:
+// 1. Creates a repository with git-flow defaults
+// 2. Calls ComputePath for feature/user-auth with the default template
+// 3. Verifies the result ends with the host-separated "feature/user-auth" pair
+// 4. Verifies the result is absolute
+func TestComputePathNestedBranchProducesNestedDirs(t *testing.T) {
+	t.Parallel()
+	dir := setupInitializedRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	repo, cfg := openConfigured(t, dir)
+
+	got, err := worktree.ComputePath(cfg, repo, "feature/user-auth")
+	if err != nil {
+		t.Fatalf("ComputePath failed: %v", err)
+	}
+
+	if !filepath.IsAbs(got) {
+		t.Errorf("Expected an absolute path, got %q", got)
+	}
+	nested := filepath.Join("feature", "user-auth")
+	if filepath.Join(filepath.Base(filepath.Dir(got)), filepath.Base(got)) != nested {
+		t.Errorf("Expected %q to end in the nested pair %q", got, nested)
+	}
+}
+
+// TestComputePathCreatesNothing verifies path computation has no side effects.
+// Steps:
+// 1. Creates a repository with git-flow defaults
+// 2. Calls ComputePath for feature/x
+// 3. Verifies the returned path does not exist
+// 4. Verifies its parent directory does not exist either
+func TestComputePathCreatesNothing(t *testing.T) {
+	t.Parallel()
+	dir := setupInitializedRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(dir + "-worktrees")
+	repo, cfg := openConfigured(t, dir)
+
+	got, err := worktree.ComputePath(cfg, repo, "feature/x")
+	if err != nil {
+		t.Fatalf("ComputePath failed: %v", err)
+	}
+
+	if _, err := os.Stat(got); !os.IsNotExist(err) {
+		t.Errorf("Expected %q not to exist", got)
+	}
+	if _, err := os.Stat(filepath.Dir(got)); !os.IsNotExist(err) {
+		t.Errorf("Expected %q not to exist", filepath.Dir(got))
+	}
+}

--- a/test/internal/worktree/path_test.go
+++ b/test/internal/worktree/path_test.go
@@ -3,6 +3,7 @@ package worktree_test
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/gittower/git-flow-next/internal/config"
@@ -94,6 +95,65 @@ func TestComputePathExpandsTilde(t *testing.T) {
 	want := filepath.Join(home, "wt", "feature", "x")
 	if got != want {
 		t.Errorf("Expected %q, got %q", want, got)
+	}
+}
+
+// TestComputePathExpandsBareTilde verifies a template that is nothing but '~'
+// resolves to the home directory itself, the boundary of the '~/…' form above.
+// Steps:
+// 1. Creates a repository with git-flow defaults
+// 2. Overrides HOME for the test process (so no t.Parallel)
+// 3. Sets gitflow.worktreePath to '~'
+// 4. Verifies ComputePath returns <HOME>
+func TestComputePathExpandsBareTilde(t *testing.T) {
+	dir := setupInitializedRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	setTemplate(t, dir, "~")
+	repo, cfg := openConfigured(t, dir)
+
+	got, err := worktree.ComputePath(cfg, repo, "feature/x")
+	if err != nil {
+		t.Fatalf("ComputePath failed: %v", err)
+	}
+
+	if got != home {
+		t.Errorf("Expected %q, got %q", home, got)
+	}
+}
+
+// TestComputePathBackslashTildeIsLiteralOnUnix verifies the tilde is only
+// home-rooted when the character after it is a HOST path separator. On Unix a
+// backslash is an ordinary filename character, so '~\wt' must stay a relative
+// path rather than expanding. The Windows half of that rule — where '~\wt' DOES
+// expand — cannot be exercised here, since CI runs ubuntu-latest only.
+// Steps:
+// 1. Creates a repository with git-flow defaults, skipping on Windows
+// 2. Overrides HOME for the test process (so no t.Parallel)
+// 3. Sets gitflow.worktreePath to a backslash-separated '~\wt'
+// 4. Verifies the result is rooted in the repository, not in HOME
+func TestComputePathBackslashTildeIsLiteralOnUnix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("a backslash is a path separator on Windows, where '~\\wt' expands by design")
+	}
+	dir := setupInitializedRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	setTemplate(t, dir, `~\wt`)
+	repo, cfg := openConfigured(t, dir)
+
+	got, err := worktree.ComputePath(cfg, repo, "feature/x")
+	if err != nil {
+		t.Fatalf("ComputePath failed: %v", err)
+	}
+
+	want := filepath.Join(testutil.EvalPath(t, dir), `~\wt`)
+	if got != want {
+		t.Errorf("Expected the backslash form to stay literal at %q, got %q", want, got)
 	}
 }
 

--- a/test/testutil/git.go
+++ b/test/testutil/git.go
@@ -116,13 +116,39 @@ func RunGitWithEnv(t *testing.T, dir string, env []string, args ...string) (stri
 	return string(output), nil
 }
 
+// gitFlowEnv assembles the environment for a git-flow subprocess.
+//
+// Order matters, and it is: the test process environment, then an empty
+// GIT_FLOW_CD_FILE, then the caller's extra env, then GIT_EDITOR=: last.
+// exec dedups env keeping the FINAL value of a key, so:
+//   - the ambient GIT_FLOW_CD_FILE of a developer who exported the variable is
+//     neutralized for every test that does not opt in — otherwise each run would
+//     write into that developer's file and the "variable unset" scenario would
+//     silently stop testing anything;
+//   - a caller that does pass GIT_FLOW_CD_FILE=<path> still wins, since its
+//     value comes after the neutralizing one;
+//   - GIT_EDITOR=: comes last so caller env can never make git interactive.
+func gitFlowEnv(env []string) []string {
+	full := append(os.Environ(), "GIT_FLOW_CD_FILE=")
+	full = append(full, env...)
+	return append(full, "GIT_EDITOR=:")
+}
+
 // RunGitFlow runs a git-flow command in the specified directory and returns its output
 func RunGitFlow(t *testing.T, dir string, args ...string) (string, error) {
+	return RunGitFlowWithEnv(t, dir, nil, args...)
+}
+
+// RunGitFlowWithEnv runs a git-flow command in the specified directory with extra
+// environment variables appended to the child process env, returning its combined
+// output. The extra env is scoped to the subprocess only — it never mutates the
+// test process environment — so concurrent tests can isolate settings like
+// GIT_FLOW_CD_FILE without leaking into each other (see RunGitFlow for the
+// no-extra-env case).
+func RunGitFlowWithEnv(t *testing.T, dir string, env []string, args ...string) (string, error) {
 	cmd := exec.Command(gitFlowPath, args...)
 	cmd.Dir = dir
-	// Set GIT_EDITOR to colon (:) to prevent interactive editor from opening
-	// The colon is a shell builtin that does nothing and returns success
-	cmd.Env = append(os.Environ(), "GIT_EDITOR=:")
+	cmd.Env = gitFlowEnv(env)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
@@ -140,11 +166,17 @@ func RunGitFlow(t *testing.T, dir string, args ...string) (string, error) {
 // separately. Use it when a test has to prove which stream carried the output;
 // RunGitFlow merges the two and cannot distinguish them.
 func RunGitFlowStreams(t *testing.T, dir string, args ...string) (string, string, error) {
+	return RunGitFlowStreamsWithEnv(t, dir, nil, args...)
+}
+
+// RunGitFlowStreamsWithEnv runs a git-flow command with extra environment
+// variables and returns stdout and stderr separately. It is the stream-separating
+// counterpart of RunGitFlowWithEnv, for tests that need both an environment
+// (e.g. GIT_FLOW_CD_FILE) and proof of which stream carried the output.
+func RunGitFlowStreamsWithEnv(t *testing.T, dir string, env []string, args ...string) (string, string, error) {
 	cmd := exec.Command(gitFlowPath, args...)
 	cmd.Dir = dir
-	// Set GIT_EDITOR to colon (:) to prevent interactive editor from opening
-	// The colon is a shell builtin that does nothing and returns success
-	cmd.Env = append(os.Environ(), "GIT_EDITOR=:")
+	cmd.Env = gitFlowEnv(env)
 	var stdout, stderr strings.Builder
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -212,6 +244,28 @@ func RunGitFlowInteractive(t *testing.T, dir string, input string, args ...strin
 		return string(output), err
 	}
 	return string(output), nil
+}
+
+// EvalPath returns path with all symlinks resolved, failing the test if it
+// cannot be resolved.
+//
+// It exists because SetupTestRepo returns the raw os.MkdirTemp path (on macOS
+// /var/folders/…) while git reports the resolved one (/private/var/folders/…),
+// so any comparison between a test-computed path and a git-reported path must
+// resolve both sides.
+//
+// IMPORTANT: call this only on a path that EXISTS — typically the repository
+// root — and build expectations by appending the remaining components with
+// filepath.Join. filepath.EvalSymlinks fails on a path that does not exist, so it
+// can never be applied to a computed-but-not-yet-created path (e.g. the worktree
+// path `worktree path` prints).
+func EvalPath(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatalf("Failed to resolve symlinks for %q: %v", path, err)
+	}
+	return resolved
 }
 
 // SharedConfigPath returns the path to the committable .gitflow file at the root

--- a/test/testutil/git.go
+++ b/test/testutil/git.go
@@ -204,9 +204,7 @@ func RunGitFlowWithInput(t *testing.T, dir string, input string, args ...string)
 	cmd := exec.Command(gitFlowPath, args...)
 	cmd.Dir = dir
 	cmd.Stdin = strings.NewReader(input)
-	// Set GIT_EDITOR to colon (:) to prevent interactive editor from opening
-	// The colon is a shell builtin that does nothing and returns success
-	cmd.Env = append(os.Environ(), "GIT_EDITOR=:")
+	cmd.Env = gitFlowEnv(nil)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
@@ -232,7 +230,7 @@ func RunGitFlowInteractive(t *testing.T, dir string, input string, args ...strin
 	cmd := exec.Command(gitFlowPath, args...)
 	cmd.Dir = dir
 	cmd.Stdin = strings.NewReader(input)
-	cmd.Env = append(os.Environ(), "GIT_EDITOR=:", "GIT_FLOW_ASSUME_INTERACTIVE=1")
+	cmd.Env = append(gitFlowEnv(nil), "GIT_FLOW_ASSUME_INTERACTIVE=1")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {


### PR DESCRIPTION
Introduces the worktree foundation the rest of epic #171 builds on — path templates, provenance markers, a Git worktree operations layer, the `GIT_FLOW_CD_FILE` navigation channel, and the `git flow worktree` command.

`git flow worktree` is a static top-level command with `add`, `remove`, `list`, `prune` and `path`, addressing worktrees by full branch name. Target paths come from the `gitflow.worktreePath` template (`{{ repo }}`, `{{ branch }}`, `{{ branchName }}`, `{{ topicType }}`, spaced or unspaced, `~` expanded, always absolute), defaulting to `../{{ repo }}-worktrees/{{ branch }}`. Worktrees git-flow creates get the repository-local `gitflow.worktree.<branch>.managed` marker, which is what `list` uses to tag everything else `(unmanaged)` and what `prune` sweeps. New code lives in `internal/git/worktree.go` (porcelain listing, add/remove/prune/detach, dirty check), `internal/worktree/` (path computation and provenance), `internal/navigate/cdfile.go` and `cmd/worktree.go`, with additions to `internal/errors`, `internal/config/shared.go` and `internal/git/repo.go`. 66 new tests cover all 31 spec scenarios plus the decisions below, and the manpage `docs/git-flow-worktree.1.md` plus the configuration reference document the command.

Resolves #172
Relates #171

### Remarks

- The documented Git floor is **2.17+**, not the 2.15+ in the spec's Technical Notes. That figure is a factual error: `git worktree remove` landed in 2.17, so scenarios 11-16 cannot work below it. There is no runtime version probe — on older Git the user sees Git's own error. The porcelain `prunable` annotation (2.36+) is never parsed.
- `GIT_FLOW_CD_FILE` ships here as a channel only. The `git flow shell-init` command and the shell wrapper that set the variable and act on the file arrive in #174; until then it is exercised by tests and by anyone who sets the variable themselves. `worktree add` prints a plain `cd` hint and deliberately no shell-init tip, since naming a command that does not exist yet would advertise an error.
- `IsSharedManagedKey` gains a `gitflow.worktree.` carve-out so the machine-local provenance marker never reaches the committed `.gitflow`. Without it, `config sync` would not share the marker — it would delete it from local config. `gitflow.worktreePath` stays shared-managed on purpose, so the trailing dot in the prefix is load-bearing.
- `prune` sweeps markers by branch, so a worktree that is still live but detached loses its marker and thereafter lists as `(detached)` … `(unmanaged)`. This fails safe: a branch-keyed marker that outlived a detach could later be inherited by a worktree the user created by hand, and #175 would then delete their work. The worst case in this direction is a git-flow-created worktree being left alone. #175 inherits the rule.
- Relative `--path` resolves against the invocation directory, while a relative `gitflow.worktreePath` template resolves against the main worktree root. The asymmetry is intentional — hand-typed paths are cwd-rooted, templates are repo-rooted — and both directions are pinned by tests.
- An existing **empty** target directory is accepted; a non-empty one is refused. Plain `git worktree add` succeeds on an empty directory, and being stricter than the tool git-flow wraps buys nothing. Scenario 9's literal wording ("exists as a non-worktree directory") would have covered the empty case, so this is a deliberate reading, documented in the manpage NOTES and pinned by a test.
- `IsManaged` reads local scope only, matching the write side. A merged read would let a stray global marker tag a hand-made worktree as git-flow's, with no way to clear it since clearing only touches local scope.
- Nothing from #173-#177 is implemented: no `start` integration or per-type worktree default, no `checkout`/`shell-init`, no cleanup on `finish`/`delete`, no `list` integration for topic branches, no hooks.

**Review focus:**
- `cmd/worktree.go` — order of operations in `add` and `remove`: refusal precedence (the main-worktree refusal beats "no worktree for that branch"), a missing directory counting as clean, and the CD destination being written only after the mutation succeeds
- `internal/config/shared.go` — the carve-out prefix and its trailing dot
- `internal/worktree/provenance.go` — the branch-keyed marker sweep
- `internal/git/worktree.go` — the porcelain parser's tolerance of unknown annotations, and symlink resolution on both sides of every path comparison