### PR TITLE
feat(worktree): Add navigation and shell-init

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,14 @@ jobs:
       - name: Build
         run: go build ./...
 
+      # The shell-init wrapper tests execute the emitted scripts against their
+      # real interpreters. ubuntu-latest ships neither zsh nor fish, and the
+      # tests fail rather than skip when a shell is missing — a skip would leave
+      # the suite green while two of the three scripts were never run once.
+      - name: Install shells
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y zsh fish
+
       - name: Test
         run: go test -shuffle=on -timeout 20m ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- The EXIT STATUS section of the `git flow <type> checkout` manpage documented codes 1/2/3/4 that the command has never returned; it now documents the actual 2/3/5/6
+- The EXIT STATUS section of the `git flow <type> checkout` manpage documented codes 1/2/3/4 that the command has never returned; it now documents the actual 1/2/3/5/6
 
 ## [2.0.0] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `checkout` is worktree-aware: when the branch has a worktree, it reports the path and offers it to the calling shell instead of switching the current worktree's branch. `--worktree` creates a missing worktree first and records git-flow as its creator, `--clobber` clears a plain directory out of the way, `--no-cd` suppresses only the shell handover, and `--quiet` drops the shell-init tip
+- `checkout` is worktree-aware: when the branch has a worktree, it reports the path and offers it to the calling shell instead of switching the current worktree's branch. `--worktree` creates a missing worktree first and records git-flow as its creator, `--force` clears a plain directory out of the way, `--no-cd` suppresses only the shell handover, and `--quiet` drops the shell-init tip
 - `shell-init {bash|zsh|fish}` prints a shell wrapper that turns that handover into an automatic `cd`. It defines both a `git` and a `git-flow` function, so the documented `git flow …` form navigates too, and it scopes the navigation variable to a single command rather than exporting it
 - `worktree add` now points at `shell-init` when the navigation channel is unused, and gains `--quiet` to suppress that tip
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `checkout` is worktree-aware: when the branch has a worktree, it reports the path and offers it to the calling shell instead of switching the current worktree's branch. `--worktree` creates a missing worktree first and records git-flow as its creator, `--clobber` clears a plain directory out of the way, `--no-cd` suppresses only the shell handover, and `--quiet` drops the shell-init tip
+- `shell-init {bash|zsh|fish}` prints a shell wrapper that turns that handover into an automatic `cd`. It defines both a `git` and a `git-flow` function, so the documented `git flow …` form navigates too, and it scopes the navigation variable to a single command rather than exporting it
+- `worktree add` now points at `shell-init` when the navigation channel is unused, and gains `--quiet` to suppress that tip
+
+### Fixed
+
+- The EXIT STATUS section of the `git flow <type> checkout` manpage documented codes 1/2/3/4 that the command has never returned; it now documents the actual 2/3/5/6
+
 ## [2.0.0] - 2026-08-09
 
 ### Added

--- a/TESTING_GUIDELINES.md
+++ b/TESTING_GUIDELINES.md
@@ -466,6 +466,10 @@ To test a specific prebuilt binary instead (e.g. a release artifact), set the `G
 GIT_FLOW_PATH=/path/to/git-flow go test ./test/cmd/
 ```
 
+### Required Shells
+
+The shell-init wrapper tests execute the emitted scripts against their real interpreters, so **bash, zsh and fish must be installed** to run the suite (`brew install fish`, `sudo apt-get install -y zsh fish`). A missing shell **fails** the affected tests rather than skipping them: a skip would leave the suite green while two of the three emitted scripts were never executed once, which is exactly how a fish syntax error or a `$status`-clobbering statement would reach a release. `testutil.RunShell` handles the invocation; `testutil.RequireShell` produces the failure with the install command in it.
+
 ### CRITICAL: Use Test Helpers, Not Bash Piping
 
 **IMPORTANT**: When running git-flow commands that require interactive input, always use the `runGitFlowWithInput` helper function instead of bash piping.

--- a/cmd/checkout.go
+++ b/cmd/checkout.go
@@ -8,12 +8,31 @@ import (
 	"github.com/gittower/git-flow-next/internal/config"
 	"github.com/gittower/git-flow-next/internal/errors"
 	"github.com/gittower/git-flow-next/internal/git"
+	"github.com/gittower/git-flow-next/internal/navigate"
 )
 
+// CheckoutOptions carries the flags of 'git flow <type> checkout'. They are
+// grouped because they travel together through one call; individually they are
+// unrelated switches.
+type CheckoutOptions struct {
+	// Worktree creates the branch's worktree when it does not exist yet.
+	Worktree bool
+	// NoCD suppresses the navigation-destination write, and nothing else: the
+	// branch switch and the printed path both still happen.
+	NoCD bool
+	// Clobber allows a plain directory in the way of a new worktree to be
+	// removed. It only means anything alongside Worktree.
+	Clobber bool
+	// Quiet suppresses the shell-init tip.
+	Quiet bool
+	// ShowCommands echoes the git command before running it.
+	ShowCommands bool
+}
+
 // CheckoutCommand handles checking out a topic branch
-func CheckoutCommand(branchType string, nameOrPrefix string, showCommands bool) {
+func CheckoutCommand(branchType string, nameOrPrefix string, opts CheckoutOptions) {
 	repo := mustOpenRepo()
-	if err := executeCheckout(repo, branchType, nameOrPrefix, showCommands); err != nil {
+	if err := executeCheckout(repo, branchType, nameOrPrefix, opts); err != nil {
 		var exitCode errors.ExitCode
 		if flowErr, ok := err.(errors.Error); ok {
 			exitCode = flowErr.ExitCode()
@@ -26,7 +45,7 @@ func CheckoutCommand(branchType string, nameOrPrefix string, showCommands bool) 
 }
 
 // executeCheckout performs the actual branch checkout logic and returns any errors
-func executeCheckout(repo *git.Repo, branchType string, nameOrPrefix string, showCommands bool) error {
+func executeCheckout(repo *git.Repo, branchType string, nameOrPrefix string, opts CheckoutOptions) error {
 	// Load configuration
 	cfg, err := config.Load(repo)
 	if err != nil {
@@ -94,17 +113,80 @@ func executeCheckout(repo *git.Repo, branchType string, nameOrPrefix string, sho
 		}
 	}
 
+	// The worktree lookup runs on the RESOLVED name, never on what the user
+	// typed: 'checkout user' must find feature/user-auth's worktree.
+	entry, err := repo.WorktreeForBranch(fullBranchName)
+	if err != nil {
+		return &errors.GitError{Operation: "look up worktree for branch", Err: err}
+	}
+
+	if entry != nil {
+		// A registered worktree whose directory is gone must never be handed to
+		// the shell as a destination: git-flow would exit 0 while the shell
+		// failed to enter it.
+		if _, statErr := os.Stat(entry.Path); statErr != nil {
+			if !os.IsNotExist(statErr) {
+				return &errors.GitError{Operation: "inspect the worktree directory", Err: statErr}
+			}
+			return &errors.GitError{
+				Operation: fmt.Sprintf("check out branch '%s'", fullBranchName),
+				Err:       fmt.Errorf("its worktree at %s is gone; 'git flow worktree prune' drops stale entries", entry.Path),
+			}
+		}
+
+		// Navigating to the worktree the command already runs in would replace
+		// today's output with navigation lines and ask the shell to cd where it
+		// already is. So the ordinary case — checking out the branch you are on
+		// — stays exactly as it was, and only a genuine move navigates.
+		if !git.SamePath(entry.Path, repo.WorkTree()) {
+			return navigateToWorktree(fullBranchName, entry.Path, false, opts)
+		}
+	} else if opts.Worktree {
+		// --clobber reaches createWorktreeAt only from here: with no creation
+		// requested there is nothing to clobber, so the flag is ignored.
+		target, err := createWorktreeAt(cfg, repo, fullBranchName, "", opts.Clobber)
+		if err != nil {
+			return err
+		}
+		return navigateToWorktree(fullBranchName, target, true, opts)
+	}
+
 	// Show git command if requested
-	if showCommands {
+	if opts.ShowCommands {
 		fmt.Printf("$ git checkout %s\n", fullBranchName)
 	}
 
-	// Checkout the branch
+	// Checkout the branch. This stays 'git checkout' rather than 'git switch',
+	// which would raise the required Git version from 2.17 to 2.23.
 	err = repo.Checkout(fullBranchName)
 	if err != nil {
 		return &errors.GitError{Operation: fmt.Sprintf("checkout branch '%s'", fullBranchName), Err: err}
 	}
 
 	fmt.Printf("Switched to branch '%s'\n", fullBranchName)
+	return nil
+}
+
+// navigateToWorktree reports the branch's worktree and offers it to the calling
+// shell. The branch is never checked out in the current worktree — git allows a
+// branch in only one worktree at a time, and the destination already has it.
+//
+// The destination is written only after the worktree is known to exist, and a
+// write failure warns rather than failing a command that otherwise succeeded:
+// the user still has the path on screen.
+func navigateToWorktree(branch string, path string, created bool, opts CheckoutOptions) error {
+	if created {
+		fmt.Printf("Created worktree for branch '%s' at %s\n", branch, path)
+	} else {
+		fmt.Printf("Worktree for branch '%s' at %s\n", branch, path)
+	}
+	fmt.Printf("To switch to it: cd %s\n", path)
+	printShellInitTip(opts.Quiet)
+
+	if !opts.NoCD {
+		if err := navigate.WriteDestination(path); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
+		}
+	}
 	return nil
 }

--- a/cmd/checkout.go
+++ b/cmd/checkout.go
@@ -21,9 +21,9 @@ type CheckoutOptions struct {
 	// NoCD suppresses the navigation-destination write, and nothing else: the
 	// branch switch and the printed path both still happen.
 	NoCD bool
-	// Clobber allows a plain directory in the way of a new worktree to be
+	// Force allows a plain directory in the way of a new worktree to be
 	// removed. It only means anything alongside Worktree.
-	Clobber bool
+	Force bool
 	// Quiet suppresses the shell-init tip.
 	Quiet bool
 	// ShowCommands echoes the git command before running it.
@@ -144,9 +144,9 @@ func executeCheckout(repo *git.Repo, branchType string, nameOrPrefix string, opt
 			return navigateToWorktree(fullBranchName, entry.Path, false, opts)
 		}
 	} else if opts.Worktree {
-		// --clobber reaches createWorktreeAt only from here: with no creation
-		// requested there is nothing to clobber, so the flag is ignored.
-		target, err := createWorktreeAt(cfg, repo, fullBranchName, "", opts.Clobber)
+		// --force reaches createWorktreeAt only from here: with no creation
+		// requested there is nothing in the way to remove, so the flag is ignored.
+		target, err := createWorktreeAt(cfg, repo, fullBranchName, "", opts.Force)
 		if err != nil {
 			return err
 		}
@@ -180,7 +180,7 @@ func executeCheckout(repo *git.Repo, branchType string, nameOrPrefix string, opt
 //
 // The .git entry settles it without a git subprocess: a linked worktree carries a
 // .git FILE and the main worktree a .git DIRECTORY, so an Lstat that refuses only
-// on absence accepts both — the same idiom clobberTarget uses.
+// on absence accepts both — the same idiom removeObstruction uses.
 func worktreeIsPresent(path string) (bool, error) {
 	info, err := os.Stat(path)
 	if err != nil {

--- a/cmd/checkout.go
+++ b/cmd/checkout.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/gittower/git-flow-next/internal/config"
@@ -121,13 +122,14 @@ func executeCheckout(repo *git.Repo, branchType string, nameOrPrefix string, opt
 	}
 
 	if entry != nil {
-		// A registered worktree whose directory is gone must never be handed to
+		// A registered worktree that is no longer there must never be handed to
 		// the shell as a destination: git-flow would exit 0 while the shell
-		// failed to enter it.
-		if _, statErr := os.Stat(entry.Path); statErr != nil {
-			if !os.IsNotExist(statErr) {
-				return &errors.GitError{Operation: "inspect the worktree directory", Err: statErr}
-			}
+		// failed to enter it, or entered something unrelated.
+		present, presentErr := worktreeIsPresent(entry.Path)
+		if presentErr != nil {
+			return &errors.GitError{Operation: "inspect the worktree directory", Err: presentErr}
+		}
+		if !present {
 			return &errors.GitError{
 				Operation: fmt.Sprintf("check out branch '%s'", fullBranchName),
 				Err:       fmt.Errorf("its worktree at %s is gone; 'git flow worktree prune' drops stale entries", entry.Path),
@@ -165,6 +167,40 @@ func executeCheckout(repo *git.Repo, branchType string, nameOrPrefix string, opt
 
 	fmt.Printf("Switched to branch '%s'\n", fullBranchName)
 	return nil
+}
+
+// worktreeIsPresent reports whether the directory a worktree entry records is
+// still that worktree.
+//
+// Existence alone is not enough. A user who deletes a worktree directory by hand
+// and puts something else at that exact path leaves an entry pointing at a plain
+// directory or a file, and handing either to the shell is the failure SC-7 exists
+// to prevent: git-flow exits 0 while the shell either cannot enter the path at
+// all or lands somewhere that is not the worktree.
+//
+// The .git entry settles it without a git subprocess: a linked worktree carries a
+// .git FILE and the main worktree a .git DIRECTORY, so an Lstat that refuses only
+// on absence accepts both — the same idiom clobberTarget uses.
+func worktreeIsPresent(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	// Checked before the join, so a regular file at path is answered here rather
+	// than by an ENOTDIR that os.IsNotExist does not recognize.
+	if !info.IsDir() {
+		return false, nil
+	}
+	if _, err := os.Lstat(filepath.Join(path, ".git")); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 // navigateToWorktree reports the branch's worktree and offers it to the calling

--- a/cmd/shellinit.go
+++ b/cmd/shellinit.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -27,7 +28,11 @@ var shellInitCmd = &cobra.Command{
 		case "fish":
 			script = fishShellInit
 		default:
-			return nil
+			// Unreachable while ValidArgs and these cases agree. It is an error
+			// rather than a silent no-op so that adding a fourth shell to one
+			// without the other fails on the spot instead of printing nothing and
+			// exiting 0, which reads to the user as a broken install.
+			return fmt.Errorf("unsupported shell %q", args[0])
 		}
 		// io.WriteString rather than a Fprint: the scripts contain printf
 		// directives of their own, which a formatting call would misread.

--- a/cmd/shellinit.go
+++ b/cmd/shellinit.go
@@ -73,17 +73,17 @@ Source the script LAST in your startup file: the "git" function replaces any
 git alias or function defined before it.
 `
 
-// bashShellInit is the wrapper for bash. Every construct here is bash
-// 3.2-compatible, the version macOS still ships.
+// posixNavCore is the part of the wrapper bash and zsh share verbatim: the
+// navigation contract in __git_flow_nav, plus the git() function that routes
+// "git flow ..." into it. The two scripts differ ONLY in how git-flow() is
+// defined, so the core lives here once — a fix applied to a copy would otherwise
+// leave the other shell silently behind.
 //
-// The pieces that look fussy are the ones that were measured:
+// Every construct is bash 3.2-compatible, the version macOS still ships. The
+// pieces that look fussy are the ones that were measured:
 //
 //   - The single __git_flow_nav holds the whole contract and has a POSIX-valid
 //     name; git() and git-flow() are thin wrappers around it.
-//   - git-flow() is skipped outright in POSIX mode and otherwise defined from a
-//     quoted eval. "bash --posix" rejects git-flow as a function name, and that
-//     error is FATAL inside eval — the shell exits and neither 2>/dev/null nor
-//     "|| :" intercepts it — which would take the git() function down with it.
 //   - The assignment prefix, never export, keeps GIT_FLOW_CD_FILE scoped to the
 //     single command, so it cannot leak into other programs or subshells.
 //   - "command" prevents the functions from recursing into themselves.
@@ -92,10 +92,12 @@ git alias or function defined before it.
 //     function before the temp file is removed.
 //   - local is declared and assigned separately, so mktemp's exit status is not
 //     masked by local's always-zero one.
+//   - "${TMPDIR:-/tmp}" falls back for an unset AND for a set-but-empty TMPDIR;
+//     the fish script's test -n is the equivalent.
 //   - The mktemp template is the one form both GNU coreutils and BSD accept.
 //   - A failed cd is reported rather than swallowed, and the wrapper still
 //     returns git-flow's own status.
-const bashShellInit = `__git_flow_nav() {
+const posixNavCore = `__git_flow_nav() {
     local __gf_file=""
     __gf_file=$(mktemp "${TMPDIR:-/tmp}/git-flow-cd.XXXXXX") || {
         command git-flow "$@"
@@ -125,7 +127,15 @@ git() {
     fi
     command git "$@"
 }
+`
 
+// bashShellInit is the shared core plus bash's guarded git-flow().
+//
+// git-flow() is skipped outright in POSIX mode and otherwise defined from a
+// quoted eval. "bash --posix" rejects git-flow as a function name, and that error
+// is FATAL inside eval — the shell exits and neither 2>/dev/null nor "|| :"
+// intercepts it — which would take the git() function down with it.
+const bashShellInit = posixNavCore + `
 case ":$SHELLOPTS:" in
     *:posix:*) : ;;
     *) eval '
@@ -136,45 +146,15 @@ git-flow() {
 esac
 `
 
-// zshShellInit is the wrapper for zsh. It is the bash script with git-flow()
-// defined directly and unconditionally.
+// zshShellInit is the shared core plus git-flow() defined directly and
+// unconditionally.
 //
 // The POSIX guard is deliberately absent. SHELLOPTS is normally unset in zsh, so
 // expanding it aborts sourcing under a caller's set -u; and when zsh does
 // inherit an exported SHELLOPTS containing posix from a parent bash, the guard
 // would skip git-flow() for a restriction zsh does not have — zsh accepts the
 // name perfectly well.
-const zshShellInit = `__git_flow_nav() {
-    local __gf_file=""
-    __gf_file=$(mktemp "${TMPDIR:-/tmp}/git-flow-cd.XXXXXX") || {
-        command git-flow "$@"
-        return $?
-    }
-
-    local __gf_status=0
-    GIT_FLOW_CD_FILE="$__gf_file" command git-flow "$@" || __gf_status=$?
-
-    if [ -s "$__gf_file" ]; then
-        local __gf_dest=""
-        IFS= read -r __gf_dest < "$__gf_file" || :
-        if [ -n "$__gf_dest" ]; then
-            cd -- "$__gf_dest" || printf 'git-flow: cannot enter %s\n' "$__gf_dest" >&2
-        fi
-    fi
-
-    rm -f "$__gf_file"
-    return $__gf_status
-}
-
-git() {
-    if [ "${1:-}" = "flow" ]; then
-        shift
-        __git_flow_nav "$@"
-        return $?
-    fi
-    command git "$@"
-}
-
+const zshShellInit = posixNavCore + `
 git-flow() {
     __git_flow_nav "$@"
 }

--- a/cmd/shellinit.go
+++ b/cmd/shellinit.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"fmt"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -18,18 +18,21 @@ var shellInitCmd = &cobra.Command{
 	Args:      cobra.ExactValidArgs(1),
 	ValidArgs: []string{"bash", "zsh", "fish"},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		var script string
 		switch args[0] {
 		case "bash":
-			_, err := fmt.Fprint(os.Stdout, bashShellInit)
-			return err
+			script = bashShellInit
 		case "zsh":
-			_, err := fmt.Fprint(os.Stdout, zshShellInit)
-			return err
+			script = zshShellInit
 		case "fish":
-			_, err := fmt.Fprint(os.Stdout, fishShellInit)
-			return err
+			script = fishShellInit
+		default:
+			return nil
 		}
-		return nil
+		// io.WriteString rather than a Fprint: the scripts contain printf
+		// directives of their own, which a formatting call would misread.
+		_, err := io.WriteString(os.Stdout, script)
+		return err
 	},
 }
 

--- a/cmd/shellinit.go
+++ b/cmd/shellinit.go
@@ -1,0 +1,234 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(shellInitCmd)
+}
+
+var shellInitCmd = &cobra.Command{
+	Use:       "shell-init {bash|zsh|fish}",
+	Short:     "Print the shell integration script",
+	Long:      shellInitLong,
+	Args:      cobra.ExactValidArgs(1),
+	ValidArgs: []string{"bash", "zsh", "fish"},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		switch args[0] {
+		case "bash":
+			_, err := fmt.Fprint(os.Stdout, bashShellInit)
+			return err
+		case "zsh":
+			_, err := fmt.Fprint(os.Stdout, zshShellInit)
+			return err
+		case "fish":
+			_, err := fmt.Fprint(os.Stdout, fishShellInit)
+			return err
+		}
+		return nil
+	},
+}
+
+const shellInitLong = `Print a shell script that makes git-flow change your shell's directory.
+
+git-flow runs as a subprocess and cannot change the directory of the shell
+that started it, so a command that would move you writes its destination to
+the file named by GIT_FLOW_CD_FILE. The script printed here installs a
+wrapper that supplies that file for one command at a time, changes directory
+when the command came back with a destination, and removes the file
+afterwards. git-flow's own output is never captured, so colors, progress and
+prompts behave exactly as they do without the wrapper.
+
+Both a "git" and a "git-flow" shell function are defined: the "git" function
+is what makes the documented "git flow ..." form navigate, since git would
+otherwise run the git-flow binary as a subprocess of its own.
+
+Bash:
+
+  eval "$(git flow shell-init bash)"
+
+  # To load it for each session, add that line to ~/.bashrc
+
+Zsh:
+
+  eval "$(git flow shell-init zsh)"
+
+  # To load it for each session, add that line to ~/.zshrc
+
+Fish:
+
+  git flow shell-init fish | source
+
+  # To load it for each session, add that line to
+  # ~/.config/fish/config.fish
+
+Source the script LAST in your startup file: the "git" function replaces any
+git alias or function defined before it.
+`
+
+// bashShellInit is the wrapper for bash. Every construct here is bash
+// 3.2-compatible, the version macOS still ships.
+//
+// The pieces that look fussy are the ones that were measured:
+//
+//   - The single __git_flow_nav holds the whole contract and has a POSIX-valid
+//     name; git() and git-flow() are thin wrappers around it.
+//   - git-flow() is skipped outright in POSIX mode and otherwise defined from a
+//     quoted eval. "bash --posix" rejects git-flow as a function name, and that
+//     error is FATAL inside eval — the shell exits and neither 2>/dev/null nor
+//     "|| :" intercepts it — which would take the git() function down with it.
+//   - The assignment prefix, never export, keeps GIT_FLOW_CD_FILE scoped to the
+//     single command, so it cannot leak into other programs or subshells.
+//   - "command" prevents the functions from recursing into themselves.
+//   - "|| __gf_status=$?" rather than "; __gf_status=$?" keeps the wrapper
+//     transparent to a caller's set -e: an unguarded failure would abort the
+//     function before the temp file is removed.
+//   - local is declared and assigned separately, so mktemp's exit status is not
+//     masked by local's always-zero one.
+//   - The mktemp template is the one form both GNU coreutils and BSD accept.
+//   - A failed cd is reported rather than swallowed, and the wrapper still
+//     returns git-flow's own status.
+const bashShellInit = `__git_flow_nav() {
+    local __gf_file=""
+    __gf_file=$(mktemp "${TMPDIR:-/tmp}/git-flow-cd.XXXXXX") || {
+        command git-flow "$@"
+        return $?
+    }
+
+    local __gf_status=0
+    GIT_FLOW_CD_FILE="$__gf_file" command git-flow "$@" || __gf_status=$?
+
+    if [ -s "$__gf_file" ]; then
+        local __gf_dest=""
+        IFS= read -r __gf_dest < "$__gf_file" || :
+        if [ -n "$__gf_dest" ]; then
+            cd -- "$__gf_dest" || printf 'git-flow: cannot enter %s\n' "$__gf_dest" >&2
+        fi
+    fi
+
+    rm -f "$__gf_file"
+    return $__gf_status
+}
+
+git() {
+    if [ "${1:-}" = "flow" ]; then
+        shift
+        __git_flow_nav "$@"
+        return $?
+    fi
+    command git "$@"
+}
+
+case ":$SHELLOPTS:" in
+    *:posix:*) : ;;
+    *) eval '
+git-flow() {
+    __git_flow_nav "$@"
+}
+' ;;
+esac
+`
+
+// zshShellInit is the wrapper for zsh. It is the bash script with git-flow()
+// defined directly and unconditionally.
+//
+// The POSIX guard is deliberately absent. SHELLOPTS is normally unset in zsh, so
+// expanding it aborts sourcing under a caller's set -u; and when zsh does
+// inherit an exported SHELLOPTS containing posix from a parent bash, the guard
+// would skip git-flow() for a restriction zsh does not have — zsh accepts the
+// name perfectly well.
+const zshShellInit = `__git_flow_nav() {
+    local __gf_file=""
+    __gf_file=$(mktemp "${TMPDIR:-/tmp}/git-flow-cd.XXXXXX") || {
+        command git-flow "$@"
+        return $?
+    }
+
+    local __gf_status=0
+    GIT_FLOW_CD_FILE="$__gf_file" command git-flow "$@" || __gf_status=$?
+
+    if [ -s "$__gf_file" ]; then
+        local __gf_dest=""
+        IFS= read -r __gf_dest < "$__gf_file" || :
+        if [ -n "$__gf_dest" ]; then
+            cd -- "$__gf_dest" || printf 'git-flow: cannot enter %s\n' "$__gf_dest" >&2
+        fi
+    fi
+
+    rm -f "$__gf_file"
+    return $__gf_status
+}
+
+git() {
+    if [ "${1:-}" = "flow" ]; then
+        shift
+        __git_flow_nav "$@"
+        return $?
+    fi
+    command git "$@"
+}
+
+git-flow() {
+    __git_flow_nav "$@"
+}
+`
+
+// fishShellInit is the wrapper for fish, which needs fish 3.0 or newer.
+//
+// Fish-specific points, each of which the wrapper tests pin:
+//
+//   - There is no $?; $status must be captured in the statement IMMEDIATELY
+//     after the command, or an intervening test, if or echo replaces it.
+//   - "env VAR=... git-flow" scopes the variable to one command; the inline
+//     "VAR=... cmd" prefix needs fish 3.1, and env execs the binary, which also
+//     sidesteps the function shadowing without needing "command".
+//   - "set -e argv[1]" rather than a slice, which errors on an out-of-range
+//     range in older fish.
+//   - "if not cd ..." rather than "cd ...; or ...", so the diagnostic does not
+//     itself clobber $status before the return.
+//   - cd inside a function changes the shell's directory, because fish
+//     functions are not subshells.
+const fishShellInit = `function __git_flow_nav --description 'Run git-flow and act on its navigation channel'
+    set -l gf_dir /tmp
+    if set -q TMPDIR
+        set gf_dir $TMPDIR
+    end
+    set -l gf_file (mktemp "$gf_dir/git-flow-cd.XXXXXX")
+    if test -z "$gf_file"
+        command git-flow $argv
+        return $status
+    end
+
+    env GIT_FLOW_CD_FILE="$gf_file" git-flow $argv
+    set -l gf_status $status
+
+    if test -s "$gf_file"
+        read -l gf_dest <"$gf_file"
+        if test -n "$gf_dest"
+            if not cd "$gf_dest"
+                echo "git-flow: cannot enter $gf_dest" >&2
+            end
+        end
+    end
+
+    rm -f "$gf_file"
+    return $gf_status
+end
+
+function git-flow --description 'git-flow with automatic directory switching'
+    __git_flow_nav $argv
+end
+
+function git --description 'git with git-flow directory switching'
+    if test (count $argv) -gt 0; and test "$argv[1]" = flow
+        set -e argv[1]
+        __git_flow_nav $argv
+        return $status
+    end
+    command git $argv
+end
+`

--- a/cmd/shellinit.go
+++ b/cmd/shellinit.go
@@ -35,7 +35,8 @@ var shellInitCmd = &cobra.Command{
 			return fmt.Errorf("unsupported shell %q", args[0])
 		}
 		// io.WriteString rather than a Fprint: the scripts contain printf
-		// directives of their own, which a formatting call would misread.
+		// directives of their own, and go vet flags an fmt.Fprint whose argument
+		// looks like a format string ("possible Printf formatting directive").
 		_, err := io.WriteString(os.Stdout, script)
 		return err
 	},

--- a/cmd/shellinit.go
+++ b/cmd/shellinit.go
@@ -195,9 +195,18 @@ git-flow() {
 //     itself clobber $status before the return.
 //   - cd inside a function changes the shell's directory, because fish
 //     functions are not subshells.
+//   - "test -n $TMPDIR" rather than "set -q TMPDIR", which is TRUE for a
+//     set-but-EMPTY variable: that took the branch, ran mktemp against /, and
+//     lost navigation behind a raw mkstemp error while bash and zsh fell back
+//     cleanly through "${TMPDIR:-/tmp}".
+//   - cd takes no "--" here, where the bash and zsh core writes 'cd -- "$dest"'.
+//     The guard is unnecessary in every shell — navigate.WriteDestinationTo only
+//     ever writes an absolute path, so a destination cannot begin with "-" — and
+//     fish's floor for this script is 3.0, whose handling of "--" in cd no test
+//     here can exercise. The divergence is deliberate, not an oversight.
 const fishShellInit = `function __git_flow_nav --description 'Run git-flow and act on its navigation channel'
     set -l gf_dir /tmp
-    if set -q TMPDIR
+    if test -n "$TMPDIR"
         set gf_dir $TMPDIR
     end
     set -l gf_file (mktemp "$gf_dir/git-flow-cd.XXXXXX")

--- a/cmd/topicbranch.go
+++ b/cmd/topicbranch.go
@@ -371,14 +371,23 @@ func registerBranchCommand(branchType string) {
 			if len(args) > 0 {
 				nameOrPrefix = args[0]
 			}
-			showCommands, _ := cmd.Flags().GetBool("showcommands")
-			CheckoutCommand(branchType, nameOrPrefix, showCommands)
+			opts := CheckoutOptions{}
+			opts.Worktree, _ = cmd.Flags().GetBool("worktree")
+			opts.NoCD, _ = cmd.Flags().GetBool("no-cd")
+			opts.Clobber, _ = cmd.Flags().GetBool("clobber")
+			opts.Quiet, _ = cmd.Flags().GetBool("quiet")
+			opts.ShowCommands, _ = cmd.Flags().GetBool("showcommands")
+			CheckoutCommand(branchType, nameOrPrefix, opts)
 			return nil
 		},
 	}
 
 	// Add flags
 	checkoutCmd.Flags().Bool("showcommands", false, "Show git commands while executing them")
+	checkoutCmd.Flags().BoolP("worktree", "w", false, "Create the branch's worktree if it does not exist, then navigate to it")
+	checkoutCmd.Flags().Bool("no-cd", false, "Do not write a navigation destination for the calling shell")
+	checkoutCmd.Flags().Bool("clobber", false, "Remove a plain directory in the way of a new worktree (with --worktree)")
+	checkoutCmd.Flags().BoolP("quiet", "q", false, "Do not print the shell-init tip")
 
 	branchCmd.AddCommand(checkoutCmd)
 

--- a/cmd/topicbranch.go
+++ b/cmd/topicbranch.go
@@ -374,7 +374,7 @@ func registerBranchCommand(branchType string) {
 			opts := CheckoutOptions{}
 			opts.Worktree, _ = cmd.Flags().GetBool("worktree")
 			opts.NoCD, _ = cmd.Flags().GetBool("no-cd")
-			opts.Clobber, _ = cmd.Flags().GetBool("clobber")
+			opts.Force, _ = cmd.Flags().GetBool("force")
 			opts.Quiet, _ = cmd.Flags().GetBool("quiet")
 			opts.ShowCommands, _ = cmd.Flags().GetBool("showcommands")
 			CheckoutCommand(branchType, nameOrPrefix, opts)
@@ -386,7 +386,7 @@ func registerBranchCommand(branchType string) {
 	checkoutCmd.Flags().Bool("showcommands", false, "Show git commands while executing them")
 	checkoutCmd.Flags().BoolP("worktree", "w", false, "Create the branch's worktree if it does not exist, then navigate to it")
 	checkoutCmd.Flags().Bool("no-cd", false, "Do not write a navigation destination for the calling shell")
-	checkoutCmd.Flags().Bool("clobber", false, "Remove a plain directory in the way of a new worktree (with --worktree)")
+	checkoutCmd.Flags().Bool("force", false, "Remove a plain directory in the way of a new worktree (with --worktree)")
 	checkoutCmd.Flags().BoolP("quiet", "q", false, "Do not print the shell-init tip")
 
 	branchCmd.AddCommand(checkoutCmd)

--- a/cmd/worktree.go
+++ b/cmd/worktree.go
@@ -51,7 +51,8 @@ directories of the computed path are created as needed.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		path, _ := cmd.Flags().GetString("path")
 		noCD, _ := cmd.Flags().GetBool("no-cd")
-		WorktreeAddCommand(args[0], path, noCD)
+		quiet, _ := cmd.Flags().GetBool("quiet")
+		WorktreeAddCommand(args[0], path, noCD, quiet)
 	},
 }
 
@@ -112,9 +113,9 @@ Nothing is created and nothing is changed.`,
 }
 
 // WorktreeAddCommand is the implementation of 'git flow worktree add'.
-func WorktreeAddCommand(branch string, path string, noCD bool) {
+func WorktreeAddCommand(branch string, path string, noCD bool, quiet bool) {
 	runWorktreeCommand(func(repo *git.Repo) error {
-		return executeWorktreeAdd(repo, branch, path, noCD)
+		return executeWorktreeAdd(repo, branch, path, noCD, quiet)
 	})
 }
 
@@ -185,7 +186,7 @@ func loadWorktreeConfig(repo *git.Repo) (*config.Config, error) {
 }
 
 // executeWorktreeAdd creates a worktree for an existing branch.
-func executeWorktreeAdd(repo *git.Repo, branch string, pathFlag string, noCD bool) error {
+func executeWorktreeAdd(repo *git.Repo, branch string, pathFlag string, noCD bool, quiet bool) error {
 	cfg, err := loadWorktreeConfig(repo)
 	if err != nil {
 		return err
@@ -216,6 +217,7 @@ func executeWorktreeAdd(repo *git.Repo, branch string, pathFlag string, noCD boo
 
 	fmt.Printf("Created worktree for branch '%s' at %s\n", branch, target)
 	fmt.Printf("To switch to it: cd %s\n", target)
+	printShellInitTip(quiet)
 
 	if !noCD {
 		// Written only now, after the worktree exists.
@@ -449,6 +451,24 @@ func resolveWorktreeTarget(cfg *config.Config, repo *git.Repo, branch string, pa
 	return path, nil
 }
 
+// printShellInitTip points the user at 'git flow shell-init' after a navigation
+// they now have to perform by hand.
+//
+// It prints only when the navigation channel is unused: a caller that set
+// GIT_FLOW_CD_FILE has the wrapper installed already, and telling them to
+// install it would be noise on every navigating command. The decision is made on
+// the resolved destination file rather than on whether the variable exists,
+// because an empty value means the same thing as an absent one.
+//
+// <shell> is printed verbatim: 'git flow shell-init' with no argument errors
+// with usage, so naming a placeholder is what keeps the tip honest.
+func printShellInitTip(quiet bool) {
+	if quiet || navigate.DestinationFile() != "" {
+		return
+	}
+	fmt.Println("Tip: run 'git flow shell-init <shell>' for automatic directory switching")
+}
+
 // createWorktreeAt creates the worktree for branch and records git-flow as its
 // creator, returning the path it was created at.
 //
@@ -566,6 +586,7 @@ func pathIsOccupied(path string) (bool, error) {
 func init() {
 	worktreeAddCmd.Flags().String("path", "", "Create the worktree at this path instead of the computed one")
 	worktreeAddCmd.Flags().Bool("no-cd", false, "Do not write a navigation destination for the calling shell")
+	worktreeAddCmd.Flags().BoolP("quiet", "q", false, "Do not print the shell-init tip")
 
 	worktreeRemoveCmd.Flags().Bool("force", false, "Remove even with uncommitted or untracked changes")
 	worktreeRemoveCmd.Flags().Bool("no-cd", false, "Do not write a navigation destination for the calling shell")

--- a/cmd/worktree.go
+++ b/cmd/worktree.go
@@ -478,9 +478,9 @@ func printShellInitTip(quiet bool) {
 // that the branch exists and has no worktree yet, and prints its own
 // confirmation — the wording differs between the two commands.
 //
-// clobber removes a plain directory that is in the way. It never removes
-// anything else; see clobberTarget.
-func createWorktreeAt(cfg *config.Config, repo *git.Repo, branch string, pathFlag string, clobber bool) (string, error) {
+// force removes a plain directory that is in the way. It never removes
+// anything else; see removeObstruction.
+func createWorktreeAt(cfg *config.Config, repo *git.Repo, branch string, pathFlag string, force bool) (string, error) {
 	target, err := resolveWorktreeTarget(cfg, repo, branch, pathFlag)
 	if err != nil {
 		return "", err
@@ -491,10 +491,10 @@ func createWorktreeAt(cfg *config.Config, repo *git.Repo, branch string, pathFla
 		return "", &errors.GitError{Operation: "inspect target path", Err: err}
 	}
 	if occupied {
-		if !clobber {
+		if !force {
 			return "", &errors.WorktreePathOccupiedError{Path: target}
 		}
-		if err := clobberTarget(repo, target); err != nil {
+		if err := removeObstruction(repo, target); err != nil {
 			return "", err
 		}
 	}
@@ -517,8 +517,8 @@ func createWorktreeAt(cfg *config.Config, repo *git.Repo, branch string, pathFla
 	return target, nil
 }
 
-// clobberTarget removes an occupied target path, but only when what is there is
-// a plain directory git-flow can afford to lose.
+// removeObstruction removes an occupied target path, but only when what is
+// there is a plain directory git-flow can afford to lose.
 //
 // The three refusals bound the blast radius of a mistyped path template. The
 // .git test uses Lstat and refuses on ANY result — the linked-worktree form is a
@@ -530,13 +530,13 @@ func createWorktreeAt(cfg *config.Config, repo *git.Repo, branch string, pathFla
 // destructive — Go's RemoveAll never descends through a symlink — and the blast
 // radius is exactly one dangling link, so the asymmetry is left alone rather than
 // traded for an Lstat that would refuse a symlinked worktree root outright.
-func clobberTarget(repo *git.Repo, target string) error {
+func removeObstruction(repo *git.Repo, target string) error {
 	info, err := os.Stat(target)
 	if err != nil {
 		return &errors.GitError{Operation: "inspect target path", Err: err}
 	}
 	if !info.IsDir() {
-		return &errors.ClobberRefusedError{Path: target, Reason: "it is a file, not a directory"}
+		return &errors.RemovalRefusedError{Path: target, Reason: "it is a file, not a directory"}
 	}
 
 	entries, err := repo.ListWorktrees()
@@ -545,7 +545,7 @@ func clobberTarget(repo *git.Repo, target string) error {
 	}
 	for _, entry := range entries {
 		if git.SamePath(entry.Path, target) {
-			return &errors.ClobberRefusedError{
+			return &errors.RemovalRefusedError{
 				Path:   target,
 				Reason: "it is a registered worktree of this repository; 'git flow worktree remove <branch>' removes it safely",
 			}
@@ -553,7 +553,7 @@ func clobberTarget(repo *git.Repo, target string) error {
 	}
 
 	if _, err := os.Lstat(filepath.Join(target, ".git")); err == nil {
-		return &errors.ClobberRefusedError{
+		return &errors.RemovalRefusedError{
 			Path:   target,
 			Reason: "it contains a .git entry, so it looks like a repository",
 		}

--- a/cmd/worktree.go
+++ b/cmd/worktree.go
@@ -209,29 +209,9 @@ func executeWorktreeAdd(repo *git.Repo, branch string, pathFlag string, noCD boo
 		return &errors.WorktreeExistsError{Branch: branch, Path: existing.Path}
 	}
 
-	target, err := resolveWorktreeTarget(cfg, repo, branch, pathFlag)
+	target, err := createWorktreeAt(cfg, repo, branch, pathFlag, false)
 	if err != nil {
 		return err
-	}
-	if occupied, err := pathIsOccupied(target); err != nil {
-		return &errors.GitError{Operation: "inspect target path", Err: err}
-	} else if occupied {
-		return &errors.WorktreePathOccupiedError{Path: target}
-	}
-
-	// A branch name with slashes computes a nested path, whose intermediate
-	// directories have to exist first.
-	if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
-		return &errors.GitError{Operation: "create worktree parent directory", Err: err}
-	}
-	if err := repo.AddWorktree(target, branch); err != nil {
-		return &errors.GitError{Operation: "add worktree", Err: err}
-	}
-
-	// A missing marker only means later cleanup leaves this worktree alone, so a
-	// failure here warns rather than failing an operation that already succeeded.
-	if err := worktree.MarkManaged(repo, branch); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
 	}
 
 	fmt.Printf("Created worktree for branch '%s' at %s\n", branch, target)
@@ -467,6 +447,99 @@ func resolveWorktreeTarget(cfg *config.Config, repo *git.Repo, branch string, pa
 		return "", &errors.GitError{Operation: "compute worktree path", Err: err}
 	}
 	return path, nil
+}
+
+// createWorktreeAt creates the worktree for branch and records git-flow as its
+// creator, returning the path it was created at.
+//
+// It is shared by 'worktree add' and 'checkout --worktree' so the two cannot
+// drift: the target resolution, the occupancy rules and the provenance marker
+// are decided in exactly one place. The caller is expected to have established
+// that the branch exists and has no worktree yet, and prints its own
+// confirmation — the wording differs between the two commands.
+//
+// clobber removes a plain directory that is in the way. It never removes
+// anything else; see clobberTarget.
+func createWorktreeAt(cfg *config.Config, repo *git.Repo, branch string, pathFlag string, clobber bool) (string, error) {
+	target, err := resolveWorktreeTarget(cfg, repo, branch, pathFlag)
+	if err != nil {
+		return "", err
+	}
+
+	occupied, err := pathIsOccupied(target)
+	if err != nil {
+		return "", &errors.GitError{Operation: "inspect target path", Err: err}
+	}
+	if occupied {
+		if !clobber {
+			return "", &errors.WorktreePathOccupiedError{Path: target}
+		}
+		if err := clobberTarget(repo, target); err != nil {
+			return "", err
+		}
+	}
+
+	// A branch name with slashes computes a nested path, whose intermediate
+	// directories have to exist first.
+	if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+		return "", &errors.GitError{Operation: "create worktree parent directory", Err: err}
+	}
+	if err := repo.AddWorktree(target, branch); err != nil {
+		return "", &errors.GitError{Operation: "add worktree", Err: err}
+	}
+
+	// A missing marker only means later cleanup leaves this worktree alone, so a
+	// failure here warns rather than failing an operation that already succeeded.
+	if err := worktree.MarkManaged(repo, branch); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
+	}
+
+	return target, nil
+}
+
+// clobberTarget removes an occupied target path, but only when what is there is
+// a plain directory git-flow can afford to lose.
+//
+// The three refusals bound the blast radius of a mistyped path template. The
+// .git test uses Lstat and refuses on ANY result — the linked-worktree form is a
+// .git file and an ordinary clone is a .git directory, so a check that handled
+// only one of them would remove the other.
+func clobberTarget(repo *git.Repo, target string) error {
+	info, err := os.Stat(target)
+	if err != nil {
+		return &errors.GitError{Operation: "inspect target path", Err: err}
+	}
+	if !info.IsDir() {
+		return &errors.ClobberRefusedError{Path: target, Reason: "it is a file, not a directory"}
+	}
+
+	entries, err := repo.ListWorktrees()
+	if err != nil {
+		return &errors.GitError{Operation: "list worktrees", Err: err}
+	}
+	for _, entry := range entries {
+		if git.SamePath(entry.Path, target) {
+			return &errors.ClobberRefusedError{
+				Path:   target,
+				Reason: "it is a registered worktree of this repository; 'git flow worktree remove <branch>' removes it safely",
+			}
+		}
+	}
+
+	if _, err := os.Lstat(filepath.Join(target, ".git")); err == nil {
+		return &errors.ClobberRefusedError{
+			Path:   target,
+			Reason: "it contains a .git entry, so it looks like a repository",
+		}
+	} else if !os.IsNotExist(err) {
+		return &errors.GitError{Operation: "inspect target path", Err: err}
+	}
+
+	if err := os.RemoveAll(target); err != nil {
+		return &errors.GitError{Operation: "remove the directory in the way", Err: err}
+	}
+	fmt.Printf("Removed %s to make room for the worktree\n", target)
+	return nil
 }
 
 // pathIsOccupied reports whether something is already in the way at path. An

--- a/cmd/worktree.go
+++ b/cmd/worktree.go
@@ -524,6 +524,12 @@ func createWorktreeAt(cfg *config.Config, repo *git.Repo, branch string, pathFla
 // .git test uses Lstat and refuses on ANY result — the linked-worktree form is a
 // .git file and an ordinary clone is a .git directory, so a check that handled
 // only one of them would remove the other.
+//
+// When target is a SYMLINK the guards below follow it while RemoveAll acts on the
+// link itself, so the object inspected and the object removed differ. That is not
+// destructive — Go's RemoveAll never descends through a symlink — and the blast
+// radius is exactly one dangling link, so the asymmetry is left alone rather than
+// traded for an Lstat that would refuse a symlinked worktree root outright.
 func clobberTarget(repo *git.Repo, target string) error {
 	info, err := os.Stat(target)
 	if err != nil {

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ This directory contains comprehensive manpage-style documentation for all git-fl
 - **git-flow-hotfix.1.md** - Hotfix branch management
 - **git-flow-overview.1.md** - Repository workflow overview
 - **git-flow-completion.1.md** - Shell completion script generation
+- **git-flow-shell-init.1.md** - Shell integration script for directory switching
 
 ### Configuration Documentation (Section 5)
 - **gitflow-config.5.md** - Complete configuration reference and examples

--- a/docs/git-flow-checkout.1.md
+++ b/docs/git-flow-checkout.1.md
@@ -6,7 +6,7 @@ git-flow-checkout - Switch to topic branches
 
 ## SYNOPSIS
 
-**git-flow** *topic* **checkout** *name*|*nameprefix* [**--worktree**] [**--no-cd**] [**--clobber**] [**--quiet**] [**--showcommands**]
+**git-flow** *topic* **checkout** *name*|*nameprefix* [**--worktree**] [**--no-cd**] [**--force**] [**--quiet**] [**--showcommands**]
 
 ## DESCRIPTION
 
@@ -32,8 +32,8 @@ When the branch has a worktree, checkout **navigates to it** instead of switchin
 **--no-cd**
 : Do not write a navigation destination for the calling shell, even when **GIT_FLOW_CD_FILE** is set. The path is still printed for manual use, and the branch switch — when there is one — still happens.
 
-**--clobber**
-: Remove a plain directory standing in the way of a new worktree. Only meaningful together with **--worktree**; on its own it does nothing at all, because with no worktree to create there is nothing to clobber. Removal is refused when the target is a file, a registered worktree of this repository, or a directory containing a `.git` entry.
+**--force**
+: Remove a plain directory standing in the way of a new worktree. Only meaningful together with **--worktree**; on its own it does nothing at all, because with no worktree to create there is nothing in the way to remove. Removal is refused when the target is a file, a registered worktree of this repository, or a directory containing a `.git` entry.
 
 **--quiet**, **-q**
 : Do not print the tip naming **git flow shell-init**.
@@ -253,7 +253,7 @@ git checkout feature/branch -- specific-file.txt
 : Branch not found
 
 **6**
-: A refusal: the target path of a new worktree is occupied, or **--clobber** was asked to remove a file, a registered worktree, or a directory containing a `.git` entry
+: A refusal: the target path of a new worktree is occupied, or **--force** was asked to remove a file, a registered worktree, or a directory containing a `.git` entry
 
 ## SEE ALSO
 

--- a/docs/git-flow-checkout.1.md
+++ b/docs/git-flow-checkout.1.md
@@ -240,6 +240,9 @@ git checkout feature/branch -- specific-file.txt
 **0**
 : Successful checkout or navigation
 
+**1**
+: Usage error, such as more than one branch name on the command line
+
 **2**
 : Invalid topic branch type
 

--- a/docs/git-flow-checkout.1.md
+++ b/docs/git-flow-checkout.1.md
@@ -49,7 +49,7 @@ A branch that has a worktree lives somewhere else on disk, and Git allows a bran
 |---|---|---|
 | The branch has a worktree elsewhere (linked or the main one) | either | Navigate to it. The current worktree's branch is unchanged |
 | The branch's worktree **is** the worktree you are in | either | Ordinary checkout — `Switched to branch '<name>'`, nothing written to the channel |
-| The branch has a worktree whose directory is gone | either | Error naming **git flow worktree prune**; nothing is written |
+| The branch has a worktree whose directory is gone, or was replaced by something that is not a worktree | either | Error naming **git flow worktree prune**; nothing is written |
 | The branch has no worktree | no | Ordinary checkout |
 | The branch has no worktree | yes | Create it, record it as git-flow-created, then navigate |
 
@@ -244,7 +244,7 @@ git checkout feature/branch -- specific-file.txt
 : Invalid topic branch type
 
 **3**
-: A Git operation failed — an ambiguous branch name, a failed checkout, or a worktree whose directory is gone
+: A Git operation failed — an ambiguous branch name, a failed checkout, or a worktree that is no longer at its recorded path
 
 **5**
 : Branch not found

--- a/docs/git-flow-checkout.1.md
+++ b/docs/git-flow-checkout.1.md
@@ -6,13 +6,15 @@ git-flow-checkout - Switch to topic branches
 
 ## SYNOPSIS
 
-**git-flow** *topic* **checkout** *name*|*nameprefix*
+**git-flow** *topic* **checkout** *name*|*nameprefix* [**--worktree**] [**--no-cd**] [**--clobber**] [**--quiet**] [**--showcommands**]
 
 ## DESCRIPTION
 
 Switch to an existing topic branch of the specified type. This command works with any topic branch type (feature, release, hotfix, support, or custom types) and supports partial name matching for convenience.
 
 The checkout command is a convenient wrapper around **git checkout** that automatically handles branch prefixes and provides partial name matching.
+
+When the branch has a worktree, checkout **navigates to it** instead of switching the current worktree's branch. See **WORKTREES** below.
 
 ## ARGUMENTS
 
@@ -24,8 +26,45 @@ The checkout command is a convenient wrapper around **git checkout** that automa
 
 ## OPTIONS
 
+**--worktree**, **-w**
+: Create the branch's worktree if it does not exist yet, then navigate to it. The worktree is created at the path the **gitflow.worktreePath** template computes and is recorded as git-flow-created. Without this flag, a branch with no worktree is simply checked out.
+
+**--no-cd**
+: Do not write a navigation destination for the calling shell, even when **GIT_FLOW_CD_FILE** is set. The path is still printed for manual use, and the branch switch — when there is one — still happens.
+
+**--clobber**
+: Remove a plain directory standing in the way of a new worktree. Only meaningful together with **--worktree**; on its own it does nothing at all, because with no worktree to create there is nothing to clobber. Removal is refused when the target is a file, a registered worktree of this repository, or a directory containing a `.git` entry.
+
+**--quiet**, **-q**
+: Do not print the tip naming **git flow shell-init**.
+
 **--showcommands**
-: Show the underlying git commands as they are executed.
+: Show the underlying git commands as they are executed. Navigating to a worktree runs no git command, so nothing is shown for it.
+
+## WORKTREES
+
+A branch that has a worktree lives somewhere else on disk, and Git allows a branch in only one worktree at a time. Rather than failing the way a plain **git checkout** would, checkout **navigates**: it prints the worktree's path and offers it to the calling shell through **GIT_FLOW_CD_FILE**, leaving the current worktree's branch untouched.
+
+| State | **--worktree** | Behaviour |
+|---|---|---|
+| The branch has a worktree elsewhere (linked or the main one) | either | Navigate to it. The current worktree's branch is unchanged |
+| The branch's worktree **is** the worktree you are in | either | Ordinary checkout — `Switched to branch '<name>'`, nothing written to the channel |
+| The branch has a worktree whose directory is gone | either | Error naming **git flow worktree prune**; nothing is written |
+| The branch has no worktree | no | Ordinary checkout |
+| The branch has no worktree | yes | Create it, record it as git-flow-created, then navigate |
+
+Navigating to a worktree that already exists **never changes its provenance**: a worktree created by hand with **git worktree add** stays `(unmanaged)` in **git flow worktree list** no matter how often you check the branch out. Only creation writes the marker.
+
+The per-branch-type worktree default governs **start**, not checkout: checkout creates a missing worktree only when **--worktree** is given explicitly.
+
+## ENVIRONMENT
+
+**GIT_FLOW_CD_FILE**
+: When set to a writable path, a navigation writes its absolute destination there. git-flow runs as a subprocess and cannot change its parent shell's working directory, so this variable is how a caller asks for that destination in a form it can act on. The variable is an input git-flow reads, never one it sets, which is why it is not a Git config key.
+
+: The destination is written **only after** the worktree is known to exist, so a refused or failed command leaves the file empty; an ordinary branch switch is not a navigation and writes nothing. **--no-cd** suppresses the write. A failure to write is **not fatal**: the command still succeeds and a warning is printed to standard error.
+
+: **git flow shell-init** prints a shell wrapper that supplies this file and changes directory for you. See **git-flow-shell-init**(1).
 
 ## PARTIAL NAME MATCHING
 
@@ -199,23 +238,23 @@ git checkout feature/branch -- specific-file.txt
 ## EXIT STATUS
 
 **0**
-: Successful checkout
-
-**1**
-: Branch not found
+: Successful checkout or navigation
 
 **2**
-: Ambiguous branch name
-
-**3**
 : Invalid topic branch type
 
-**4**
-: Git checkout failed
+**3**
+: A Git operation failed — an ambiguous branch name, a failed checkout, or a worktree whose directory is gone
+
+**5**
+: Branch not found
+
+**6**
+: A refusal: the target path of a new worktree is occupied, or **--clobber** was asked to remove a file, a registered worktree, or a directory containing a `.git` entry
 
 ## SEE ALSO
 
-**git-flow**(1), **git-flow-list**(1), **git-flow-start**(1), **git-checkout**(1)
+**git-flow**(1), **git-flow-list**(1), **git-flow-start**(1), **git-flow-worktree**(1), **git-flow-shell-init**(1), **git-checkout**(1)
 
 ## NOTES
 
@@ -225,3 +264,5 @@ git checkout feature/branch -- specific-file.txt
 - Use **git flow list** to see available branches before checkout
 - For complex checkout operations, use **git checkout** directly
 - Partial matching prioritizes exact matches over prefix matches
+- The worktree lookup runs on the **resolved** branch name, so a partial name finds the worktree of the branch it resolves to
+- Checkout uses **git checkout** rather than **git switch**, keeping the required Git version at 2.17 rather than 2.23

--- a/docs/git-flow-shell-init.1.md
+++ b/docs/git-flow-shell-init.1.md
@@ -1,0 +1,116 @@
+# GIT-FLOW-SHELL-INIT(1)
+
+## NAME
+
+git-flow-shell-init - Print the shell integration script
+
+## SYNOPSIS
+
+**git-flow shell-init** *shell*
+
+## DESCRIPTION
+
+Print a shell script that makes git-flow change your shell's working directory.
+
+git-flow runs as a subprocess and cannot change the directory of the shell that started it, so a command that would move you — **checkout** to a branch that has a worktree, **worktree add**, **worktree remove** — writes its absolute destination to the file named by **GIT_FLOW_CD_FILE** instead. The script printed here installs a wrapper that supplies that file, one command at a time, changes directory when the command came back with a destination, and removes the file afterwards.
+
+For each invocation the wrapper creates a temporary file with **mktemp**(1), points **GIT_FLOW_CD_FILE** at it for that single command, runs git-flow with its output going straight to the terminal, changes directory if the file came back non-empty, and removes the file on every path — success, failure, or no destination at all — while returning git-flow's own exit code. Because git-flow's output is never captured, colors, progress and interactive prompts behave exactly as they do without the wrapper.
+
+The variable is set **per invocation rather than exported**, so it does not leak into other programs, subshells, or scripts that happen to call git-flow from the same shell.
+
+Supported shells: **bash**, **zsh**, **fish**. PowerShell and `cmd` are not supported.
+
+## ARGUMENTS
+
+**bash**
+: Print the wrapper for bash, to be evaluated with `eval`. Requires bash 3.2 or newer.
+
+**zsh**
+: Print the wrapper for zsh, to be evaluated with `eval`.
+
+**fish**
+: Print the wrapper for fish, to be piped into `source`. Requires fish 3.0 or newer.
+
+## OPTIONS
+
+None.
+
+## WHAT THE SCRIPT DEFINES
+
+Each script defines **two** shell functions, both delegating to one shared helper:
+
+**git**
+: Intercepts **git flow ...** and hands it to the helper; every other git invocation is passed through to the real binary verbatim, with git's own exit code. This is the function that makes the documented **git flow ...** form navigate — a **git-flow** function alone never could, because git executes the `git-flow` binary as a subprocess of its own, and a directory change there dies with the subprocess.
+
+**git-flow**
+: The same behaviour for the direct **git-flow ...** form.
+
+## ENVIRONMENT
+
+**GIT_FLOW_CD_FILE**
+: The navigation channel the wrapper supplies. When set to a writable path, a command that navigates writes its absolute destination there; git-flow only ever reads this variable, never sets it globally. See **git-flow-worktree**(1) for the channel's full contract, and **git-flow-checkout**(1) for what **checkout** writes to it.
+
+: A command that navigates also prints a tip naming this command, but only when the channel is unused — with the wrapper installed the tip would be advice you have already taken. **--quiet** on **checkout** and **worktree add** suppresses it outright.
+
+## EXAMPLES
+
+### Bash
+
+```bash
+eval "$(git flow shell-init bash)"
+
+# To load it for each session:
+echo 'eval "$(git flow shell-init bash)"' >> ~/.bashrc
+```
+
+### Zsh
+
+```bash
+eval "$(git flow shell-init zsh)"
+
+# To load it for each session:
+echo 'eval "$(git flow shell-init zsh)"' >> ~/.zshrc
+```
+
+### Fish
+
+```bash
+git flow shell-init fish | source
+
+# To load it for each session:
+echo 'git flow shell-init fish | source' >> ~/.config/fish/config.fish
+```
+
+### Using it
+
+```bash
+$ git flow feature checkout user-auth
+Worktree for branch 'feature/user-auth' at /home/you/my-project-worktrees/feature/user-auth
+To switch to it: cd /home/you/my-project-worktrees/feature/user-auth
+$ pwd
+/home/you/my-project-worktrees/feature/user-auth
+```
+
+## EXIT STATUS
+
+**0**
+: The script was printed
+
+**1**
+: The shell argument is missing or names an unsupported shell
+
+## SEE ALSO
+
+**git-flow**(1), **git-flow-checkout**(1), **git-flow-worktree**(1), **git-flow-completion**(1), **bash**(1), **zsh**(1), **fish**(1)
+
+## NOTES
+
+- The script defines **both** a `git` and a `git-flow` function. Only the `git` one makes the advertised **git flow ...** form navigate.
+- The `git` function **shadows an existing git alias or function** — the last definition wins. Source git-flow's script **last** in your startup file, or fold your own wrapper into it.
+- Only **git flow ...** with `flow` as the **first** argument is intercepted. `git -C somewhere flow ...` runs the binary directly and does not navigate; parsing git's global options in shell would be fragile and is deliberately not attempted.
+- **bash --posix** cannot define a function whose name contains a hyphen. Sourcing still succeeds and installs the `git` wrapper; `git-flow` then resolves to the binary as usual, so the direct form does not navigate in POSIX mode.
+- If the destination cannot be entered — it was removed between the write and the change of directory — the wrapper reports it on standard error and still returns git-flow's own exit code, rather than reporting the failure of the `cd`.
+- The wrapper is transparent to **set -e**: it never aborts a caller's script before removing its temporary file, and it never swallows a failure the caller is not asking about.
+- Pressing Ctrl-C during a wrapped command may leave a single empty temporary file in **TMPDIR**. No `trap` prevents this reliably, and a predictable name would trade the leak for a symlink attack in a shared `/tmp`.
+- The variable is in git-flow's environment for the wrapped command, so hooks git-flow spawns inherit it.
+- This command is unrelated to **git-flow-completion**(1), which generates tab completion; the two are installed independently.

--- a/docs/git-flow-worktree.1.md
+++ b/docs/git-flow-worktree.1.md
@@ -6,7 +6,7 @@ git-flow-worktree - Manage worktrees for branches
 
 ## SYNOPSIS
 
-**git-flow worktree add** *branch* [**--path** *path*] [**--no-cd**]
+**git-flow worktree add** *branch* [**--path** *path*] [**--no-cd**] [**--quiet**]
 
 **git-flow worktree remove** *branch* [**--force**] [**--no-cd**]
 
@@ -52,6 +52,9 @@ git-flow records the worktrees it creates by writing a provenance marker in Git 
 **--no-cd**
 : Do not write a navigation destination for the calling shell, even when **GIT_FLOW_CD_FILE** is set (**add** and **remove**).
 
+**--quiet**, **-q**
+: Do not print the tip naming **git flow shell-init** (**add** only).
+
 ## ENVIRONMENT
 
 **GIT_FLOW_CD_FILE**
@@ -62,6 +65,8 @@ git-flow records the worktrees it creates by writing a provenance marker in Git 
 : The destination is written **only after** the operation it follows has succeeded, so a refused or failed command leaves the file empty. **--no-cd** suppresses the write even when the variable is set. A failure to write the destination is **not fatal**: the operation still succeeds and a warning is printed to standard error.
 
 : When the variable is unset — an ordinary shell, a script, CI — nothing is written and the command prints the human `cd` hint it would print anyway. Nothing machine-readable ever goes to standard output, so a caller that does not use the channel never sees a protocol line.
+
+: **add** also prints a tip naming **git flow shell-init**, but only in that same state: a caller that set the variable has the wrapper installed already, and the advice would be noise. **--quiet** suppresses the tip outright. See **git-flow-shell-init**(1).
 
 ## EXAMPLES
 
@@ -138,7 +143,7 @@ git config gitflow.worktreePath '~/worktrees/{{ topicType }}/{{ branchName }}'
 
 ## SEE ALSO
 
-**git-flow**(1), **gitflow-config**(5), **git-worktree**(1)
+**git-flow**(1), **git-flow-checkout**(1), **git-flow-shell-init**(1), **gitflow-config**(5), **git-worktree**(1)
 
 ## NOTES
 

--- a/docs/git-flow.1.md
+++ b/docs/git-flow.1.md
@@ -41,6 +41,9 @@ This implementation maintains compatibility with existing git-flow repositories 
 **worktree**
 : Manage worktrees for branches: add, remove, list, prune, and print the computed path. See **git-flow-worktree**(1).
 
+**shell-init** *shell*
+: Print a shell script that lets git-flow change your shell's working directory when a command navigates. See **git-flow-shell-init**(1).
+
 **version**
 : Show version information. Prints `<version> (git-flow-next)`, so tooling that parses the first whitespace-separated token reads a bare version number.
 
@@ -150,7 +153,7 @@ git flow config add topic bugfix develop --prefix=bug/
 
 ## SEE ALSO
 
-**git-flow-init**(1), **git-flow-config**(1), **git-flow-completion**(1), **git-flow-start**(1), **git-flow-finish**(1), **git-flow-integrate**(1), **git-flow-update**(1), **git-flow-delete**(1), **git-flow-track**(1), **git-flow-worktree**(1), **gitflow-config**(5), **git**(1)
+**git-flow-init**(1), **git-flow-config**(1), **git-flow-completion**(1), **git-flow-start**(1), **git-flow-finish**(1), **git-flow-integrate**(1), **git-flow-update**(1), **git-flow-delete**(1), **git-flow-track**(1), **git-flow-worktree**(1), **git-flow-shell-init**(1), **gitflow-config**(5), **git**(1)
 
 ## AUTHORS
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ Comprehensive manpage-style documentation for git-flow-next commands and configu
 | **git-flow integrate** | Integrate a base branch into its parent | [git-flow-integrate(1)](git-flow-integrate.1.md) |
 | **git-flow worktree** | Manage worktrees for branches | [git-flow-worktree(1)](git-flow-worktree.1.md) |
 | **git-flow completion** | Generate shell completion scripts | [git-flow-completion(1)](git-flow-completion.1.md) |
+| **git-flow shell-init** | Print the shell integration script for directory switching | [git-flow-shell-init(1)](git-flow-shell-init.1.md) |
 
 ## Topic Branch Commands
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -687,23 +687,23 @@ func (e *WorktreeDirtyError) ExitCode() ExitCode {
 	return ExitCodeValidationError
 }
 
-// ClobberRefusedError indicates --clobber was asked to remove something it must
-// not: the flag exists to clear a stale directory out of the way, and every
-// other occupant of the target path is either somebody's data or somebody's
-// repository.
+// RemovalRefusedError indicates a forced removal was asked to remove something
+// it must not: forcing exists to clear a stale directory out of the way, and
+// every other occupant of the target path is either somebody's data or
+// somebody's repository.
 //
 // Reason is the second half of the message rather than a code, so the three
 // refusals read as one family in the terminal.
-type ClobberRefusedError struct {
+type RemovalRefusedError struct {
 	Path   string
 	Reason string
 }
 
-func (e *ClobberRefusedError) Error() string {
+func (e *RemovalRefusedError) Error() string {
 	return fmt.Sprintf("refusing to remove %s: %s", e.Path, e.Reason)
 }
 
-func (e *ClobberRefusedError) ExitCode() ExitCode {
+func (e *RemovalRefusedError) ExitCode() ExitCode {
 	return ExitCodeValidationError
 }
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -687,6 +687,26 @@ func (e *WorktreeDirtyError) ExitCode() ExitCode {
 	return ExitCodeValidationError
 }
 
+// ClobberRefusedError indicates --clobber was asked to remove something it must
+// not: the flag exists to clear a stale directory out of the way, and every
+// other occupant of the target path is either somebody's data or somebody's
+// repository.
+//
+// Reason is the second half of the message rather than a code, so the three
+// refusals read as one family in the terminal.
+type ClobberRefusedError struct {
+	Path   string
+	Reason string
+}
+
+func (e *ClobberRefusedError) Error() string {
+	return fmt.Sprintf("refusing to remove %s: %s", e.Path, e.Reason)
+}
+
+func (e *ClobberRefusedError) ExitCode() ExitCode {
+	return ExitCodeValidationError
+}
+
 // MissingUserIdentityError indicates git user.name/user.email are not configured
 type MissingUserIdentityError struct{}
 

--- a/test/cmd/checkout_worktree_test.go
+++ b/test/cmd/checkout_worktree_test.go
@@ -16,7 +16,7 @@ func managedMarkerFor(branch string) string {
 }
 
 // writeObstruction creates dir and a file inside it, the "occupied path" state
-// every clobber scenario starts from. An EMPTY directory is deliberately not an
+// every --force scenario starts from. An EMPTY directory is deliberately not an
 // obstruction (#172 decision 12), so the file is what makes the path occupied.
 func writeObstruction(t *testing.T, dir string, name string, content string) {
 	t.Helper()
@@ -212,7 +212,7 @@ func TestCheckoutHandMadeWorktreeStaysUnmanaged(t *testing.T) {
 }
 
 // TestCheckoutWorktreeOccupiedPathFails covers scenario 5: --worktree refuses an
-// occupied target path when --clobber is not given.
+// occupied target path when --force is not given.
 // Steps:
 // 1. Initializes git-flow and creates feature/x
 // 2. Creates the computed worktree path as a directory holding a file
@@ -244,17 +244,17 @@ func TestCheckoutWorktreeOccupiedPathFails(t *testing.T) {
 	}
 }
 
-// TestCheckoutWorktreeClobberReplacesStaleDirectory covers scenario 6: --clobber
+// TestCheckoutWorktreeForceReplacesStaleDirectory covers scenario 6: --force
 // replaces a plain directory in the way and creates the worktree there.
 // Steps:
 // 1. Initializes git-flow and creates feature/x
 // 2. Creates the computed worktree path as a directory holding a file
-// 3. Runs 'git flow feature checkout x --worktree --clobber' with GIT_FLOW_CD_FILE set
+// 3. Runs 'git flow feature checkout x --worktree --force' with GIT_FLOW_CD_FILE set
 // 4. Verifies exit code 0 and that the stale file is gone
 // 5. Verifies a worktree exists at the path, the marker is written and the CD file holds the path
 // 6. Verifies stdout reports the creation
 // 7. Verifies stdout announces the removal, so the one destructive operation in the command cannot go silent
-func TestCheckoutWorktreeClobberReplacesStaleDirectory(t *testing.T) {
+func TestCheckoutWorktreeForceReplacesStaleDirectory(t *testing.T) {
 	t.Parallel()
 	dir := initWorktreeRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
@@ -264,9 +264,9 @@ func TestCheckoutWorktreeClobberReplacesStaleDirectory(t *testing.T) {
 	writeObstruction(t, wtPath, "stale.txt", "old")
 	cdFile := cdFilePath(t)
 
-	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x", "--worktree", "--clobber")
+	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x", "--worktree", "--force")
 	if err != nil {
-		t.Fatalf("feature checkout --worktree --clobber failed: %v\nStderr: %s", err, stderr)
+		t.Fatalf("feature checkout --worktree --force failed: %v\nStderr: %s", err, stderr)
 	}
 
 	if _, err := os.Stat(filepath.Join(wtPath, "stale.txt")); !os.IsNotExist(err) {
@@ -284,7 +284,7 @@ func TestCheckoutWorktreeClobberReplacesStaleDirectory(t *testing.T) {
 	if !strings.Contains(stdout, "Created worktree for branch 'feature/x' at "+wtPath) {
 		t.Errorf("Expected stdout to report the creation, got %q", stdout)
 	}
-	// Without this the suite would accept a --clobber that removed the directory
+	// Without this the suite would accept a --force that removed the directory
 	// silently: the only other test touching this line pins its ABSENCE.
 	if !strings.Contains(stdout, "Removed "+wtPath+" to make room for the worktree") {
 		t.Errorf("Expected stdout to announce the removal, got %q", stdout)
@@ -574,16 +574,16 @@ func TestCheckoutReplacedWorktreeFileFails(t *testing.T) {
 	assertStaleWorktreeRefused(t, dir, wtPath, branchBefore)
 }
 
-// TestCheckoutClobberRefusesFile covers SC-4: --clobber refuses a file at the
+// TestCheckoutForceRefusesFile covers SC-4: --force refuses a file at the
 // target path.
 // Steps:
 // 1. Initializes git-flow and creates feature/x
 // 2. Creates the computed worktree path as a file with known content
-// 3. Runs 'git flow feature checkout x --worktree --clobber' with GIT_FLOW_CD_FILE set
+// 3. Runs 'git flow feature checkout x --worktree --force' with GIT_FLOW_CD_FILE set
 // 4. Verifies exit code 6 and that stderr refuses because the target is a file
 // 5. Verifies the file still exists with its content intact
 // 6. Verifies the CD file is still zero-length
-func TestCheckoutClobberRefusesFile(t *testing.T) {
+func TestCheckoutForceRefusesFile(t *testing.T) {
 	t.Parallel()
 	dir := initWorktreeRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
@@ -598,7 +598,7 @@ func TestCheckoutClobberRefusesFile(t *testing.T) {
 	}
 	cdFile := cdFilePath(t)
 
-	_, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x", "--worktree", "--clobber")
+	_, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x", "--worktree", "--force")
 	if got := worktreeExitCode(err); got != 6 {
 		t.Fatalf("Expected exit code 6, got %d\nStderr: %s", got, stderr)
 	}
@@ -609,16 +609,16 @@ func TestCheckoutClobberRefusesFile(t *testing.T) {
 	assertCDFileEmpty(t, cdFile)
 }
 
-// TestCheckoutClobberRefusesRegisteredWorktree covers SC-4: --clobber refuses a
+// TestCheckoutForceRefusesRegisteredWorktree covers SC-4: --force refuses a
 // registered worktree of this repository.
 // Steps:
 // 1. Initializes git-flow and sets a branch-independent path template so two branches compute the same target
 // 2. Creates feature/x and feature/y and adds a worktree for feature/y at that shared target
-// 3. Runs 'git flow feature checkout x --worktree --clobber' with GIT_FLOW_CD_FILE set
+// 3. Runs 'git flow feature checkout x --worktree --force' with GIT_FLOW_CD_FILE set
 // 4. Verifies exit code 6 and that stderr points at 'git flow worktree remove'
 // 5. Verifies the other worktree still exists and is still listed by git
 // 6. Verifies the CD file is still zero-length
-func TestCheckoutClobberRefusesRegisteredWorktree(t *testing.T) {
+func TestCheckoutForceRefusesRegisteredWorktree(t *testing.T) {
 	t.Parallel()
 	dir := initWorktreeRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
@@ -637,7 +637,7 @@ func TestCheckoutClobberRefusesRegisteredWorktree(t *testing.T) {
 	}
 	cdFile := cdFilePath(t)
 
-	_, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x", "--worktree", "--clobber")
+	_, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x", "--worktree", "--force")
 	if got := worktreeExitCode(err); got != 6 {
 		t.Fatalf("Expected exit code 6, got %d\nStderr: %s", got, stderr)
 	}
@@ -653,16 +653,16 @@ func TestCheckoutClobberRefusesRegisteredWorktree(t *testing.T) {
 	assertCDFileEmpty(t, cdFile)
 }
 
-// TestCheckoutClobberRefusesDirectoryWithGitEntry covers SC-4: --clobber refuses
+// TestCheckoutForceRefusesDirectoryWithGitEntry covers SC-4: --force refuses
 // a directory holding a .git FILE, the linked-worktree form.
 // Steps:
 // 1. Initializes git-flow and creates feature/x
 // 2. Creates the computed path as a directory holding a .git file and a decoy file
-// 3. Runs 'git flow feature checkout x --worktree --clobber' with GIT_FLOW_CD_FILE set
+// 3. Runs 'git flow feature checkout x --worktree --force' with GIT_FLOW_CD_FILE set
 // 4. Verifies exit code 6 and that stderr refuses because the directory looks like a repository
 // 5. Verifies the directory and both files are intact
 // 6. Verifies the CD file is still zero-length
-func TestCheckoutClobberRefusesDirectoryWithGitEntry(t *testing.T) {
+func TestCheckoutForceRefusesDirectoryWithGitEntry(t *testing.T) {
 	t.Parallel()
 	dir := initWorktreeRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
@@ -675,7 +675,7 @@ func TestCheckoutClobberRefusesDirectoryWithGitEntry(t *testing.T) {
 	}
 	cdFile := cdFilePath(t)
 
-	_, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x", "--worktree", "--clobber")
+	_, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x", "--worktree", "--force")
 	if got := worktreeExitCode(err); got != 6 {
 		t.Fatalf("Expected exit code 6, got %d\nStderr: %s", got, stderr)
 	}
@@ -687,7 +687,7 @@ func TestCheckoutClobberRefusesDirectoryWithGitEntry(t *testing.T) {
 	assertCDFileEmpty(t, cdFile)
 }
 
-// TestCheckoutClobberRefusesDirectoryWithGitDirectory covers SC-4: --clobber
+// TestCheckoutForceRefusesDirectoryWithGitDirectory covers SC-4: --force
 // refuses a directory holding a .git DIRECTORY, the ordinary-clone form.
 //
 // It is separate from the .git-file case because an implementation that stats
@@ -696,11 +696,11 @@ func TestCheckoutClobberRefusesDirectoryWithGitEntry(t *testing.T) {
 // Steps:
 // 1. Initializes git-flow and creates feature/x
 // 2. Creates the computed path as a directory holding a .git/ directory with a file inside it, plus a sentinel file
-// 3. Runs 'git flow feature checkout x --worktree --clobber' with GIT_FLOW_CD_FILE set
+// 3. Runs 'git flow feature checkout x --worktree --force' with GIT_FLOW_CD_FILE set
 // 4. Verifies exit code 6 and that stderr refuses because the directory looks like a repository
 // 5. Verifies the directory, the .git directory's content and the sentinel are all intact
 // 6. Verifies the CD file is still zero-length
-func TestCheckoutClobberRefusesDirectoryWithGitDirectory(t *testing.T) {
+func TestCheckoutForceRefusesDirectoryWithGitDirectory(t *testing.T) {
 	t.Parallel()
 	dir := initWorktreeRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
@@ -711,7 +711,7 @@ func TestCheckoutClobberRefusesDirectoryWithGitDirectory(t *testing.T) {
 	writeObstruction(t, filepath.Join(wtPath, ".git"), "HEAD", "ref: refs/heads/main\n")
 	cdFile := cdFilePath(t)
 
-	_, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x", "--worktree", "--clobber")
+	_, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x", "--worktree", "--force")
 	if got := worktreeExitCode(err); got != 6 {
 		t.Fatalf("Expected exit code 6, got %d\nStderr: %s", got, stderr)
 	}
@@ -723,15 +723,15 @@ func TestCheckoutClobberRefusesDirectoryWithGitDirectory(t *testing.T) {
 	assertCDFileEmpty(t, cdFile)
 }
 
-// TestCheckoutClobberWithNothingToClobberSucceeds covers SC-4: --clobber with an
+// TestCheckoutForceWithNothingToRemoveSucceeds covers SC-4: --force with an
 // empty target path is an ordinary creation.
 // Steps:
 // 1. Initializes git-flow and creates feature/x with nothing at the computed path
-// 2. Runs 'git flow feature checkout x --worktree --clobber' with GIT_FLOW_CD_FILE set
+// 2. Runs 'git flow feature checkout x --worktree --force' with GIT_FLOW_CD_FILE set
 // 3. Verifies exit code 0 and that the worktree was created and marked
-// 4. Verifies stdout reports the creation and says nothing about clobbering
+// 4. Verifies stdout reports the creation and says nothing about a removal
 // 5. Verifies stderr is empty
-func TestCheckoutClobberWithNothingToClobberSucceeds(t *testing.T) {
+func TestCheckoutForceWithNothingToRemoveSucceeds(t *testing.T) {
 	t.Parallel()
 	dir := initWorktreeRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
@@ -739,9 +739,9 @@ func TestCheckoutClobberWithNothingToClobberSucceeds(t *testing.T) {
 	createFreeBranch(t, dir, "feature/x")
 	cdFile := cdFilePath(t)
 
-	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x", "--worktree", "--clobber")
+	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x", "--worktree", "--force")
 	if err != nil {
-		t.Fatalf("feature checkout --worktree --clobber failed: %v\nStderr: %s", err, stderr)
+		t.Fatalf("feature checkout --worktree --force failed: %v\nStderr: %s", err, stderr)
 	}
 
 	wtPath := computedWorktreePath(t, dir, "feature/x")
@@ -755,7 +755,7 @@ func TestCheckoutClobberWithNothingToClobberSucceeds(t *testing.T) {
 		t.Errorf("Expected stdout to report the creation, got %q", stdout)
 	}
 	if strings.Contains(strings.ToLower(stdout), "removed") {
-		t.Errorf("Expected no removal message when there was nothing to clobber, got %q", stdout)
+		t.Errorf("Expected no removal message when there was nothing to remove, got %q", stdout)
 	}
 	if stderr != "" {
 		t.Errorf("Expected no output on stderr, got %q", stderr)
@@ -930,16 +930,16 @@ func TestCheckoutCurrentMainWorktreeUsesClassicBehavior(t *testing.T) {
 	}
 }
 
-// TestCheckoutClobberWithoutWorktreeIsSilentNoOp covers SC-15: --clobber without
+// TestCheckoutForceWithoutWorktreeIsSilentNoOp covers SC-15: --force without
 // --worktree changes nothing and says nothing.
 // Steps:
 // 1. Initializes git-flow and creates feature/x
 // 2. Creates the computed worktree path as a directory holding a sentinel file
-// 3. Runs 'git flow feature checkout x --clobber' without --worktree, with GIT_FLOW_CD_FILE set
+// 3. Runs 'git flow feature checkout x --force' without --worktree, with GIT_FLOW_CD_FILE set
 // 4. Verifies stdout equals exactly the classic 'Switched to branch' message and stderr is empty
 // 5. Verifies the sentinel directory and its file are byte-identical
 // 6. Verifies no worktree was created and the CD file is still zero-length
-func TestCheckoutClobberWithoutWorktreeIsSilentNoOp(t *testing.T) {
+func TestCheckoutForceWithoutWorktreeIsSilentNoOp(t *testing.T) {
 	t.Parallel()
 	dir := initWorktreeRepo(t)
 	defer testutil.CleanupTestRepo(t, dir)
@@ -949,9 +949,9 @@ func TestCheckoutClobberWithoutWorktreeIsSilentNoOp(t *testing.T) {
 	writeObstruction(t, wtPath, "sentinel.txt", "do not delete")
 	cdFile := cdFilePath(t)
 
-	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x", "--clobber")
+	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x", "--force")
 	if err != nil {
-		t.Fatalf("feature checkout --clobber failed: %v\nStderr: %s", err, stderr)
+		t.Fatalf("feature checkout --force failed: %v\nStderr: %s", err, stderr)
 	}
 
 	if want := "Switched to branch 'feature/x'\n"; stdout != want {

--- a/test/cmd/checkout_worktree_test.go
+++ b/test/cmd/checkout_worktree_test.go
@@ -1,0 +1,899 @@
+package cmd_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// managedMarkerFor returns the provenance marker key for a branch, the key that
+// records git-flow as the creator of its worktree.
+func managedMarkerFor(branch string) string {
+	return "gitflow.worktree." + branch + ".managed"
+}
+
+// writeObstruction creates dir and a file inside it, the "occupied path" state
+// every clobber scenario starts from. An EMPTY directory is deliberately not an
+// obstruction (#172 decision 12), so the file is what makes the path occupied.
+func writeObstruction(t *testing.T, dir string, name string, content string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("Failed to create obstruction directory %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write obstruction file in %s: %v", dir, err)
+	}
+}
+
+// assertFileContent fails unless path holds exactly want, proving a refused
+// command left the user's data untouched.
+func assertFileContent(t *testing.T, path string, want string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Expected %s to still exist: %v", path, err)
+	}
+	if string(data) != want {
+		t.Errorf("Expected %s to hold %q, got %q", path, want, string(data))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Group A — checkout navigation (spec scenarios 1-9, 18)
+// ---------------------------------------------------------------------------
+
+// TestCheckoutNavigatesToExistingWorktree covers scenario 1: checkout navigates
+// to the branch's worktree instead of switching the main worktree's branch.
+// Steps:
+// 1. Initializes git-flow, creates feature/x and a worktree for it
+// 2. Records the branch checked out in the main worktree
+// 3. Runs 'git flow feature checkout x' with GIT_FLOW_CD_FILE set to an empty file
+// 4. Verifies the CD file holds the worktree path and the main worktree's branch is unchanged
+// 5. Verifies stdout carries the worktree and cd lines and no 'Switched to branch' line
+// 6. Verifies no shell-init tip is printed, since the channel is plainly in use
+func TestCheckoutNavigatesToExistingWorktree(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := addWorktree(t, dir, "feature/x")
+	branchBefore := testutil.GetCurrentBranch(t, dir)
+	cdFile := cdFilePath(t)
+
+	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x")
+	if err != nil {
+		t.Fatalf("feature checkout failed: %v\nStderr: %s", err, stderr)
+	}
+
+	if got := readCDFile(t, cdFile); got != wtPath {
+		t.Errorf("Expected CD file to hold %q, got %q", wtPath, got)
+	}
+	if got := testutil.GetCurrentBranch(t, dir); got != branchBefore {
+		t.Errorf("Expected the main worktree to stay on %q, got %q", branchBefore, got)
+	}
+	if !strings.Contains(stdout, "Worktree for branch 'feature/x' at "+wtPath) {
+		t.Errorf("Expected stdout to name the worktree, got %q", stdout)
+	}
+	if !strings.Contains(stdout, "To switch to it: cd "+wtPath) {
+		t.Errorf("Expected stdout to carry the cd hint, got %q", stdout)
+	}
+	if strings.Contains(stdout, "Switched to branch") {
+		t.Errorf("Expected no classic switch message, got %q", stdout)
+	}
+	if strings.Contains(stdout, "Tip:") {
+		t.Errorf("Expected no shell-init tip while the channel is in use, got %q", stdout)
+	}
+}
+
+// TestCheckoutWithoutWorktreeSwitchesBranch covers scenario 2: with no worktree
+// and no --worktree, checkout behaves exactly as it does today.
+// Steps:
+// 1. Initializes git-flow and creates feature/x without checking it out
+// 2. Runs 'git flow feature checkout x' with GIT_FLOW_CD_FILE set to an empty file
+// 3. Verifies stdout is the classic 'Switched to branch' message
+// 4. Verifies the main worktree is now on feature/x
+// 5. Verifies the CD file is still zero-length, since a classic switch is not a navigation
+// 6. Verifies no worktree was created
+func TestCheckoutWithoutWorktreeSwitchesBranch(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	createFreeBranch(t, dir, "feature/x")
+	cdFile := cdFilePath(t)
+
+	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x")
+	if err != nil {
+		t.Fatalf("feature checkout failed: %v\nStderr: %s", err, stderr)
+	}
+
+	if want := "Switched to branch 'feature/x'\n"; stdout != want {
+		t.Errorf("Expected stdout %q, got %q", want, stdout)
+	}
+	if got := testutil.GetCurrentBranch(t, dir); got != "feature/x" {
+		t.Errorf("Expected to be on feature/x, got %q", got)
+	}
+	assertCDFileEmpty(t, cdFile)
+	if _, err := os.Stat(computedWorktreePath(t, dir, "feature/x")); !os.IsNotExist(err) {
+		t.Errorf("Expected no worktree to be created at the computed path")
+	}
+}
+
+// TestCheckoutWorktreeFlagCreatesAndMarks covers scenario 3: --worktree creates
+// the missing worktree, records provenance, and navigates to it.
+// Steps:
+// 1. Initializes git-flow and creates feature/x without checking it out
+// 2. Runs 'git flow feature checkout x --worktree' with GIT_FLOW_CD_FILE set
+// 3. Verifies the worktree exists at the computed path and git lists it
+// 4. Verifies the provenance marker is set to true
+// 5. Verifies the CD file holds the worktree path and stdout reports the creation
+// 6. Verifies the main worktree's branch is unchanged
+func TestCheckoutWorktreeFlagCreatesAndMarks(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	branchBefore := testutil.GetCurrentBranch(t, dir)
+	cdFile := cdFilePath(t)
+
+	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x", "--worktree")
+	if err != nil {
+		t.Fatalf("feature checkout --worktree failed: %v\nStderr: %s", err, stderr)
+	}
+
+	wtPath := computedWorktreePath(t, dir, "feature/x")
+	if info, err := os.Stat(wtPath); err != nil || !info.IsDir() {
+		t.Fatalf("Expected a worktree directory at %s: %v", wtPath, err)
+	}
+	if !strings.Contains(gitWorktreeList(t, dir), wtPath) {
+		t.Errorf("Expected git worktree list to show %s", wtPath)
+	}
+	if got := testutil.GitConfigValue(t, dir, managedMarkerFor("feature/x")); got != "true" {
+		t.Errorf("Expected the provenance marker to be true, got %q", got)
+	}
+	if got := readCDFile(t, cdFile); got != wtPath {
+		t.Errorf("Expected CD file to hold %q, got %q", wtPath, got)
+	}
+	if !strings.Contains(stdout, "Created worktree for branch 'feature/x' at "+wtPath) {
+		t.Errorf("Expected stdout to report the creation, got %q", stdout)
+	}
+	if got := testutil.GetCurrentBranch(t, dir); got != branchBefore {
+		t.Errorf("Expected the main worktree to stay on %q, got %q", branchBefore, got)
+	}
+}
+
+// TestCheckoutHandMadeWorktreeStaysUnmanaged covers scenario 4: arriving at a
+// worktree git-flow did not create never writes a provenance marker.
+// Steps:
+// 1. Initializes git-flow and creates feature/x
+// 2. Creates a worktree for it with plain 'git worktree add' at a path of the test's choosing
+// 3. Runs 'git flow feature checkout x' with GIT_FLOW_CD_FILE set
+// 4. Verifies the CD file holds the hand-made path
+// 5. Verifies no provenance marker was written
+// 6. Verifies 'git flow worktree list' still tags the row (unmanaged)
+func TestCheckoutHandMadeWorktreeStaysUnmanaged(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	createFreeBranch(t, dir, "feature/x")
+	handPath := filepath.Join(t.TempDir(), "hand")
+	if out, err := testutil.RunGit(t, dir, "worktree", "add", handPath, "feature/x"); err != nil {
+		t.Fatalf("Failed to create the hand-made worktree: %v\nOutput: %s", err, out)
+	}
+	cdFile := cdFilePath(t)
+
+	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x")
+	if err != nil {
+		t.Fatalf("feature checkout failed: %v\nStderr: %s", err, stderr)
+	}
+
+	want := testutil.EvalPath(t, handPath)
+	if got := readCDFile(t, cdFile); got != want {
+		t.Errorf("Expected CD file to hold the hand-made path %q, got %q", want, got)
+	}
+	if got := testutil.GitConfigValue(t, dir, managedMarkerFor("feature/x")); got != "" {
+		t.Errorf("Expected no provenance marker, got %q", got)
+	}
+	if !strings.Contains(stdout, "Worktree for branch 'feature/x'") {
+		t.Errorf("Expected stdout to name the worktree, got %q", stdout)
+	}
+
+	list, err := testutil.RunGitFlow(t, dir, "worktree", "list")
+	if err != nil {
+		t.Fatalf("worktree list failed: %v\nOutput: %s", err, list)
+	}
+	if !strings.Contains(list, "(unmanaged)") {
+		t.Errorf("Expected the hand-made worktree to stay unmanaged, got %q", list)
+	}
+}
+
+// TestCheckoutWorktreeOccupiedPathFails covers scenario 5: --worktree refuses an
+// occupied target path when --clobber is not given.
+// Steps:
+// 1. Initializes git-flow and creates feature/x
+// 2. Creates the computed worktree path as a directory holding a file
+// 3. Runs 'git flow feature checkout x --worktree' with GIT_FLOW_CD_FILE set
+// 4. Verifies exit code 6 and that stderr names the occupied path
+// 5. Verifies the CD file is still zero-length and the obstruction is untouched
+// 6. Verifies no worktree was registered
+func TestCheckoutWorktreeOccupiedPathFails(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := computedWorktreePath(t, dir, "feature/x")
+	writeObstruction(t, wtPath, "keep.txt", "precious")
+	cdFile := cdFilePath(t)
+
+	_, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x", "--worktree")
+	if got := worktreeExitCode(err); got != 6 {
+		t.Fatalf("Expected exit code 6, got %d\nStderr: %s", got, stderr)
+	}
+	if !strings.Contains(stderr, wtPath) {
+		t.Errorf("Expected stderr to name %q, got %q", wtPath, stderr)
+	}
+	assertCDFileEmpty(t, cdFile)
+	assertFileContent(t, filepath.Join(wtPath, "keep.txt"), "precious")
+	if strings.Contains(gitWorktreeList(t, dir), wtPath) {
+		t.Errorf("Expected no worktree to be registered at %s", wtPath)
+	}
+}
+
+// TestCheckoutWorktreeClobberReplacesStaleDirectory covers scenario 6: --clobber
+// replaces a plain directory in the way and creates the worktree there.
+// Steps:
+// 1. Initializes git-flow and creates feature/x
+// 2. Creates the computed worktree path as a directory holding a file
+// 3. Runs 'git flow feature checkout x --worktree --clobber' with GIT_FLOW_CD_FILE set
+// 4. Verifies exit code 0 and that the stale file is gone
+// 5. Verifies a worktree exists at the path, the marker is written and the CD file holds the path
+// 6. Verifies stdout reports the creation
+func TestCheckoutWorktreeClobberReplacesStaleDirectory(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := computedWorktreePath(t, dir, "feature/x")
+	writeObstruction(t, wtPath, "stale.txt", "old")
+	cdFile := cdFilePath(t)
+
+	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x", "--worktree", "--clobber")
+	if err != nil {
+		t.Fatalf("feature checkout --worktree --clobber failed: %v\nStderr: %s", err, stderr)
+	}
+
+	if _, err := os.Stat(filepath.Join(wtPath, "stale.txt")); !os.IsNotExist(err) {
+		t.Errorf("Expected the stale file to be removed")
+	}
+	if !strings.Contains(gitWorktreeList(t, dir), wtPath) {
+		t.Errorf("Expected git worktree list to show %s", wtPath)
+	}
+	if got := testutil.GitConfigValue(t, dir, managedMarkerFor("feature/x")); got != "true" {
+		t.Errorf("Expected the provenance marker to be true, got %q", got)
+	}
+	if got := readCDFile(t, cdFile); got != wtPath {
+		t.Errorf("Expected CD file to hold %q, got %q", wtPath, got)
+	}
+	if !strings.Contains(stdout, "Created worktree for branch 'feature/x' at "+wtPath) {
+		t.Errorf("Expected stdout to report the creation, got %q", stdout)
+	}
+}
+
+// TestCheckoutNoCDLeavesFileEmptyAndKeepsBranch covers scenario 7: --no-cd
+// suppresses only the channel write.
+// Steps:
+// 1. Initializes git-flow, creates feature/x and a worktree for it
+// 2. Records the branch checked out in the main worktree
+// 3. Runs 'git flow feature checkout x --no-cd' with GIT_FLOW_CD_FILE set
+// 4. Verifies the CD file is still zero-length
+// 5. Verifies the main worktree's branch is unchanged
+// 6. Verifies stdout still carries the human-readable cd hint
+func TestCheckoutNoCDLeavesFileEmptyAndKeepsBranch(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := addWorktree(t, dir, "feature/x")
+	branchBefore := testutil.GetCurrentBranch(t, dir)
+	cdFile := cdFilePath(t)
+
+	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x", "--no-cd")
+	if err != nil {
+		t.Fatalf("feature checkout --no-cd failed: %v\nStderr: %s", err, stderr)
+	}
+
+	assertCDFileEmpty(t, cdFile)
+	if got := testutil.GetCurrentBranch(t, dir); got != branchBefore {
+		t.Errorf("Expected the main worktree to stay on %q, got %q", branchBefore, got)
+	}
+	if !strings.Contains(stdout, "To switch to it: cd "+wtPath) {
+		t.Errorf("Expected stdout to keep the cd hint, got %q", stdout)
+	}
+}
+
+// TestCheckoutWithoutCDFileEnvPrintsPath covers scenario 8: with the channel
+// unused the path is printed for manual use, with the shell-init tip.
+// Steps:
+// 1. Initializes git-flow, creates feature/x and a worktree for it
+// 2. Records the branch checked out in the main worktree
+// 3. Runs 'git flow feature checkout x' with GIT_FLOW_CD_FILE unset
+// 4. Verifies stdout equals exactly the two navigation lines plus the tip
+// 5. Verifies stderr is empty
+// 6. Verifies the main worktree's branch is unchanged, as in scenario 1
+func TestCheckoutWithoutCDFileEnvPrintsPath(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := addWorktree(t, dir, "feature/x")
+	branchBefore := testutil.GetCurrentBranch(t, dir)
+
+	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, nil, "feature", "checkout", "x")
+	if err != nil {
+		t.Fatalf("feature checkout failed: %v\nStderr: %s", err, stderr)
+	}
+
+	want := "Worktree for branch 'feature/x' at " + wtPath + "\n" +
+		"To switch to it: cd " + wtPath + "\n" +
+		"Tip: run 'git flow shell-init <shell>' for automatic directory switching\n"
+	if stdout != want {
+		t.Errorf("Expected stdout %q, got %q", want, stdout)
+	}
+	if stderr != "" {
+		t.Errorf("Expected no output on stderr, got %q", stderr)
+	}
+	if got := testutil.GetCurrentBranch(t, dir); got != branchBefore {
+		t.Errorf("Expected the main worktree to stay on %q, got %q", branchBefore, got)
+	}
+}
+
+// TestCheckoutIgnoresBranchTypeWorktreeDefault covers scenario 9 as a FORWARD
+// GUARD: checkout never auto-creates a worktree from a branch-type default.
+//
+// gitflow.branch.<type>.worktree does not exist until #173, so this test passes
+// VACUOUSLY today. It is kept so #173 cannot accidentally teach checkout to
+// honour the key; do not read it as live coverage.
+// Steps:
+// 1. Initializes git-flow and creates feature/x
+// 2. Sets gitflow.branch.feature.worktree to true
+// 3. Runs 'git flow feature checkout x' with GIT_FLOW_CD_FILE set
+// 4. Verifies stdout is the classic 'Switched to branch' message
+// 5. Verifies no worktree was created and the CD file is untouched
+func TestCheckoutIgnoresBranchTypeWorktreeDefault(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	createFreeBranch(t, dir, "feature/x")
+	if out, err := testutil.RunGit(t, dir, "config", "gitflow.branch.feature.worktree", "true"); err != nil {
+		t.Fatalf("Failed to set the branch type worktree default: %v\nOutput: %s", err, out)
+	}
+	cdFile := cdFilePath(t)
+
+	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x")
+	if err != nil {
+		t.Fatalf("feature checkout failed: %v\nStderr: %s", err, stderr)
+	}
+
+	if want := "Switched to branch 'feature/x'\n"; stdout != want {
+		t.Errorf("Expected stdout %q, got %q", want, stdout)
+	}
+	if _, err := os.Stat(computedWorktreePath(t, dir, "feature/x")); !os.IsNotExist(err) {
+		t.Errorf("Expected no worktree to be created")
+	}
+	assertCDFileEmpty(t, cdFile)
+}
+
+// TestCheckoutQuietSuppressesShellInitTip covers scenario 18: --quiet suppresses
+// the shell-init tip.
+// Steps:
+// 1. Initializes git-flow, creates feature/x and a worktree for it
+// 2. Runs 'git flow feature checkout x --quiet' with GIT_FLOW_CD_FILE unset, the only state where the tip would print
+// 3. Verifies stdout equals exactly the two navigation lines
+// 4. Verifies no Tip line is present and stderr is empty
+func TestCheckoutQuietSuppressesShellInitTip(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := addWorktree(t, dir, "feature/x")
+
+	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, nil, "feature", "checkout", "x", "--quiet")
+	if err != nil {
+		t.Fatalf("feature checkout --quiet failed: %v\nStderr: %s", err, stderr)
+	}
+
+	want := "Worktree for branch 'feature/x' at " + wtPath + "\n" +
+		"To switch to it: cd " + wtPath + "\n"
+	if stdout != want {
+		t.Errorf("Expected stdout %q, got %q", want, stdout)
+	}
+	if stderr != "" {
+		t.Errorf("Expected no output on stderr, got %q", stderr)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Group B — checkout decisions with no spec scenario
+// ---------------------------------------------------------------------------
+
+// TestCheckoutBranchInMainWorktreeNavigatesToMainWorktree covers SC-6: a branch
+// checked out in the main worktree is navigated to like any other worktree.
+// Steps:
+// 1. Initializes git-flow and creates feature/x and feature/other
+// 2. Adds a worktree for feature/other so the command can run from a linked worktree
+// 3. Checks feature/x out in the main worktree
+// 4. Runs 'git flow feature checkout x' from the linked worktree with GIT_FLOW_CD_FILE set
+// 5. Verifies the CD file holds the main worktree root and stdout names it
+// 6. Verifies git's 'already used by worktree' failure never appears, because no classic switch is attempted
+func TestCheckoutBranchInMainWorktreeNavigatesToMainWorktree(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	createFreeBranch(t, dir, "feature/other")
+	linkedPath := addWorktree(t, dir, "feature/other")
+	if out, err := testutil.RunGit(t, dir, "checkout", "feature/x"); err != nil {
+		t.Fatalf("Failed to check feature/x out in the main worktree: %v\nOutput: %s", err, out)
+	}
+	cdFile := cdFilePath(t)
+
+	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, linkedPath, cdEnv(cdFile), "feature", "checkout", "x")
+	if err != nil {
+		t.Fatalf("feature checkout from a linked worktree failed: %v\nStderr: %s", err, stderr)
+	}
+
+	mainRoot := testutil.EvalPath(t, dir)
+	if got := readCDFile(t, cdFile); got != mainRoot {
+		t.Errorf("Expected CD file to hold the main worktree %q, got %q", mainRoot, got)
+	}
+	if !strings.Contains(stdout, "Worktree for branch 'feature/x' at "+mainRoot) {
+		t.Errorf("Expected stdout to name the main worktree, got %q", stdout)
+	}
+	if strings.Contains(stderr, "already used by worktree") {
+		t.Errorf("Expected no classic switch to be attempted, got %q", stderr)
+	}
+}
+
+// TestCheckoutStaleWorktreeEntryFails covers SC-7: a worktree entry whose
+// directory is gone is never handed to the shell as a destination.
+// Steps:
+// 1. Initializes git-flow, creates feature/x and a worktree for it
+// 2. Deletes the worktree directory by hand, leaving the admin entry behind
+// 3. Runs 'git flow feature checkout x' with GIT_FLOW_CD_FILE set
+// 4. Verifies exit code 3 and that stderr names the recorded path and 'git flow worktree prune'
+// 5. Verifies the CD file is still zero-length
+// 6. Verifies the main worktree's branch was not switched
+func TestCheckoutStaleWorktreeEntryFails(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := addWorktree(t, dir, "feature/x")
+	branchBefore := testutil.GetCurrentBranch(t, dir)
+	if err := os.RemoveAll(wtPath); err != nil {
+		t.Fatalf("Failed to remove the worktree directory: %v", err)
+	}
+	cdFile := cdFilePath(t)
+
+	_, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x")
+	if got := worktreeExitCode(err); got != 3 {
+		t.Fatalf("Expected exit code 3, got %d\nStderr: %s", got, stderr)
+	}
+	if !strings.Contains(stderr, wtPath) {
+		t.Errorf("Expected stderr to name the recorded path %q, got %q", wtPath, stderr)
+	}
+	if !strings.Contains(stderr, "git flow worktree prune") {
+		t.Errorf("Expected stderr to point at 'git flow worktree prune', got %q", stderr)
+	}
+	assertCDFileEmpty(t, cdFile)
+	if got := testutil.GetCurrentBranch(t, dir); got != branchBefore {
+		t.Errorf("Expected the main worktree to stay on %q, got %q", branchBefore, got)
+	}
+}
+
+// TestCheckoutClobberRefusesFile covers SC-4: --clobber refuses a file at the
+// target path.
+// Steps:
+// 1. Initializes git-flow and creates feature/x
+// 2. Creates the computed worktree path as a file with known content
+// 3. Runs 'git flow feature checkout x --worktree --clobber' with GIT_FLOW_CD_FILE set
+// 4. Verifies exit code 6 and that stderr refuses because the target is a file
+// 5. Verifies the file still exists with its content intact
+// 6. Verifies the CD file is still zero-length
+func TestCheckoutClobberRefusesFile(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := computedWorktreePath(t, dir, "feature/x")
+	if err := os.MkdirAll(filepath.Dir(wtPath), 0755); err != nil {
+		t.Fatalf("Failed to create the target's parent directory: %v", err)
+	}
+	if err := os.WriteFile(wtPath, []byte("not a worktree"), 0644); err != nil {
+		t.Fatalf("Failed to create the obstructing file: %v", err)
+	}
+	cdFile := cdFilePath(t)
+
+	_, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x", "--worktree", "--clobber")
+	if got := worktreeExitCode(err); got != 6 {
+		t.Fatalf("Expected exit code 6, got %d\nStderr: %s", got, stderr)
+	}
+	if !strings.Contains(stderr, "it is a file, not a directory") {
+		t.Errorf("Expected stderr to refuse a file, got %q", stderr)
+	}
+	assertFileContent(t, wtPath, "not a worktree")
+	assertCDFileEmpty(t, cdFile)
+}
+
+// TestCheckoutClobberRefusesRegisteredWorktree covers SC-4: --clobber refuses a
+// registered worktree of this repository.
+// Steps:
+// 1. Initializes git-flow and sets a branch-independent path template so two branches compute the same target
+// 2. Creates feature/x and feature/y and adds a worktree for feature/y at that shared target
+// 3. Runs 'git flow feature checkout x --worktree --clobber' with GIT_FLOW_CD_FILE set
+// 4. Verifies exit code 6 and that stderr points at 'git flow worktree remove'
+// 5. Verifies the other worktree still exists and is still listed by git
+// 6. Verifies the CD file is still zero-length
+func TestCheckoutClobberRefusesRegisteredWorktree(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	// The template is repository-unique on purpose: filepath.Dir(dir) is the
+	// shared system temp directory, so a fixed name would collide with every
+	// other parallel test and concurrent 'go test' run.
+	sharedRoot := filepath.Join(filepath.Dir(testutil.EvalPath(t, dir)), filepath.Base(dir)+"-shared-wt")
+	defer os.RemoveAll(sharedRoot)
+	if out, err := testutil.RunGit(t, dir, "config", "gitflow.worktreePath", "../{{ repo }}-shared-wt"); err != nil {
+		t.Fatalf("Failed to set gitflow.worktreePath: %v\nOutput: %s", err, out)
+	}
+	createFreeBranch(t, dir, "feature/x")
+	createFreeBranch(t, dir, "feature/y")
+	if out, err := testutil.RunGitFlow(t, dir, "worktree", "add", "feature/y"); err != nil {
+		t.Fatalf("Failed to add the shared worktree: %v\nOutput: %s", err, out)
+	}
+	cdFile := cdFilePath(t)
+
+	_, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x", "--worktree", "--clobber")
+	if got := worktreeExitCode(err); got != 6 {
+		t.Fatalf("Expected exit code 6, got %d\nStderr: %s", got, stderr)
+	}
+	if !strings.Contains(stderr, "git flow worktree remove") {
+		t.Errorf("Expected stderr to point at 'git flow worktree remove', got %q", stderr)
+	}
+	if _, err := os.Stat(sharedRoot); err != nil {
+		t.Errorf("Expected the other worktree to survive: %v", err)
+	}
+	if !strings.Contains(gitWorktreeList(t, dir), sharedRoot) {
+		t.Errorf("Expected git worktree list to still show %s", sharedRoot)
+	}
+	assertCDFileEmpty(t, cdFile)
+}
+
+// TestCheckoutClobberRefusesDirectoryWithGitEntry covers SC-4: --clobber refuses
+// a directory holding a .git FILE, the linked-worktree form.
+// Steps:
+// 1. Initializes git-flow and creates feature/x
+// 2. Creates the computed path as a directory holding a .git file and a decoy file
+// 3. Runs 'git flow feature checkout x --worktree --clobber' with GIT_FLOW_CD_FILE set
+// 4. Verifies exit code 6 and that stderr refuses because the directory looks like a repository
+// 5. Verifies the directory and both files are intact
+// 6. Verifies the CD file is still zero-length
+func TestCheckoutClobberRefusesDirectoryWithGitEntry(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := computedWorktreePath(t, dir, "feature/x")
+	writeObstruction(t, wtPath, "decoy.txt", "work in progress")
+	if err := os.WriteFile(filepath.Join(wtPath, ".git"), []byte("gitdir: /elsewhere\n"), 0644); err != nil {
+		t.Fatalf("Failed to create the .git file: %v", err)
+	}
+	cdFile := cdFilePath(t)
+
+	_, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x", "--worktree", "--clobber")
+	if got := worktreeExitCode(err); got != 6 {
+		t.Fatalf("Expected exit code 6, got %d\nStderr: %s", got, stderr)
+	}
+	if !strings.Contains(stderr, "it contains a .git entry") {
+		t.Errorf("Expected stderr to refuse a repository-looking directory, got %q", stderr)
+	}
+	assertFileContent(t, filepath.Join(wtPath, "decoy.txt"), "work in progress")
+	assertFileContent(t, filepath.Join(wtPath, ".git"), "gitdir: /elsewhere\n")
+	assertCDFileEmpty(t, cdFile)
+}
+
+// TestCheckoutClobberRefusesDirectoryWithGitDirectory covers SC-4: --clobber
+// refuses a directory holding a .git DIRECTORY, the ordinary-clone form.
+//
+// It is separate from the .git-file case because an implementation that stats
+// the entry and checks !IsDir() passes that one and then removes somebody's
+// clone.
+// Steps:
+// 1. Initializes git-flow and creates feature/x
+// 2. Creates the computed path as a directory holding a .git/ directory with a file inside it, plus a sentinel file
+// 3. Runs 'git flow feature checkout x --worktree --clobber' with GIT_FLOW_CD_FILE set
+// 4. Verifies exit code 6 and that stderr refuses because the directory looks like a repository
+// 5. Verifies the directory, the .git directory's content and the sentinel are all intact
+// 6. Verifies the CD file is still zero-length
+func TestCheckoutClobberRefusesDirectoryWithGitDirectory(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := computedWorktreePath(t, dir, "feature/x")
+	writeObstruction(t, wtPath, "sentinel.txt", "somebody's clone")
+	writeObstruction(t, filepath.Join(wtPath, ".git"), "HEAD", "ref: refs/heads/main\n")
+	cdFile := cdFilePath(t)
+
+	_, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x", "--worktree", "--clobber")
+	if got := worktreeExitCode(err); got != 6 {
+		t.Fatalf("Expected exit code 6, got %d\nStderr: %s", got, stderr)
+	}
+	if !strings.Contains(stderr, "it contains a .git entry") {
+		t.Errorf("Expected stderr to refuse a repository-looking directory, got %q", stderr)
+	}
+	assertFileContent(t, filepath.Join(wtPath, "sentinel.txt"), "somebody's clone")
+	assertFileContent(t, filepath.Join(wtPath, ".git", "HEAD"), "ref: refs/heads/main\n")
+	assertCDFileEmpty(t, cdFile)
+}
+
+// TestCheckoutClobberWithNothingToClobberSucceeds covers SC-4: --clobber with an
+// empty target path is an ordinary creation.
+// Steps:
+// 1. Initializes git-flow and creates feature/x with nothing at the computed path
+// 2. Runs 'git flow feature checkout x --worktree --clobber' with GIT_FLOW_CD_FILE set
+// 3. Verifies exit code 0 and that the worktree was created and marked
+// 4. Verifies stdout reports the creation and says nothing about clobbering
+// 5. Verifies stderr is empty
+func TestCheckoutClobberWithNothingToClobberSucceeds(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	cdFile := cdFilePath(t)
+
+	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x", "--worktree", "--clobber")
+	if err != nil {
+		t.Fatalf("feature checkout --worktree --clobber failed: %v\nStderr: %s", err, stderr)
+	}
+
+	wtPath := computedWorktreePath(t, dir, "feature/x")
+	if !strings.Contains(gitWorktreeList(t, dir), wtPath) {
+		t.Errorf("Expected git worktree list to show %s", wtPath)
+	}
+	if got := testutil.GitConfigValue(t, dir, managedMarkerFor("feature/x")); got != "true" {
+		t.Errorf("Expected the provenance marker to be true, got %q", got)
+	}
+	if !strings.Contains(stdout, "Created worktree for branch 'feature/x' at "+wtPath) {
+		t.Errorf("Expected stdout to report the creation, got %q", stdout)
+	}
+	if strings.Contains(strings.ToLower(stdout), "removed") {
+		t.Errorf("Expected no removal message when there was nothing to clobber, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Errorf("Expected no output on stderr, got %q", stderr)
+	}
+}
+
+// TestCheckoutWorktreeFlagWithExistingWorktreeNavigates covers --worktree on a
+// branch that already has one: it navigates and leaves provenance alone.
+// Steps:
+// 1. Initializes git-flow, creates feature/x and a worktree for it
+// 2. Records the provenance marker value
+// 3. Runs 'git flow feature checkout x --worktree' with GIT_FLOW_CD_FILE set
+// 4. Verifies no second worktree was created and the CD file holds the existing path
+// 5. Verifies stdout says 'Worktree for branch', not 'Created worktree'
+// 6. Verifies the provenance marker is unchanged
+func TestCheckoutWorktreeFlagWithExistingWorktreeNavigates(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := addWorktree(t, dir, "feature/x")
+	markerBefore := testutil.GitConfigValue(t, dir, managedMarkerFor("feature/x"))
+	cdFile := cdFilePath(t)
+
+	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x", "--worktree")
+	if err != nil {
+		t.Fatalf("feature checkout --worktree failed: %v\nStderr: %s", err, stderr)
+	}
+
+	if got := strings.Count(gitWorktreeList(t, dir), "\n"); got != 2 {
+		t.Errorf("Expected exactly the main worktree and one linked worktree, got %q", gitWorktreeList(t, dir))
+	}
+	if got := readCDFile(t, cdFile); got != wtPath {
+		t.Errorf("Expected CD file to hold %q, got %q", wtPath, got)
+	}
+	if !strings.Contains(stdout, "Worktree for branch 'feature/x' at "+wtPath) {
+		t.Errorf("Expected stdout to name the existing worktree, got %q", stdout)
+	}
+	if strings.Contains(stdout, "Created worktree") {
+		t.Errorf("Expected no creation message, got %q", stdout)
+	}
+	if got := testutil.GitConfigValue(t, dir, managedMarkerFor("feature/x")); got != markerBefore {
+		t.Errorf("Expected provenance %q to be unchanged, got %q", markerBefore, got)
+	}
+}
+
+// TestCheckoutNoCDStillSwitchesBranchWithoutWorktree covers SC-9: --no-cd never
+// blocks the classic branch switch.
+// Steps:
+// 1. Initializes git-flow and creates feature/x without checking it out
+// 2. Runs 'git flow feature checkout x --no-cd' with GIT_FLOW_CD_FILE set
+// 3. Verifies the main worktree is now on feature/x
+// 4. Verifies stdout is the classic 'Switched to branch' message
+// 5. Verifies the CD file is still zero-length
+func TestCheckoutNoCDStillSwitchesBranchWithoutWorktree(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	createFreeBranch(t, dir, "feature/x")
+	cdFile := cdFilePath(t)
+
+	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x", "--no-cd")
+	if err != nil {
+		t.Fatalf("feature checkout --no-cd failed: %v\nStderr: %s", err, stderr)
+	}
+
+	if got := testutil.GetCurrentBranch(t, dir); got != "feature/x" {
+		t.Errorf("Expected to be on feature/x, got %q", got)
+	}
+	if want := "Switched to branch 'feature/x'\n"; stdout != want {
+		t.Errorf("Expected stdout %q, got %q", want, stdout)
+	}
+	assertCDFileEmpty(t, cdFile)
+}
+
+// TestCheckoutPrefixMatchNavigatesToWorktree covers the worktree lookup running
+// on the RESOLVED branch name, never on the user's raw argument.
+// Steps:
+// 1. Initializes git-flow, creates feature/user-auth and a worktree for it
+// 2. Runs 'git flow feature checkout user' with the unique prefix and GIT_FLOW_CD_FILE set
+// 3. Verifies the CD file holds feature/user-auth's worktree path
+// 4. Verifies stdout names the resolved branch
+func TestCheckoutPrefixMatchNavigatesToWorktree(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/user-auth")
+	wtPath := addWorktree(t, dir, "feature/user-auth")
+	cdFile := cdFilePath(t)
+
+	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "user")
+	if err != nil {
+		t.Fatalf("feature checkout by prefix failed: %v\nStderr: %s", err, stderr)
+	}
+
+	if got := readCDFile(t, cdFile); got != wtPath {
+		t.Errorf("Expected CD file to hold %q, got %q", wtPath, got)
+	}
+	if !strings.Contains(stdout, "Worktree for branch 'feature/user-auth' at "+wtPath) {
+		t.Errorf("Expected stdout to name the resolved branch, got %q", stdout)
+	}
+}
+
+// TestCheckoutUnwritableCDFileWarnsAndSucceeds covers a destination file that
+// cannot be written: the navigation still happens and the command still succeeds.
+// Steps:
+// 1. Initializes git-flow, creates feature/x and a worktree for it
+// 2. Points GIT_FLOW_CD_FILE at a path inside a directory that does not exist
+// 3. Runs 'git flow feature checkout x'
+// 4. Verifies exit code 0 and that stdout still carries the navigation lines
+// 5. Verifies stderr carries a Warning naming the destination file
+func TestCheckoutUnwritableCDFileWarnsAndSucceeds(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := addWorktree(t, dir, "feature/x")
+	unwritable := filepath.Join(t.TempDir(), "missing-dir", "cd-destination")
+
+	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(unwritable), "feature", "checkout", "x")
+	if err != nil {
+		t.Fatalf("Expected exit code 0, got %v\nStderr: %s", err, stderr)
+	}
+
+	if !strings.Contains(stdout, "Worktree for branch 'feature/x' at "+wtPath) {
+		t.Errorf("Expected stdout to carry the navigation lines, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "Warning:") || !strings.Contains(stderr, unwritable) {
+		t.Errorf("Expected a warning naming %q, got %q", unwritable, stderr)
+	}
+}
+
+// TestCheckoutCurrentMainWorktreeUsesClassicBehavior covers SC-14: when the
+// destination is the worktree the command already runs in, nothing changes.
+//
+// Without this an implementation that navigates whenever the branch has ANY
+// worktree — including the one it is standing in — would change the output of
+// the most common checkout invocation and make the installed wrapper perform a
+// no-op cd to the repository root.
+// Steps:
+// 1. Initializes git-flow and runs 'feature start x' so feature/x is checked out in the main worktree
+// 2. Runs 'git flow feature checkout x' from the main worktree with GIT_FLOW_CD_FILE set
+// 3. Verifies stdout equals exactly the classic 'Switched to branch' message
+// 4. Verifies stderr is empty and no navigation or tip lines were printed
+// 5. Verifies the CD file is still zero-length and the branch is still feature/x
+func TestCheckoutCurrentMainWorktreeUsesClassicBehavior(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	if out, err := testutil.RunGitFlow(t, dir, "feature", "start", "x"); err != nil {
+		t.Fatalf("feature start failed: %v\nOutput: %s", err, out)
+	}
+	cdFile := cdFilePath(t)
+
+	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x")
+	if err != nil {
+		t.Fatalf("feature checkout failed: %v\nStderr: %s", err, stderr)
+	}
+
+	if want := "Switched to branch 'feature/x'\n"; stdout != want {
+		t.Errorf("Expected stdout %q, got %q", want, stdout)
+	}
+	if stderr != "" {
+		t.Errorf("Expected no output on stderr, got %q", stderr)
+	}
+	assertCDFileEmpty(t, cdFile)
+	if got := testutil.GetCurrentBranch(t, dir); got != "feature/x" {
+		t.Errorf("Expected to be on feature/x, got %q", got)
+	}
+}
+
+// TestCheckoutClobberWithoutWorktreeIsSilentNoOp covers SC-15: --clobber without
+// --worktree changes nothing and says nothing.
+// Steps:
+// 1. Initializes git-flow and creates feature/x
+// 2. Creates the computed worktree path as a directory holding a sentinel file
+// 3. Runs 'git flow feature checkout x --clobber' without --worktree, with GIT_FLOW_CD_FILE set
+// 4. Verifies stdout equals exactly the classic 'Switched to branch' message and stderr is empty
+// 5. Verifies the sentinel directory and its file are byte-identical
+// 6. Verifies no worktree was created and the CD file is still zero-length
+func TestCheckoutClobberWithoutWorktreeIsSilentNoOp(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := computedWorktreePath(t, dir, "feature/x")
+	writeObstruction(t, wtPath, "sentinel.txt", "do not delete")
+	cdFile := cdFilePath(t)
+
+	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x", "--clobber")
+	if err != nil {
+		t.Fatalf("feature checkout --clobber failed: %v\nStderr: %s", err, stderr)
+	}
+
+	if want := "Switched to branch 'feature/x'\n"; stdout != want {
+		t.Errorf("Expected stdout %q, got %q", want, stdout)
+	}
+	if stderr != "" {
+		t.Errorf("Expected no output on stderr, got %q", stderr)
+	}
+	if got := testutil.GetCurrentBranch(t, dir); got != "feature/x" {
+		t.Errorf("Expected to be on feature/x, got %q", got)
+	}
+	assertFileContent(t, filepath.Join(wtPath, "sentinel.txt"), "do not delete")
+	if strings.Contains(gitWorktreeList(t, dir), wtPath) {
+		t.Errorf("Expected no worktree at %s", wtPath)
+	}
+	assertCDFileEmpty(t, cdFile)
+}

--- a/test/cmd/checkout_worktree_test.go
+++ b/test/cmd/checkout_worktree_test.go
@@ -253,6 +253,7 @@ func TestCheckoutWorktreeOccupiedPathFails(t *testing.T) {
 // 4. Verifies exit code 0 and that the stale file is gone
 // 5. Verifies a worktree exists at the path, the marker is written and the CD file holds the path
 // 6. Verifies stdout reports the creation
+// 7. Verifies stdout announces the removal, so the one destructive operation in the command cannot go silent
 func TestCheckoutWorktreeClobberReplacesStaleDirectory(t *testing.T) {
 	t.Parallel()
 	dir := initWorktreeRepo(t)
@@ -282,6 +283,11 @@ func TestCheckoutWorktreeClobberReplacesStaleDirectory(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "Created worktree for branch 'feature/x' at "+wtPath) {
 		t.Errorf("Expected stdout to report the creation, got %q", stdout)
+	}
+	// Without this the suite would accept a --clobber that removed the directory
+	// silently: the only other test touching this line pins its ABSENCE.
+	if !strings.Contains(stdout, "Removed "+wtPath+" to make room for the worktree") {
+		t.Errorf("Expected stdout to announce the removal, got %q", stdout)
 	}
 }
 

--- a/test/cmd/checkout_worktree_test.go
+++ b/test/cmd/checkout_worktree_test.go
@@ -484,6 +484,18 @@ func TestCheckoutStaleWorktreeEntryFails(t *testing.T) {
 	if err := os.RemoveAll(wtPath); err != nil {
 		t.Fatalf("Failed to remove the worktree directory: %v", err)
 	}
+	assertStaleWorktreeRefused(t, dir, wtPath, branchBefore)
+}
+
+// assertStaleWorktreeRefused runs the checkout and verifies the recorded path was
+// refused rather than offered to the shell. It is shared by the three ways a
+// worktree directory stops being that worktree: removed outright, replaced by an
+// unrelated directory, or replaced by a file.
+//
+// The CD-file assertion is the one that matters: SC-7's whole point is that
+// git-flow must not exit 0 with a destination the shell cannot use.
+func assertStaleWorktreeRefused(t *testing.T, dir string, wtPath string, branchBefore string) {
+	t.Helper()
 	cdFile := cdFilePath(t)
 
 	_, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "feature", "checkout", "x")
@@ -500,6 +512,60 @@ func TestCheckoutStaleWorktreeEntryFails(t *testing.T) {
 	if got := testutil.GetCurrentBranch(t, dir); got != branchBefore {
 		t.Errorf("Expected the main worktree to stay on %q, got %q", branchBefore, got)
 	}
+}
+
+// TestCheckoutReplacedWorktreeDirectoryFails covers SC-7 where the recorded path
+// still EXISTS but is no longer the worktree: a plain directory took its place.
+// A guard that only tested existence navigated the shell into it and exited 0.
+// Steps:
+// 1. Initializes git-flow, creates feature/x and a worktree for it
+// 2. Deletes the worktree directory and puts an unrelated plain directory at the same path
+// 3. Runs 'git flow feature checkout x' with GIT_FLOW_CD_FILE set
+// 4. Verifies exit code 3 and that stderr names the recorded path and 'git flow worktree prune'
+// 5. Verifies the CD file is still zero-length, so the shell was never sent there
+// 6. Verifies the main worktree's branch was not switched
+func TestCheckoutReplacedWorktreeDirectoryFails(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := addWorktree(t, dir, "feature/x")
+	branchBefore := testutil.GetCurrentBranch(t, dir)
+	if err := os.RemoveAll(wtPath); err != nil {
+		t.Fatalf("Failed to remove the worktree directory: %v", err)
+	}
+	writeObstruction(t, wtPath, "unrelated.txt", "not a worktree")
+
+	assertStaleWorktreeRefused(t, dir, wtPath, branchBefore)
+}
+
+// TestCheckoutReplacedWorktreeFileFails covers SC-7 where the recorded path was
+// replaced by a REGULAR FILE. This is SC-7's stated rationale exactly: existence
+// alone let git-flow exit 0 while the wrapper reported 'cannot enter <path>'.
+// Steps:
+// 1. Initializes git-flow, creates feature/x and a worktree for it
+// 2. Deletes the worktree directory and writes a regular file at the same path
+// 3. Runs 'git flow feature checkout x' with GIT_FLOW_CD_FILE set
+// 4. Verifies exit code 3 and that stderr names the recorded path and 'git flow worktree prune'
+// 5. Verifies the CD file is still zero-length, so the shell was never sent there
+// 6. Verifies the main worktree's branch was not switched
+func TestCheckoutReplacedWorktreeFileFails(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	wtPath := addWorktree(t, dir, "feature/x")
+	branchBefore := testutil.GetCurrentBranch(t, dir)
+	if err := os.RemoveAll(wtPath); err != nil {
+		t.Fatalf("Failed to remove the worktree directory: %v", err)
+	}
+	if err := os.WriteFile(wtPath, []byte("not a worktree"), 0644); err != nil {
+		t.Fatalf("Failed to write the replacing file: %v", err)
+	}
+
+	assertStaleWorktreeRefused(t, dir, wtPath, branchBefore)
 }
 
 // TestCheckoutClobberRefusesFile covers SC-4: --clobber refuses a file at the

--- a/test/cmd/shellinit_test.go
+++ b/test/cmd/shellinit_test.go
@@ -222,7 +222,7 @@ func TestShellInitFishScriptSyntaxValid(t *testing.T) {
 // the invalid identifier is evaluated without the POSIX guard.
 // Steps:
 // 1. Starts bash with --posix, rc files disabled
-// 2. Evaluates the output of 'git-flow shell-init bash'
+// 2. Evaluates the output of 'git flow shell-init bash'
 // 3. Echoes SOURCED and checks that a git function is installed
 // 4. Verifies exit code 0 and that both markers are present
 func TestShellInitBashScriptSourcesUnderPosixMode(t *testing.T) {
@@ -234,7 +234,7 @@ func TestShellInitBashScriptSourcesUnderPosixMode(t *testing.T) {
 		// The command TYPE is what is asserted: a bare 'type git' succeeds for
 		// the ordinary git executable on PATH, so it would pass for a script
 		// that skips the git() function entirely in POSIX mode.
-		Script: `eval "$(git-flow shell-init bash)"; echo SOURCED; test "$(type -t git)" = function && echo HAVE-GIT-FN`,
+		Script: `eval "$(git flow shell-init bash)"; echo SOURCED; test "$(type -t git)" = function && echo HAVE-GIT-FN`,
 	})
 
 	if res.ExitCode != 0 {

--- a/test/cmd/shellinit_test.go
+++ b/test/cmd/shellinit_test.go
@@ -1,0 +1,249 @@
+package cmd_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// shellInitScript returns the script 'git flow shell-init <shell>' emits,
+// failing the test when the command itself fails.
+func shellInitScript(t *testing.T, shell string) string {
+	t.Helper()
+	stdout, stderr, err := testutil.RunGitFlowStreams(t, t.TempDir(), "shell-init", shell)
+	if err != nil {
+		t.Fatalf("shell-init %s failed: %v\nStderr: %s", shell, err, stderr)
+	}
+	if stderr != "" {
+		t.Errorf("Expected no output on stderr, got %q", stderr)
+	}
+	return stdout
+}
+
+// assertContainsAll fails for every wanted substring the script is missing.
+func assertContainsAll(t *testing.T, script string, wanted []string) {
+	t.Helper()
+	for _, want := range wanted {
+		if !strings.Contains(script, want) {
+			t.Errorf("Expected the script to contain %q", want)
+		}
+	}
+}
+
+// assertContainsNone fails for every forbidden substring the script carries.
+func assertContainsNone(t *testing.T, script string, forbidden []string) {
+	t.Helper()
+	for _, bad := range forbidden {
+		if strings.Contains(script, bad) {
+			t.Errorf("Expected the script NOT to contain %q", bad)
+		}
+	}
+}
+
+// TestShellInitBashScriptContent covers scenario 10: the bash script defines the
+// wrapper, supplies the navigation file per invocation, and cleans up.
+// Steps:
+// 1. Runs 'git flow shell-init bash'
+// 2. Verifies the script defines the shared navigation function and both the git and git-flow wrappers
+// 3. Verifies it sets GIT_FLOW_CD_FILE, calls git-flow and delegates ordinary git verbatim
+// 4. Verifies it creates a temporary file with mktemp, removes it and returns a status
+// 5. Verifies it never exports GIT_FLOW_CD_FILE, which would leak into other programs
+// 6. Verifies no command substitution wraps the git-flow invocation, which would capture the output the spec requires to stream
+func TestShellInitBashScriptContent(t *testing.T) {
+	t.Parallel()
+	script := shellInitScript(t, "bash")
+
+	assertContainsAll(t, script, []string{
+		"__git_flow_nav",
+		"git()",
+		"git-flow()",
+		"GIT_FLOW_CD_FILE=",
+		"command git-flow",
+		// Asserted with its arguments: "command git" alone is a substring of
+		// "command git-flow" and would pass for a script that never delegates.
+		`command git "$@"`,
+		"mktemp",
+		"rm -f",
+		"return",
+	})
+	assertContainsNone(t, script, []string{
+		"export GIT_FLOW_CD_FILE",
+		"$(command git-flow",
+		"$(git-flow",
+	})
+}
+
+// TestShellInitZshScriptContent covers scenario 11: the zsh script carries the
+// same wrapper contract as the bash one.
+// Steps:
+// 1. Runs 'git flow shell-init zsh'
+// 2. Verifies the script defines the shared navigation function and both the git and git-flow wrappers
+// 3. Verifies it sets GIT_FLOW_CD_FILE, calls git-flow and delegates ordinary git verbatim
+// 4. Verifies it creates a temporary file with mktemp, removes it and returns a status
+// 5. Verifies it never exports GIT_FLOW_CD_FILE and never captures git-flow's output in a command substitution
+func TestShellInitZshScriptContent(t *testing.T) {
+	t.Parallel()
+	script := shellInitScript(t, "zsh")
+
+	assertContainsAll(t, script, []string{
+		"__git_flow_nav",
+		"git()",
+		"git-flow()",
+		"GIT_FLOW_CD_FILE=",
+		"command git-flow",
+		`command git "$@"`,
+		"mktemp",
+		"rm -f",
+		"return",
+	})
+	assertContainsNone(t, script, []string{
+		"export GIT_FLOW_CD_FILE",
+		"$(command git-flow",
+		"$(git-flow",
+	})
+}
+
+// TestShellInitFishScriptContent covers scenario 11: the fish script carries the
+// same wrapper contract in fish syntax.
+// Steps:
+// 1. Runs 'git flow shell-init fish'
+// 2. Verifies the script defines the shared navigation function and both the git and git-flow wrappers
+// 3. Verifies it scopes GIT_FLOW_CD_FILE to one command with env, captures $status and delegates ordinary git verbatim
+// 4. Verifies it creates a temporary file with mktemp and removes it
+// 5. Verifies it never exports the variable with set -x or set -gx, fish's actual export forms
+// 6. Verifies no command substitution wraps the git-flow invocation
+func TestShellInitFishScriptContent(t *testing.T) {
+	t.Parallel()
+	script := shellInitScript(t, "fish")
+
+	assertContainsAll(t, script, []string{
+		"function __git_flow_nav",
+		"function git-flow",
+		"function git",
+		"env GIT_FLOW_CD_FILE=",
+		"$status",
+		"mktemp",
+		"rm -f",
+		"command git $argv",
+	})
+	// Not asserted: "contains no export". Fish has no export builtin, so that
+	// would be true of every fish script ever written, correct or broken.
+	assertContainsNone(t, script, []string{
+		"set -x GIT_FLOW_CD_FILE",
+		"set -gx GIT_FLOW_CD_FILE",
+		"(command git-flow",
+		"(git-flow ",
+	})
+}
+
+// TestShellInitUnknownShellFails covers scenario 12: an unsupported shell is
+// rejected.
+// Steps:
+// 1. Runs 'git flow shell-init tcsh'
+// 2. Verifies exit code 1, the code main.go returns for every error Execute reports
+// 3. Verifies stderr carries Cobra's invalid-argument message naming the command
+func TestShellInitUnknownShellFails(t *testing.T) {
+	t.Parallel()
+	_, stderr, err := testutil.RunGitFlowStreams(t, t.TempDir(), "shell-init", "tcsh")
+	if got := worktreeExitCode(err); got != 1 {
+		t.Fatalf("Expected exit code 1, got %d\nStderr: %s", got, stderr)
+	}
+	if !strings.Contains(stderr, `invalid argument "tcsh" for "git-flow shell-init"`) {
+		t.Errorf("Expected an invalid-argument message, got %q", stderr)
+	}
+}
+
+// TestShellInitNoArgumentFails covers scenario 13: the shell argument is
+// mandatory, which is why the tip names a <shell> placeholder.
+// Steps:
+// 1. Runs 'git flow shell-init' with no argument
+// 2. Verifies exit code 1
+// 3. Verifies stderr carries Cobra's arity message and the usage block
+func TestShellInitNoArgumentFails(t *testing.T) {
+	t.Parallel()
+	_, stderr, err := testutil.RunGitFlowStreams(t, t.TempDir(), "shell-init")
+	if got := worktreeExitCode(err); got != 1 {
+		t.Fatalf("Expected exit code 1, got %d\nStderr: %s", got, stderr)
+	}
+	if !strings.Contains(stderr, "accepts 1 arg(s), received 0") {
+		t.Errorf("Expected an arity message, got %q", stderr)
+	}
+	if !strings.Contains(stderr, "Usage:") || !strings.Contains(stderr, "shell-init") {
+		t.Errorf("Expected the usage block, got %q", stderr)
+	}
+}
+
+// TestShellInitBashScriptSyntaxValid checks the emitted bash script parses.
+// Steps:
+// 1. Runs 'git flow shell-init bash'
+// 2. Parses the script with 'bash -n'
+// 3. Verifies bash accepts it and writes nothing to stderr
+func TestShellInitBashScriptSyntaxValid(t *testing.T) {
+	t.Parallel()
+	stderr, ok := testutil.CheckShellSyntax(t, "bash", shellInitScript(t, "bash"))
+	if !ok || stderr != "" {
+		t.Errorf("Expected bash to accept the script, got %q", stderr)
+	}
+}
+
+// TestShellInitZshScriptSyntaxValid checks the emitted zsh script parses.
+// Steps:
+// 1. Runs 'git flow shell-init zsh'
+// 2. Parses the script with 'zsh -n'
+// 3. Verifies zsh accepts it and writes nothing to stderr
+func TestShellInitZshScriptSyntaxValid(t *testing.T) {
+	t.Parallel()
+	stderr, ok := testutil.CheckShellSyntax(t, "zsh", shellInitScript(t, "zsh"))
+	if !ok || stderr != "" {
+		t.Errorf("Expected zsh to accept the script, got %q", stderr)
+	}
+}
+
+// TestShellInitFishScriptSyntaxValid checks the emitted fish script parses.
+// Steps:
+// 1. Runs 'git flow shell-init fish'
+// 2. Parses the script with 'fish --no-execute'
+// 3. Verifies fish accepts it and writes nothing to stderr
+func TestShellInitFishScriptSyntaxValid(t *testing.T) {
+	t.Parallel()
+	stderr, ok := testutil.CheckShellSyntax(t, "fish", shellInitScript(t, "fish"))
+	if !ok || stderr != "" {
+		t.Errorf("Expected fish to accept the script, got %q", stderr)
+	}
+}
+
+// TestShellInitBashScriptSourcesUnderPosixMode covers SC-1's trap: bash in POSIX
+// mode cannot define a function named git-flow, and sourcing must survive it.
+//
+// The git-flow function is expected to be ABSENT here — that is the documented
+// degradation. The SOURCED assertion is load-bearing: it proves the shell
+// survived the definition rather than dying on it, which is what happens when
+// the invalid identifier is evaluated without the POSIX guard.
+// Steps:
+// 1. Starts bash with --posix, rc files disabled
+// 2. Evaluates the output of 'git-flow shell-init bash'
+// 3. Echoes SOURCED and checks that a git function is installed
+// 4. Verifies exit code 0 and that both markers are present
+func TestShellInitBashScriptSourcesUnderPosixMode(t *testing.T) {
+	t.Parallel()
+	res := testutil.RunShell(t, testutil.ShellRun{
+		Shell:     "bash",
+		Dir:       t.TempDir(),
+		ShellArgs: []string{"--posix"},
+		// The command TYPE is what is asserted: a bare 'type git' succeeds for
+		// the ordinary git executable on PATH, so it would pass for a script
+		// that skips the git() function entirely in POSIX mode.
+		Script: `eval "$(git-flow shell-init bash)"; echo SOURCED; test "$(type -t git)" = function && echo HAVE-GIT-FN`,
+	})
+
+	if res.ExitCode != 0 {
+		t.Fatalf("Expected exit code 0, got %d\nStderr: %s", res.ExitCode, res.Stderr)
+	}
+	if !strings.Contains(res.Stdout, "SOURCED") {
+		t.Errorf("Expected sourcing to survive POSIX mode, got %q", res.Stdout)
+	}
+	if !strings.Contains(res.Stdout, "HAVE-GIT-FN") {
+		t.Errorf("Expected the git wrapper to be installed in POSIX mode, got %q", res.Stdout)
+	}
+}

--- a/test/cmd/shellinit_wrapper_test.go
+++ b/test/cmd/shellinit_wrapper_test.go
@@ -1,0 +1,873 @@
+package cmd_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// The wrapper behaviours below are each written once and run against all three
+// emitted scripts, so a failure names both the shell and the behaviour.
+
+// installWrapper returns the line that installs the emitted wrapper in shell,
+// exactly as the manpage tells users to write it.
+func installWrapper(shell string) string {
+	return testutil.ShellInstallLine(shell)
+}
+
+// captureStatus returns the statement that records the previous command's exit
+// code in a variable. In fish it MUST be the statement immediately after the
+// command: any test, if or echo in between replaces $status with its own.
+func captureStatus(shell string, name string) string {
+	if shell == "fish" {
+		return fmt.Sprintf("set -l %s $status", name)
+	}
+	return fmt.Sprintf("%s=$?", name)
+}
+
+// lastLine returns the last non-empty line of output, which is where every
+// wrapper script below leaves its final 'pwd -P'.
+func lastLine(output string) string {
+	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if strings.TrimSpace(lines[i]) != "" {
+			return strings.TrimSpace(lines[i])
+		}
+	}
+	return ""
+}
+
+// assertWrapperTempFiles asserts both halves of the cleanup contract: the
+// wrapper left no navigation temp file behind, and it asked for exactly the
+// expected number of temporary files.
+//
+// The call count is what makes several assertions non-vacuous — a wrapper that
+// creates a file and removes it is indistinguishable from one that never
+// creates it by the leftover check alone, and a wrapper reusing one fixed file
+// passes the leftover check while handing stale destinations to later commands.
+func assertWrapperTempFiles(t *testing.T, res testutil.ShellResult, wantMktempCalls int) {
+	t.Helper()
+	if leftovers := testutil.ShellTempFileLeftovers(t, res.TempDir); len(leftovers) > 0 {
+		t.Errorf("Expected no navigation temp files left behind, got %v", leftovers)
+	}
+	if res.MktempCalls != wantMktempCalls {
+		t.Errorf("Expected %d mktemp call(s), got %d", wantMktempCalls, res.MktempCalls)
+	}
+}
+
+// wrapperRepoWithWorktree sets up a repository with feature/x and a worktree for
+// it, the starting state most wrapper behaviours need. It returns the repository
+// directory and the resolved worktree path.
+func wrapperRepoWithWorktree(t *testing.T) (string, string) {
+	t.Helper()
+	dir := initWorktreeRepo(t)
+	t.Cleanup(func() { os.RemoveAll(worktreeRootFor(dir)) })
+	t.Cleanup(func() { testutil.CleanupTestRepo(t, dir) })
+	createFreeBranch(t, dir, "feature/x")
+	return dir, addWorktree(t, dir, "feature/x")
+}
+
+// ---------------------------------------------------------------------------
+// W1 — navigation
+// ---------------------------------------------------------------------------
+
+// assertWrapperNavigatesToWorktree runs a wrapped checkout and verifies the
+// shell itself ended up in the worktree.
+func assertWrapperNavigatesToWorktree(t *testing.T, shell string) {
+	t.Helper()
+	dir, wtPath := wrapperRepoWithWorktree(t)
+
+	res := testutil.RunShell(t, testutil.ShellRun{
+		Shell:  shell,
+		Dir:    dir,
+		Script: installWrapper(shell) + "; git-flow feature checkout x; pwd -P",
+	})
+
+	if res.ExitCode != 0 {
+		t.Fatalf("Expected exit code 0, got %d\nStderr: %s", res.ExitCode, res.Stderr)
+	}
+	if got := lastLine(res.Stdout); got != wtPath {
+		t.Errorf("Expected the shell to end up in %q, got %q", wtPath, got)
+	}
+	assertWrapperTempFiles(t, res, 1)
+}
+
+// TestShellInitBashWrapperNavigatesToWorktree covers scenario 15 for bash.
+// Steps:
+// 1. Sets up a repository with feature/x and a worktree for it
+// 2. Installs the emitted bash wrapper and runs 'git-flow feature checkout x'
+// 3. Verifies the shell's own working directory is now the worktree
+// 4. Verifies exactly one temporary file was created and none was left behind
+func TestShellInitBashWrapperNavigatesToWorktree(t *testing.T) {
+	t.Parallel()
+	assertWrapperNavigatesToWorktree(t, "bash")
+}
+
+// TestShellInitZshWrapperNavigatesToWorktree covers scenario 15 for zsh.
+// Steps:
+// 1. Sets up a repository with feature/x and a worktree for it
+// 2. Installs the emitted zsh wrapper and runs 'git-flow feature checkout x'
+// 3. Verifies the shell's own working directory is now the worktree
+// 4. Verifies exactly one temporary file was created and none was left behind
+func TestShellInitZshWrapperNavigatesToWorktree(t *testing.T) {
+	t.Parallel()
+	assertWrapperNavigatesToWorktree(t, "zsh")
+}
+
+// TestShellInitFishWrapperNavigatesToWorktree covers scenario 15 for fish.
+// Steps:
+// 1. Sets up a repository with feature/x and a worktree for it
+// 2. Installs the emitted fish wrapper and runs 'git-flow feature checkout x'
+// 3. Verifies the shell's own working directory is now the worktree
+// 4. Verifies exactly one temporary file was created and none was left behind
+func TestShellInitFishWrapperNavigatesToWorktree(t *testing.T) {
+	t.Parallel()
+	assertWrapperNavigatesToWorktree(t, "fish")
+}
+
+// ---------------------------------------------------------------------------
+// W2 — the message survives the navigation
+// ---------------------------------------------------------------------------
+
+// assertWrapperKeepsMessageAndNavigates verifies git-flow's own output reaches
+// the terminal in its own order and the shell still moves.
+func assertWrapperKeepsMessageAndNavigates(t *testing.T, shell string) {
+	t.Helper()
+	dir, wtPath := wrapperRepoWithWorktree(t)
+
+	echoPWD := `echo "PWD=$(pwd -P)"`
+	if shell == "fish" {
+		echoPWD = `echo "PWD="(pwd -P)`
+	}
+	res := testutil.RunShell(t, testutil.ShellRun{
+		Shell:  shell,
+		Dir:    dir,
+		Script: installWrapper(shell) + "; git-flow feature checkout x; " + echoPWD,
+	})
+
+	if res.ExitCode != 0 {
+		t.Fatalf("Expected exit code 0, got %d\nStderr: %s", res.ExitCode, res.Stderr)
+	}
+	worktreeLine := strings.Index(res.Stdout, "Worktree for branch 'feature/x' at "+wtPath)
+	cdLine := strings.Index(res.Stdout, "To switch to it: cd "+wtPath)
+	pwdLine := strings.Index(res.Stdout, "PWD="+wtPath)
+	if worktreeLine < 0 || cdLine < 0 || pwdLine < 0 {
+		t.Fatalf("Expected both messages and the final directory in %q", res.Stdout)
+	}
+	if !(worktreeLine < cdLine && cdLine < pwdLine) {
+		t.Errorf("Expected git-flow's messages in its own order before the shell's, got %q", res.Stdout)
+	}
+	if strings.Contains(res.Stdout, "Tip:") {
+		t.Errorf("Expected no shell-init tip while the wrapper supplies the channel, got %q", res.Stdout)
+	}
+	assertWrapperTempFiles(t, res, 1)
+}
+
+// TestShellInitBashWrapperKeepsMessageAndNavigates covers scenario 14 for bash.
+// Steps:
+// 1. Sets up a repository with feature/x and a worktree for it
+// 2. Installs the emitted bash wrapper, runs the checkout and echoes the resulting directory
+// 3. Verifies git-flow's two messages appear in its own order, before the shell's echo
+// 4. Verifies the shell moved to the worktree and no shell-init tip was printed
+func TestShellInitBashWrapperKeepsMessageAndNavigates(t *testing.T) {
+	t.Parallel()
+	assertWrapperKeepsMessageAndNavigates(t, "bash")
+}
+
+// TestShellInitZshWrapperKeepsMessageAndNavigates covers scenario 14 for zsh.
+// Steps:
+// 1. Sets up a repository with feature/x and a worktree for it
+// 2. Installs the emitted zsh wrapper, runs the checkout and echoes the resulting directory
+// 3. Verifies git-flow's two messages appear in its own order, before the shell's echo
+// 4. Verifies the shell moved to the worktree and no shell-init tip was printed
+func TestShellInitZshWrapperKeepsMessageAndNavigates(t *testing.T) {
+	t.Parallel()
+	assertWrapperKeepsMessageAndNavigates(t, "zsh")
+}
+
+// TestShellInitFishWrapperKeepsMessageAndNavigates covers scenario 14 for fish.
+// Steps:
+// 1. Sets up a repository with feature/x and a worktree for it
+// 2. Installs the emitted fish wrapper, runs the checkout and echoes the resulting directory
+// 3. Verifies git-flow's two messages appear in its own order, before the shell's echo
+// 4. Verifies the shell moved to the worktree and no shell-init tip was printed
+func TestShellInitFishWrapperKeepsMessageAndNavigates(t *testing.T) {
+	t.Parallel()
+	assertWrapperKeepsMessageAndNavigates(t, "fish")
+}
+
+// ---------------------------------------------------------------------------
+// W3 — a command that does not navigate leaves the directory alone
+// ---------------------------------------------------------------------------
+
+// assertWrapperWithoutNavigationKeepsDirectory primes the channel with a real
+// navigation first, so a wrapper reusing one fixed temp file would move the
+// shell on the second, non-navigating command.
+func assertWrapperWithoutNavigationKeepsDirectory(t *testing.T, shell string) {
+	t.Helper()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	start := testutil.EvalPath(t, dir)
+
+	res := testutil.RunShell(t, testutil.ShellRun{
+		Shell: shell,
+		Dir:   dir,
+		Script: installWrapper(shell) +
+			"; git-flow worktree add feature/x" +
+			fmt.Sprintf("; cd %q", start) +
+			"; git-flow version; pwd -P",
+	})
+
+	if res.ExitCode != 0 {
+		t.Fatalf("Expected exit code 0, got %d\nStderr: %s", res.ExitCode, res.Stderr)
+	}
+	if got := lastLine(res.Stdout); got != start {
+		t.Errorf("Expected the shell to stay in %q, got %q", start, got)
+	}
+	if !strings.Contains(res.Stdout, "version") {
+		t.Errorf("Expected the version output to reach the terminal, got %q", res.Stdout)
+	}
+	assertWrapperTempFiles(t, res, 2)
+}
+
+// TestShellInitBashWrapperWithoutNavigationKeepsDirectory covers scenario 16 for bash.
+// Steps:
+// 1. Sets up a repository with feature/x
+// 2. Installs the emitted bash wrapper, creates a worktree (which navigates), then returns to the repository
+// 3. Runs 'git-flow version', a command that does not navigate
+// 4. Verifies the working directory is unchanged, the version output is present and no temp file was left
+func TestShellInitBashWrapperWithoutNavigationKeepsDirectory(t *testing.T) {
+	t.Parallel()
+	assertWrapperWithoutNavigationKeepsDirectory(t, "bash")
+}
+
+// TestShellInitZshWrapperWithoutNavigationKeepsDirectory covers scenario 16 for zsh.
+// Steps:
+// 1. Sets up a repository with feature/x
+// 2. Installs the emitted zsh wrapper, creates a worktree (which navigates), then returns to the repository
+// 3. Runs 'git-flow version', a command that does not navigate
+// 4. Verifies the working directory is unchanged, the version output is present and no temp file was left
+func TestShellInitZshWrapperWithoutNavigationKeepsDirectory(t *testing.T) {
+	t.Parallel()
+	assertWrapperWithoutNavigationKeepsDirectory(t, "zsh")
+}
+
+// TestShellInitFishWrapperWithoutNavigationKeepsDirectory covers scenario 16 for fish.
+// Steps:
+// 1. Sets up a repository with feature/x
+// 2. Installs the emitted fish wrapper, creates a worktree (which navigates), then returns to the repository
+// 3. Runs 'git-flow version', a command that does not navigate
+// 4. Verifies the working directory is unchanged, the version output is present and no temp file was left
+func TestShellInitFishWrapperWithoutNavigationKeepsDirectory(t *testing.T) {
+	t.Parallel()
+	assertWrapperWithoutNavigationKeepsDirectory(t, "fish")
+}
+
+// ---------------------------------------------------------------------------
+// W4 — a failing command keeps its exit code and cleans up
+// ---------------------------------------------------------------------------
+
+// assertWrapperPreservesFailureExitCode uses TWO runs, because no single script
+// can carry both halves: under a caller's `set -e` a wrapper that correctly
+// returns git-flow's nonzero status terminates the script AT the call, so
+// nothing after it runs (verified on bash 3.2.57 and zsh 5.9).
+//
+// Run A, without errexit, carries the observational assertions. Run B, with
+// errexit, asserts the exit code and — the point of the run — that the wrapper
+// still removed its temp file: the `command; status=$?; rm` shape aborts before
+// the rm and leaks one, while the `|| __gf_status=$?` shape does not.
+func assertWrapperPreservesFailureExitCode(t *testing.T, shell string) {
+	t.Helper()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	start := testutil.EvalPath(t, dir)
+
+	runA := testutil.RunShell(t, testutil.ShellRun{
+		Shell: shell,
+		Dir:   dir,
+		Script: installWrapper(shell) +
+			"; git-flow feature checkout nonexistent; " + captureStatus(shell, "rc") +
+			"; echo RC=$rc; pwd -P; exit $rc",
+	})
+
+	if runA.ExitCode != 5 {
+		t.Errorf("Expected the shell to exit 5, got %d\nStderr: %s", runA.ExitCode, runA.Stderr)
+	}
+	if !strings.Contains(runA.Stdout, "RC=5") {
+		t.Errorf("Expected the wrapper to return git-flow's exit code, got %q", runA.Stdout)
+	}
+	if got := lastLine(runA.Stdout); got != start {
+		t.Errorf("Expected the shell to stay in %q, got %q", start, got)
+	}
+	if !strings.Contains(runA.Stderr, "Error:") {
+		t.Errorf("Expected git-flow's error text on stderr, got %q", runA.Stderr)
+	}
+	if strings.Contains(runA.Stdout, "Error:") {
+		t.Errorf("Expected git-flow's error text to stay off stdout, got %q", runA.Stdout)
+	}
+	assertWrapperTempFiles(t, runA, 1)
+
+	if shell == "fish" {
+		// fish has no errexit, so there is no second run to make.
+		return
+	}
+
+	runB := testutil.RunShell(t, testutil.ShellRun{
+		Shell:  shell,
+		Dir:    dir,
+		Script: "set -e; " + installWrapper(shell) + "; git-flow feature checkout nonexistent",
+	})
+
+	if runB.ExitCode != 5 {
+		t.Errorf("Expected the shell to exit 5 under set -e, got %d\nStderr: %s", runB.ExitCode, runB.Stderr)
+	}
+	assertWrapperTempFiles(t, runB, 1)
+}
+
+// TestShellInitBashWrapperPreservesFailureExitCode covers scenario 17 for bash.
+// Steps:
+// 1. Sets up a repository with git-flow initialized
+// 2. Installs the emitted bash wrapper and runs a checkout of a branch that does not exist
+// 3. Verifies the wrapper returns exit code 5, the shell exits 5 and the directory is unchanged
+// 4. Verifies git-flow's error text went to stderr, not stdout
+// 5. Repeats the failing command under 'set -e' and verifies the temp file was still removed
+func TestShellInitBashWrapperPreservesFailureExitCode(t *testing.T) {
+	t.Parallel()
+	assertWrapperPreservesFailureExitCode(t, "bash")
+}
+
+// TestShellInitZshWrapperPreservesFailureExitCode covers scenario 17 for zsh.
+// Steps:
+// 1. Sets up a repository with git-flow initialized
+// 2. Installs the emitted zsh wrapper and runs a checkout of a branch that does not exist
+// 3. Verifies the wrapper returns exit code 5, the shell exits 5 and the directory is unchanged
+// 4. Verifies git-flow's error text went to stderr, not stdout
+// 5. Repeats the failing command under 'set -e' and verifies the temp file was still removed
+func TestShellInitZshWrapperPreservesFailureExitCode(t *testing.T) {
+	t.Parallel()
+	assertWrapperPreservesFailureExitCode(t, "zsh")
+}
+
+// TestShellInitFishWrapperPreservesFailureExitCode covers scenario 17 for fish.
+//
+// The status capture is the statement immediately after the command on purpose:
+// one statement in between would replace git-flow's status with its own, which
+// is the mistake this assertion exists to catch.
+// Steps:
+// 1. Sets up a repository with git-flow initialized
+// 2. Installs the emitted fish wrapper and runs a checkout of a branch that does not exist
+// 3. Verifies the wrapper returns exit code 5, the shell exits 5 and the directory is unchanged
+// 4. Verifies git-flow's error text went to stderr, not stdout, and no temp file was left
+func TestShellInitFishWrapperPreservesFailureExitCode(t *testing.T) {
+	t.Parallel()
+	assertWrapperPreservesFailureExitCode(t, "fish")
+}
+
+// ---------------------------------------------------------------------------
+// W5 — the caller's own channel is not clobbered
+// ---------------------------------------------------------------------------
+
+// assertWrapperDoesNotClobberCallerChannel seeds GIT_FLOW_CD_FILE before the
+// wrapper is installed. Starting from an absent variable would prove too little:
+// a wrapper that overwrote it globally and then unset it would pass while
+// destroying whatever the caller had set.
+//
+// The command it runs must be one that WRITES a destination. With a
+// non-navigating command the sentinel stays empty even for a wrapper that hands
+// the caller's own file straight to the child, and the second assertion would
+// prove nothing.
+func assertWrapperDoesNotClobberCallerChannel(t *testing.T, shell string) {
+	t.Helper()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+
+	sentinel := filepath.Join(t.TempDir(), "caller-channel")
+	if err := os.WriteFile(sentinel, nil, 0644); err != nil {
+		t.Fatalf("Failed to create the sentinel channel file: %v", err)
+	}
+
+	echoLeak := `echo "LEAK=[${GIT_FLOW_CD_FILE-unset}]"`
+	if shell == "fish" {
+		echoLeak = `echo "LEAK=[$GIT_FLOW_CD_FILE]"`
+	}
+	res := testutil.RunShell(t, testutil.ShellRun{
+		Shell:  shell,
+		Dir:    dir,
+		Env:    []string{"GIT_FLOW_CD_FILE=" + sentinel},
+		Script: installWrapper(shell) + "; git-flow worktree add feature/x; " + echoLeak,
+	})
+
+	if res.ExitCode != 0 {
+		t.Fatalf("Expected exit code 0, got %d\nStderr: %s", res.ExitCode, res.Stderr)
+	}
+	if want := "LEAK=[" + sentinel + "]"; !strings.Contains(res.Stdout, want) {
+		t.Errorf("Expected the caller's channel to be restored as %q, got %q", want, res.Stdout)
+	}
+	info, err := os.Stat(sentinel)
+	if err != nil {
+		t.Fatalf("Failed to stat the sentinel channel file: %v", err)
+	}
+	if info.Size() != 0 {
+		t.Errorf("Expected git-flow to write to the wrapper's temp file, not the caller's channel")
+	}
+	assertWrapperTempFiles(t, res, 1)
+}
+
+// TestShellInitBashWrapperDoesNotClobberCallerChannel covers the wrapper contract for bash.
+// Steps:
+// 1. Creates an empty sentinel file and exports GIT_FLOW_CD_FILE at it before the wrapper is installed
+// 2. Installs the emitted bash wrapper and runs 'git-flow worktree add feature/x', a command that writes a destination
+// 3. Verifies the caller's value is restored byte-for-byte after the command
+// 4. Verifies the sentinel file is still zero-length, so git-flow wrote to the wrapper's temp file rather than the caller's
+func TestShellInitBashWrapperDoesNotClobberCallerChannel(t *testing.T) {
+	t.Parallel()
+	assertWrapperDoesNotClobberCallerChannel(t, "bash")
+}
+
+// TestShellInitZshWrapperDoesNotClobberCallerChannel covers the wrapper contract for zsh.
+// Steps:
+// 1. Creates an empty sentinel file and exports GIT_FLOW_CD_FILE at it before the wrapper is installed
+// 2. Installs the emitted zsh wrapper and runs 'git-flow worktree add feature/x', a command that writes a destination
+// 3. Verifies the caller's value is restored byte-for-byte after the command
+// 4. Verifies the sentinel file is still zero-length, so git-flow wrote to the wrapper's temp file rather than the caller's
+func TestShellInitZshWrapperDoesNotClobberCallerChannel(t *testing.T) {
+	t.Parallel()
+	assertWrapperDoesNotClobberCallerChannel(t, "zsh")
+}
+
+// TestShellInitFishWrapperDoesNotClobberCallerChannel covers the wrapper contract for fish.
+// Steps:
+// 1. Creates an empty sentinel file and exports GIT_FLOW_CD_FILE at it before the wrapper is installed
+// 2. Installs the emitted fish wrapper and runs 'git-flow worktree add feature/x', a command that writes a destination
+// 3. Verifies the caller's value is restored byte-for-byte after the command
+// 4. Verifies the sentinel file is still zero-length, so git-flow wrote to the wrapper's temp file rather than the caller's
+func TestShellInitFishWrapperDoesNotClobberCallerChannel(t *testing.T) {
+	t.Parallel()
+	assertWrapperDoesNotClobberCallerChannel(t, "fish")
+}
+
+// ---------------------------------------------------------------------------
+// W6 — a destination containing spaces
+// ---------------------------------------------------------------------------
+
+// assertWrapperHandlesPathWithSpaces navigates to a worktree whose path contains
+// spaces, the classic quoting failure.
+func assertWrapperHandlesPathWithSpaces(t *testing.T, shell string) {
+	t.Helper()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	// This root is NOT worktreeRootFor(dir): the template below computes a
+	// different one, which nothing else would ever remove.
+	spacedRoot := filepath.Join(filepath.Dir(testutil.EvalPath(t, dir)), filepath.Base(dir)+" work trees")
+	defer os.RemoveAll(spacedRoot)
+	if out, err := testutil.RunGit(t, dir, "config", "gitflow.worktreePath", "../{{ repo }} work trees/{{ branch }}"); err != nil {
+		t.Fatalf("Failed to set gitflow.worktreePath: %v\nOutput: %s", err, out)
+	}
+	createFreeBranch(t, dir, "feature/x")
+
+	res := testutil.RunShell(t, testutil.ShellRun{
+		Shell:  shell,
+		Dir:    dir,
+		Script: installWrapper(shell) + "; git-flow feature checkout x --worktree; pwd -P",
+	})
+
+	if res.ExitCode != 0 {
+		t.Fatalf("Expected exit code 0, got %d\nStderr: %s", res.ExitCode, res.Stderr)
+	}
+	want := filepath.Join(spacedRoot, "feature", "x")
+	if got := lastLine(res.Stdout); got != want {
+		t.Errorf("Expected the shell to end up in %q, got %q", want, got)
+	}
+	assertWrapperTempFiles(t, res, 1)
+}
+
+// TestShellInitBashWrapperHandlesPathWithSpaces covers the wrapper contract for bash.
+// Steps:
+// 1. Sets a gitflow.worktreePath template whose directory names contain spaces
+// 2. Installs the emitted bash wrapper and runs 'git-flow feature checkout x --worktree'
+// 3. Verifies the shell's working directory is the spaced path, unsplit
+// 4. Verifies exactly one temporary file was created and none was left behind
+func TestShellInitBashWrapperHandlesPathWithSpaces(t *testing.T) {
+	t.Parallel()
+	assertWrapperHandlesPathWithSpaces(t, "bash")
+}
+
+// TestShellInitZshWrapperHandlesPathWithSpaces covers the wrapper contract for zsh.
+// Steps:
+// 1. Sets a gitflow.worktreePath template whose directory names contain spaces
+// 2. Installs the emitted zsh wrapper and runs 'git-flow feature checkout x --worktree'
+// 3. Verifies the shell's working directory is the spaced path, unsplit
+// 4. Verifies exactly one temporary file was created and none was left behind
+func TestShellInitZshWrapperHandlesPathWithSpaces(t *testing.T) {
+	t.Parallel()
+	assertWrapperHandlesPathWithSpaces(t, "zsh")
+}
+
+// TestShellInitFishWrapperHandlesPathWithSpaces covers the wrapper contract for fish.
+// Steps:
+// 1. Sets a gitflow.worktreePath template whose directory names contain spaces
+// 2. Installs the emitted fish wrapper and runs 'git-flow feature checkout x --worktree'
+// 3. Verifies the shell's working directory is the spaced path, unsplit
+// 4. Verifies exactly one temporary file was created and none was left behind
+func TestShellInitFishWrapperHandlesPathWithSpaces(t *testing.T) {
+	t.Parallel()
+	assertWrapperHandlesPathWithSpaces(t, "fish")
+}
+
+// ---------------------------------------------------------------------------
+// W7 — the git wrapper intercepts 'git flow …'
+// ---------------------------------------------------------------------------
+
+// assertGitWrapperNavigates is the decisive test for SC-1, and the directory
+// assertion is what makes it decisive: 'git flow …' succeeds with NO wrapper
+// installed at all, because git dispatches an unknown subcommand to a git-flow
+// binary on PATH. Only the shell's own working directory can prove the git()
+// function ran — git-flow as a subprocess cannot change it. Do not simplify this
+// to an output check.
+func assertGitWrapperNavigates(t *testing.T, shell string) {
+	t.Helper()
+	dir, wtPath := wrapperRepoWithWorktree(t)
+
+	res := testutil.RunShell(t, testutil.ShellRun{
+		Shell:  shell,
+		Dir:    dir,
+		Script: installWrapper(shell) + "; git flow feature checkout x; pwd -P",
+	})
+
+	if res.ExitCode != 0 {
+		t.Fatalf("Expected exit code 0, got %d\nStderr: %s", res.ExitCode, res.Stderr)
+	}
+	if got := lastLine(res.Stdout); got != wtPath {
+		t.Errorf("Expected 'git flow …' to move the shell to %q, got %q", wtPath, got)
+	}
+	assertWrapperTempFiles(t, res, 1)
+}
+
+// TestShellInitBashWrapperGitFormNavigates covers SC-1 for bash.
+// Steps:
+// 1. Sets up a repository with feature/x and a worktree for it
+// 2. Installs the emitted bash wrapper and runs 'git flow feature checkout x'
+// 3. Verifies the shell's own working directory is now the worktree, which only the git function can achieve
+// 4. Verifies exactly one temporary file was created and none was left behind
+func TestShellInitBashWrapperGitFormNavigates(t *testing.T) {
+	t.Parallel()
+	assertGitWrapperNavigates(t, "bash")
+}
+
+// TestShellInitZshWrapperGitFormNavigates covers SC-1 for zsh.
+// Steps:
+// 1. Sets up a repository with feature/x and a worktree for it
+// 2. Installs the emitted zsh wrapper and runs 'git flow feature checkout x'
+// 3. Verifies the shell's own working directory is now the worktree, which only the git function can achieve
+// 4. Verifies exactly one temporary file was created and none was left behind
+func TestShellInitZshWrapperGitFormNavigates(t *testing.T) {
+	t.Parallel()
+	assertGitWrapperNavigates(t, "zsh")
+}
+
+// TestShellInitFishWrapperGitFormNavigates covers SC-1 for fish.
+// Steps:
+// 1. Sets up a repository with feature/x and a worktree for it
+// 2. Installs the emitted fish wrapper and runs 'git flow feature checkout x'
+// 3. Verifies the shell's own working directory is now the worktree, which only the git function can achieve
+// 4. Verifies exactly one temporary file was created and none was left behind
+func TestShellInitFishWrapperGitFormNavigates(t *testing.T) {
+	t.Parallel()
+	assertGitWrapperNavigates(t, "fish")
+}
+
+// ---------------------------------------------------------------------------
+// W8 — ordinary git is delegated verbatim
+// ---------------------------------------------------------------------------
+
+// assertGitWrapperDelegatesOtherCommands verifies the delegation path: git's own
+// output and exit code, arguments passed verbatim (a pathspec containing a space
+// resolves only if they are), and — provable only through the mktemp shim — no
+// temporary file for a command that never enters the flow path.
+//
+// The verbatim-argument probe is a tracked FILE rather than a branch: git
+// forbids a space in a ref name outright, so a branch named 'feature/with space'
+// cannot be created at all.
+func assertGitWrapperDelegatesOtherCommands(t *testing.T, shell string) {
+	t.Helper()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	spacedFile := "path with space.txt"
+	if err := testutil.WriteFile(t, dir, spacedFile, "tracked\n"); err != nil {
+		t.Fatalf("Failed to create the spaced file: %v", err)
+	}
+	mustRunGit(t, dir, "add", spacedFile)
+	mustRunGit(t, dir, "commit", "-m", "Add a path containing spaces")
+	start := testutil.EvalPath(t, dir)
+
+	res := testutil.RunShell(t, testutil.ShellRun{
+		Shell: shell,
+		Dir:   dir,
+		Script: installWrapper(shell) +
+			"; git --version" +
+			"; git rev-parse --abbrev-ref HEAD" +
+			`; git ls-files --error-unmatch -- "path with space.txt"` +
+			"; git rev-parse --verify no-such-ref-here; echo RC=" + statusRef(shell) +
+			"; pwd -P",
+	})
+
+	if !strings.Contains(res.Stdout, "git version") {
+		t.Errorf("Expected git's own version output, got %q", res.Stdout)
+	}
+	if !strings.Contains(res.Stdout, testutil.GetCurrentBranch(t, dir)) {
+		t.Errorf("Expected git to report the current branch, got %q", res.Stdout)
+	}
+	if !strings.Contains(res.Stdout, spacedFile) {
+		t.Errorf("Expected the space-containing pathspec to resolve, got %q\nStderr: %s", res.Stdout, res.Stderr)
+	}
+	if !strings.Contains(res.Stdout, "RC=128") {
+		t.Errorf("Expected git's own exit code for a bad ref, got %q", res.Stdout)
+	}
+	if got := lastLine(res.Stdout); got != start {
+		t.Errorf("Expected the shell to stay in %q, got %q", start, got)
+	}
+	assertWrapperTempFiles(t, res, 0)
+}
+
+// statusRef returns the shell's expression for the previous command's exit code.
+func statusRef(shell string) string {
+	if shell == "fish" {
+		return "$status"
+	}
+	return "$?"
+}
+
+// mustRunGit runs a git command and fails the test when it does.
+func mustRunGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	out, err := testutil.RunGit(t, dir, args...)
+	if err != nil {
+		t.Fatalf("git %s failed: %v\nOutput: %s", strings.Join(args, " "), err, out)
+	}
+	return out
+}
+
+// TestShellInitBashWrapperDelegatesOtherGitCommands covers SC-1's delegation for bash.
+// Steps:
+// 1. Sets up a repository with a tracked file literally named 'path with space.txt'
+// 2. Installs the emittedbash wrapper and runs four ordinary git commands through it
+// 3. Verifies git's version, the current branch and the spaced pathspec all reach the terminal
+// 4. Verifies git's own exit code for a bad ref survives the wrapper and the directory is unchanged
+// 5. Verifies zero temporary files were created, since the delegation path must not pay for one
+func TestShellInitBashWrapperDelegatesOtherGitCommands(t *testing.T) {
+	t.Parallel()
+	assertGitWrapperDelegatesOtherCommands(t, "bash")
+}
+
+// TestShellInitZshWrapperDelegatesOtherGitCommands covers SC-1's delegation for zsh.
+// Steps:
+// 1. Sets up a repository with a tracked file literally named 'path with space.txt'
+// 2. Installs the emittedzsh wrapper and runs four ordinary git commands through it
+// 3. Verifies git's version, the current branch and the spaced pathspec all reach the terminal
+// 4. Verifies git's own exit code for a bad ref survives the wrapper and the directory is unchanged
+// 5. Verifies zero temporary files were created, since the delegation path must not pay for one
+func TestShellInitZshWrapperDelegatesOtherGitCommands(t *testing.T) {
+	t.Parallel()
+	assertGitWrapperDelegatesOtherCommands(t, "zsh")
+}
+
+// TestShellInitFishWrapperDelegatesOtherGitCommands covers SC-1's delegation for fish.
+// Steps:
+// 1. Sets up a repository with a tracked file literally named 'path with space.txt'
+// 2. Installs the emittedfish wrapper and runs four ordinary git commands through it
+// 3. Verifies git's version, the current branch and the spaced pathspec all reach the terminal
+// 4. Verifies git's own exit code for a bad ref survives the wrapper and the directory is unchanged
+// 5. Verifies zero temporary files were created, since the delegation path must not pay for one
+func TestShellInitFishWrapperDelegatesOtherGitCommands(t *testing.T) {
+	t.Parallel()
+	assertGitWrapperDelegatesOtherCommands(t, "fish")
+}
+
+// ---------------------------------------------------------------------------
+// W9 — 'git flow …' preserves a failure exit code
+// ---------------------------------------------------------------------------
+
+// assertGitWrapperPreservesFlowFailureExitCode covers the git() route, which
+// reaches the shared navigation function differently and returns through its own
+// status expression — in fish a second, independent place a delayed capture
+// turns 5 into 0.
+func assertGitWrapperPreservesFlowFailureExitCode(t *testing.T, shell string) {
+	t.Helper()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	res := testutil.RunShell(t, testutil.ShellRun{
+		Shell: shell,
+		Dir:   dir,
+		Script: installWrapper(shell) +
+			"; git flow feature checkout nonexistent; " + captureStatus(shell, "rc") +
+			"; echo RC=$rc; exit $rc",
+	})
+
+	if res.ExitCode != 5 {
+		t.Errorf("Expected the shell to exit 5, got %d\nStderr: %s", res.ExitCode, res.Stderr)
+	}
+	if !strings.Contains(res.Stdout, "RC=5") {
+		t.Errorf("Expected 'git flow …' to return git-flow's exit code, got %q", res.Stdout)
+	}
+	assertWrapperTempFiles(t, res, 1)
+}
+
+// TestShellInitBashWrapperGitFormPreservesFailureExitCode covers SC-1 and scenario 17 for bash.
+// Steps:
+// 1. Sets up a repository with git-flow initialized
+// 2. Installs the emitted bash wrapper and runs 'git flow feature checkout nonexistent'
+// 3. Verifies the recorded status is 5 and the shell exits 5
+// 4. Verifies exactly one temporary file was created and none was left behind
+func TestShellInitBashWrapperGitFormPreservesFailureExitCode(t *testing.T) {
+	t.Parallel()
+	assertGitWrapperPreservesFlowFailureExitCode(t, "bash")
+}
+
+// TestShellInitZshWrapperGitFormPreservesFailureExitCode covers SC-1 and scenario 17 for zsh.
+// Steps:
+// 1. Sets up a repository with git-flow initialized
+// 2. Installs the emitted zsh wrapper and runs 'git flow feature checkout nonexistent'
+// 3. Verifies the recorded status is 5 and the shell exits 5
+// 4. Verifies exactly one temporary file was created and none was left behind
+func TestShellInitZshWrapperGitFormPreservesFailureExitCode(t *testing.T) {
+	t.Parallel()
+	assertGitWrapperPreservesFlowFailureExitCode(t, "zsh")
+}
+
+// TestShellInitFishWrapperGitFormPreservesFailureExitCode covers SC-1 and scenario 17 for fish.
+// Steps:
+// 1. Sets up a repository with git-flow initialized
+// 2. Installs the emitted fish wrapper and runs 'git flow feature checkout nonexistent'
+// 3. Verifies the recorded status is 5 and the shell exits 5, proving the git function's own return preserved it
+// 4. Verifies exactly one temporary file was created and none was left behind
+func TestShellInitFishWrapperGitFormPreservesFailureExitCode(t *testing.T) {
+	t.Parallel()
+	assertGitWrapperPreservesFlowFailureExitCode(t, "fish")
+}
+
+// ---------------------------------------------------------------------------
+// W10 — a destination that cannot be entered is reported, not masked
+// ---------------------------------------------------------------------------
+
+// failedCDStub is a git-flow stand-in that writes a destination which does not
+// exist and exits 0. The wrapper is the unit under test here, and a real
+// destination that vanishes between the write and the cd cannot be produced
+// deterministically. shell-init is delegated to the real binary so the wrapper
+// under test is still the emitted one.
+func failedCDStub(t *testing.T) string {
+	t.Helper()
+	return fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "shell-init" ]; then
+    exec %q "$@"
+fi
+printf '%%s\n' "/no/such/git-flow/destination" > "$GIT_FLOW_CD_FILE"
+exit 0
+`, testutil.GitFlowPath())
+}
+
+// assertWrapperReportsFailedCDAndKeepsStatus covers SC-13: a failed cd is
+// reported on stderr while git-flow's own exit code survives.
+func assertWrapperReportsFailedCDAndKeepsStatus(t *testing.T, shell string) {
+	t.Helper()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	start := testutil.EvalPath(t, dir)
+
+	res := testutil.RunShell(t, testutil.ShellRun{
+		Shell:       shell,
+		Dir:         dir,
+		StubGitFlow: failedCDStub(t),
+		Script: installWrapper(shell) +
+			"; git-flow anything; " + captureStatus(shell, "rc") +
+			"; echo RC=$rc; pwd -P; exit $rc",
+	})
+
+	if res.ExitCode != 0 {
+		t.Errorf("Expected git-flow's own exit code 0 to survive a failed cd, got %d\nStderr: %s", res.ExitCode, res.Stderr)
+	}
+	if !strings.Contains(res.Stdout, "RC=0") {
+		t.Errorf("Expected the wrapper not to mask git-flow's status with cd's, got %q", res.Stdout)
+	}
+	if got := lastLine(res.Stdout); got != start {
+		t.Errorf("Expected the shell to stay in %q, got %q", start, got)
+	}
+	if !strings.Contains(res.Stderr, "/no/such/git-flow/destination") {
+		t.Errorf("Expected stderr to name the destination it could not enter, got %q", res.Stderr)
+	}
+	assertWrapperTempFiles(t, res, 1)
+}
+
+// TestShellInitBashWrapperReportsFailedCD covers SC-13 for bash.
+// Steps:
+// 1. Sets up a repository and a git-flow stub that writes a destination which does not exist
+// 2. Installs the emitted bash wrapper and runs a command through it
+// 3. Verifies the recorded status and the shell's exit code are both 0, git-flow's own
+// 4. Verifies the working directory is unchanged and stderr names the destination
+// 5. Verifies no temporary file was left behind
+func TestShellInitBashWrapperReportsFailedCD(t *testing.T) {
+	t.Parallel()
+	assertWrapperReportsFailedCDAndKeepsStatus(t, "bash")
+}
+
+// TestShellInitZshWrapperReportsFailedCD covers SC-13 for zsh.
+// Steps:
+// 1. Sets up a repository and a git-flow stub that writes a destination which does not exist
+// 2. Installs the emitted zsh wrapper and runs a command through it
+// 3. Verifies the recorded status and the shell's exit code are both 0, git-flow's own
+// 4. Verifies the working directory is unchanged and stderr names the destination
+// 5. Verifies no temporary file was left behind
+func TestShellInitZshWrapperReportsFailedCD(t *testing.T) {
+	t.Parallel()
+	assertWrapperReportsFailedCDAndKeepsStatus(t, "zsh")
+}
+
+// TestShellInitFishWrapperReportsFailedCD covers SC-13 for fish.
+// Steps:
+// 1. Sets up a repository and a git-flow stub that writes a destination which does not exist
+// 2. Installs the emitted fish wrapper and runs a command through it
+// 3. Verifies the recorded status and the shell's exit code are both 0, git-flow's own
+// 4. Verifies the working directory is unchanged and stderr names the destination
+// 5. Verifies no temporary file was left behind
+func TestShellInitFishWrapperReportsFailedCD(t *testing.T) {
+	t.Parallel()
+	assertWrapperReportsFailedCDAndKeepsStatus(t, "fish")
+}
+
+// ---------------------------------------------------------------------------
+// Helper self-check
+// ---------------------------------------------------------------------------
+
+// TestShellRunLeakDetectionCatchesLeftovers proves the leftover check can fail.
+//
+// A leak assertion that has never been seen to fail is not evidence of anything:
+// if RunShell and the check looked at different directories, every wrapper test
+// would pass no matter how badly the wrapper leaked.
+// Steps:
+// 1. Runs a throwaway bash script that deliberately creates a git-flow-cd.XXXX file in its TMPDIR
+// 2. Reads the leftovers of that same run
+// 3. Verifies exactly the deliberately leaked file is reported
+func TestShellRunLeakDetectionCatchesLeftovers(t *testing.T) {
+	t.Parallel()
+	res := testutil.RunShell(t, testutil.ShellRun{
+		Shell:  "bash",
+		Dir:    t.TempDir(),
+		Script: `: > "$TMPDIR/git-flow-cd.LEAKED"`,
+	})
+	if res.ExitCode != 0 {
+		t.Fatalf("Expected the throwaway script to succeed, got %d\nStderr: %s", res.ExitCode, res.Stderr)
+	}
+
+	leftovers := testutil.ShellTempFileLeftovers(t, res.TempDir)
+	if len(leftovers) != 1 || filepath.Base(leftovers[0]) != "git-flow-cd.LEAKED" {
+		t.Errorf("Expected the deliberate leak to be detected, got %v", leftovers)
+	}
+}

--- a/test/cmd/shellinit_wrapper_test.go
+++ b/test/cmd/shellinit_wrapper_test.go
@@ -843,6 +843,86 @@ func TestShellInitFishWrapperReportsFailedCD(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// W11 — a set-but-empty TMPDIR still navigates
+// ---------------------------------------------------------------------------
+
+// assertWrapperNavigatesWithEmptyTMPDIR verifies the /tmp fallback fires for a
+// TMPDIR that is set to the empty string, not only for one that is unset.
+//
+// This is a cross-shell parity test. bash and zsh get it from "${TMPDIR:-/tmp}";
+// fish had "set -q TMPDIR", which is TRUE for a set-but-empty variable, so it
+// took the branch and ran mktemp against "/git-flow-cd.XXXXXX". That fails, the
+// wrapper takes its no-temp-file path, and navigation is silently LOST while the
+// command itself still runs and still returns the right exit code — a failure no
+// exit-code or output assertion elsewhere would catch.
+//
+// assertWrapperTempFiles is deliberately not used: the fallback puts the temp
+// file in the real /tmp, which the run's own TMPDIR-scoped leftover check cannot
+// see and which parallel tests make unsafe to glob. The mktemp count is still
+// meaningful, and it is what proves the wrapper reached its normal path at all.
+func assertWrapperNavigatesWithEmptyTMPDIR(t *testing.T, shell string) {
+	t.Helper()
+	dir, wtPath := wrapperRepoWithWorktree(t)
+
+	res := testutil.RunShell(t, testutil.ShellRun{
+		Shell:  shell,
+		Dir:    dir,
+		Env:    []string{"TMPDIR="},
+		Script: installWrapper(shell) + "; git-flow feature checkout x; pwd -P",
+	})
+
+	if res.ExitCode != 0 {
+		t.Fatalf("Expected exit code 0, got %d\nStderr: %s", res.ExitCode, res.Stderr)
+	}
+	if got := lastLine(res.Stdout); got != wtPath {
+		t.Errorf("Expected an empty TMPDIR to fall back to /tmp and still navigate to %q, got %q", wtPath, got)
+	}
+	if strings.Contains(res.Stderr, "mkstemp") || strings.Contains(res.Stderr, "mktemp") {
+		t.Errorf("Expected no raw mktemp diagnostic on stderr, got %q", res.Stderr)
+	}
+	if res.MktempCalls != 1 {
+		t.Errorf("Expected 1 mktemp call, got %d", res.MktempCalls)
+	}
+}
+
+// TestShellInitBashWrapperNavigatesWithEmptyTMPDIR confirms bash already handles
+// a set-but-empty TMPDIR, the behaviour fish is held to.
+// Steps:
+// 1. Sets up a repository with feature/x and a worktree for it
+// 2. Installs the emitted bash wrapper with TMPDIR set to the empty string
+// 3. Runs 'git-flow feature checkout x' and verifies the shell reached the worktree
+// 4. Verifies stderr carries no mktemp diagnostic and exactly one temp file was requested
+func TestShellInitBashWrapperNavigatesWithEmptyTMPDIR(t *testing.T) {
+	t.Parallel()
+	assertWrapperNavigatesWithEmptyTMPDIR(t, "bash")
+}
+
+// TestShellInitZshWrapperNavigatesWithEmptyTMPDIR confirms zsh already handles a
+// set-but-empty TMPDIR, the behaviour fish is held to.
+// Steps:
+// 1. Sets up a repository with feature/x and a worktree for it
+// 2. Installs the emitted zsh wrapper with TMPDIR set to the empty string
+// 3. Runs 'git-flow feature checkout x' and verifies the shell reached the worktree
+// 4. Verifies stderr carries no mktemp diagnostic and exactly one temp file was requested
+func TestShellInitZshWrapperNavigatesWithEmptyTMPDIR(t *testing.T) {
+	t.Parallel()
+	assertWrapperNavigatesWithEmptyTMPDIR(t, "zsh")
+}
+
+// TestShellInitFishWrapperNavigatesWithEmptyTMPDIR is the regression test for
+// fish's 'set -q TMPDIR', which was true for a set-but-empty variable and lost
+// navigation.
+// Steps:
+// 1. Sets up a repository with feature/x and a worktree for it
+// 2. Installs the emitted fish wrapper with TMPDIR set to the empty string
+// 3. Runs 'git-flow feature checkout x' and verifies the shell reached the worktree
+// 4. Verifies stderr carries no mktemp diagnostic and exactly one temp file was requested
+func TestShellInitFishWrapperNavigatesWithEmptyTMPDIR(t *testing.T) {
+	t.Parallel()
+	assertWrapperNavigatesWithEmptyTMPDIR(t, "fish")
+}
+
+// ---------------------------------------------------------------------------
 // Helper self-check
 // ---------------------------------------------------------------------------
 

--- a/test/cmd/shellinit_wrapper_test.go
+++ b/test/cmd/shellinit_wrapper_test.go
@@ -230,7 +230,7 @@ func assertWrapperWithoutNavigationKeepsDirectory(t *testing.T, shell string) {
 	if got := lastLine(res.Stdout); got != start {
 		t.Errorf("Expected the shell to stay in %q, got %q", start, got)
 	}
-	if !strings.Contains(res.Stdout, "version") {
+	if !strings.Contains(res.Stdout, "git-flow-next") {
 		t.Errorf("Expected the version output to reach the terminal, got %q", res.Stdout)
 	}
 	assertWrapperTempFiles(t, res, 2)

--- a/test/cmd/worktree_test.go
+++ b/test/cmd/worktree_test.go
@@ -1422,10 +1422,13 @@ func TestWorktreeAddWritesCDFile(t *testing.T) {
 }
 
 // TestWorktreeAddWithoutCDFileEnv covers scenario 24: with the variable unset the
-// command prints exactly its confirmation and cd hint, and nothing else.
+// command prints exactly its confirmation, cd hint and the shell-init tip.
+//
+// The tip is the third line as of #174 (SC-2): shell-init now exists, so both
+// commands that navigate point at it in the one state where it helps.
 // Steps:
 // 1. Runs 'git flow worktree add feature/x' with GIT_FLOW_CD_FILE explicitly empty
-// 2. Verifies stdout equals exactly the confirmation and cd hint lines, proving no machine-readable protocol line rides along
+// 2. Verifies stdout equals exactly the confirmation, cd hint and tip lines, proving no machine-readable protocol line rides along
 // 3. Verifies stderr is empty, so nothing was diverted there either
 func TestWorktreeAddWithoutCDFileEnv(t *testing.T) {
 	t.Parallel()
@@ -1441,12 +1444,75 @@ func TestWorktreeAddWithoutCDFileEnv(t *testing.T) {
 
 	wtPath := computedWorktreePath(t, dir, "feature/x")
 	want := "Created worktree for branch 'feature/x' at " + wtPath + "\n" +
-		"To switch to it: cd " + wtPath + "\n"
+		"To switch to it: cd " + wtPath + "\n" +
+		"Tip: run 'git flow shell-init <shell>' for automatic directory switching\n"
 	if stdout != want {
 		t.Errorf("Expected stdout %q, got %q", want, stdout)
 	}
 	if stderr != "" {
 		t.Errorf("Expected no output on stderr, got %q", stderr)
+	}
+}
+
+// TestWorktreeAddQuietSuppressesShellInitTip covers SC-2: --quiet drops the tip
+// and nothing else.
+// Steps:
+// 1. Creates a free feature/x branch
+// 2. Runs 'git flow worktree add feature/x --quiet' with GIT_FLOW_CD_FILE unset, the only state where the tip would print
+// 3. Verifies exit code 0 and that stdout equals exactly the confirmation and cd hint lines
+// 4. Verifies the worktree was created and stderr is empty
+func TestWorktreeAddQuietSuppressesShellInitTip(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+
+	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, nil, "worktree", "add", "feature/x", "--quiet")
+	if err != nil {
+		t.Fatalf("worktree add --quiet failed: %v\nStderr: %s", err, stderr)
+	}
+
+	wtPath := computedWorktreePath(t, dir, "feature/x")
+	want := "Created worktree for branch 'feature/x' at " + wtPath + "\n" +
+		"To switch to it: cd " + wtPath + "\n"
+	if stdout != want {
+		t.Errorf("Expected stdout %q, got %q", want, stdout)
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Errorf("Expected the worktree to be created: %v", err)
+	}
+	if stderr != "" {
+		t.Errorf("Expected no output on stderr, got %q", stderr)
+	}
+}
+
+// TestWorktreeAddSuppressesTipWhenCDFileSet covers SC-2: with the channel in use
+// the wrapper is plainly installed already, so the tip is pointless.
+// Steps:
+// 1. Creates an empty GIT_FLOW_CD_FILE and a free feature/x branch
+// 2. Runs 'git flow worktree add feature/x' with the variable set
+// 3. Verifies exit code 0 and that stdout carries no Tip line
+// 4. Verifies the CD file holds the new worktree path
+func TestWorktreeAddSuppressesTipWhenCDFileSet(t *testing.T) {
+	t.Parallel()
+	dir := initWorktreeRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+	defer os.RemoveAll(worktreeRootFor(dir))
+	createFreeBranch(t, dir, "feature/x")
+	cdFile := cdFilePath(t)
+
+	stdout, stderr, err := testutil.RunGitFlowStreamsWithEnv(t, dir, cdEnv(cdFile), "worktree", "add", "feature/x")
+	if err != nil {
+		t.Fatalf("worktree add failed: %v\nStderr: %s", err, stderr)
+	}
+
+	if strings.Contains(stdout, "Tip:") {
+		t.Errorf("Expected no shell-init tip while the channel is in use, got %q", stdout)
+	}
+	want := computedWorktreePath(t, dir, "feature/x")
+	if got := readCDFile(t, cdFile); got != want {
+		t.Errorf("Expected CD file to hold %q, got %q", want, got)
 	}
 }
 

--- a/test/testutil/shell.go
+++ b/test/testutil/shell.go
@@ -236,7 +236,7 @@ func WriteExecutable(t *testing.T, path string, content string) {
 // a pipe into source for fish.
 func ShellInstallLine(shell string) string {
 	if shell == "fish" {
-		return "git-flow shell-init fish | source"
+		return "git flow shell-init fish | source"
 	}
-	return fmt.Sprintf("eval \"$(git-flow shell-init %s)\"", shell)
+	return fmt.Sprintf("eval \"$(git flow shell-init %s)\"", shell)
 }

--- a/test/testutil/shell.go
+++ b/test/testutil/shell.go
@@ -1,0 +1,242 @@
+package testutil
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// ShellRun describes one execution of an emitted shell-init script.
+type ShellRun struct {
+	// Shell is bash, zsh or fish.
+	Shell string
+	// Dir is the working directory the shell starts in. It is set as cmd.Dir;
+	// tests never call os.Chdir.
+	Dir string
+	// Env holds extra KEY=VALUE pairs layered onto the from-scratch environment.
+	Env []string
+	// Script is the shell source executed with the shell's -c option.
+	Script string
+	// ShellArgs holds extra options passed to the shell BEFORE -c, for a test
+	// that has to run the shell in a different mode (--posix, say).
+	ShellArgs []string
+	// StubGitFlow, when non-empty, is written into the PATH-prefix bin/ as an
+	// executable git-flow INSTEAD of the symlink to the real binary. It drives
+	// wrapper paths that a real git-flow cannot produce deterministically, such
+	// as a destination that no longer exists.
+	StubGitFlow string
+}
+
+// ShellResult carries everything a wrapper assertion needs, including the
+// directories the run actually used — so no assertion can accidentally inspect a
+// directory the shell never saw.
+//
+// TempDir is returned rather than fetched separately on purpose: t.TempDir()
+// allocates a NEW directory on every call within the same test, so a
+// free-standing helper would hand back a directory the shell never wrote to and
+// every leftover assertion would pass unconditionally.
+type ShellResult struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+	// TempDir is the TMPDIR this run's shell was given.
+	TempDir string
+	// MktempCalls counts the lines the mktemp shim logged during this run.
+	MktempCalls int
+}
+
+// mktempShim logs one line per invocation and then execs the real mktemp, so a
+// test can prove how many temporary files a wrapper asked for — including the
+// zero a delegated `git status` must ask for. The shim removes its own directory
+// from PATH before the exec so it never recurses into itself.
+const mktempShim = `#!/bin/sh
+printf 'mktemp\n' >> "$GIT_FLOW_TEST_MKTEMP_LOG"
+PATH="$GIT_FLOW_TEST_REAL_PATH"
+export PATH
+exec mktemp "$@"
+`
+
+// RequireShell fails the test when the shell is not installed. It deliberately
+// does NOT skip: a skip would leave the suite green while two of the three
+// emitted scripts were never executed, which is the failure mode this whole
+// group of tests exists to prevent.
+func RequireShell(t *testing.T, shell string) {
+	t.Helper()
+	if _, err := exec.LookPath(shell); err != nil {
+		t.Fatalf("Shell %q is required by the shell-init wrapper tests but is not installed.\n"+
+			"Install it and re-run: macOS 'brew install %s', Debian/Ubuntu 'sudo apt-get install -y %s'.",
+			shell, shell, shell)
+	}
+}
+
+// RunShell executes run against the real interpreter and returns its result.
+//
+// The shell is started non-interactively and without user rc files, in a
+// from-scratch environment: only PATH, HOME, TMPDIR and the handful of variables
+// below are set, so nothing from the developer's shell or git configuration can
+// change the outcome. GIT_FLOW_CD_FILE is deliberately absent unless the caller
+// supplies it.
+func RunShell(t *testing.T, run ShellRun) ShellResult {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("The emitted shell-init scripts target POSIX shells and fish")
+	}
+	RequireShell(t, run.Shell)
+
+	tempDir := t.TempDir()
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("Failed to create shell PATH directory: %v", err)
+	}
+
+	// Both `git-flow …` and the wrapper's `command git-flow` have to resolve to
+	// the binary under test; the real git is found further down the inherited
+	// PATH.
+	gitFlow := filepath.Join(binDir, "git-flow")
+	if run.StubGitFlow != "" {
+		if err := os.WriteFile(gitFlow, []byte(run.StubGitFlow), 0755); err != nil {
+			t.Fatalf("Failed to write the git-flow stub: %v", err)
+		}
+	} else if err := os.Symlink(GitFlowPath(), gitFlow); err != nil {
+		t.Fatalf("Failed to link the git-flow binary into the shell PATH: %v", err)
+	}
+
+	mktempLog := filepath.Join(tempDir, "mktemp.log")
+	realPath := os.Getenv("PATH")
+	if err := os.WriteFile(filepath.Join(binDir, "mktemp"), []byte(mktempShim), 0755); err != nil {
+		t.Fatalf("Failed to write the mktemp shim: %v", err)
+	}
+
+	var args []string
+	switch run.Shell {
+	case "bash":
+		args = []string{"--norc", "--noprofile"}
+	case "zsh":
+		args = []string{"-f"}
+	case "fish":
+		args = []string{"--no-config"}
+	default:
+		t.Fatalf("Unsupported shell %q", run.Shell)
+	}
+	args = append(args, run.ShellArgs...)
+	args = append(args, "-c", run.Script)
+
+	cmd := exec.Command(run.Shell, args...)
+	cmd.Dir = run.Dir
+	cmd.Env = append([]string{
+		"PATH=" + binDir + string(os.PathListSeparator) + realPath,
+		"HOME=" + t.TempDir(),
+		"TMPDIR=" + tempDir,
+		"GIT_FLOW_TEST_MKTEMP_LOG=" + mktempLog,
+		"GIT_FLOW_TEST_REAL_PATH=" + realPath,
+		"GIT_EDITOR=:",
+		"LANG=C",
+	}, run.Env...)
+
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	exitCode := 0
+	if err := cmd.Run(); err != nil {
+		exitErr, ok := err.(*exec.ExitError)
+		if !ok {
+			t.Fatalf("Failed to run %s: %v\nStderr: %s", run.Shell, err, stderr.String())
+		}
+		exitCode = exitErr.ExitCode()
+	}
+
+	return ShellResult{
+		Stdout:      stdout.String(),
+		Stderr:      stderr.String(),
+		ExitCode:    exitCode,
+		TempDir:     tempDir,
+		MktempCalls: countLines(t, mktempLog),
+	}
+}
+
+// countLines returns the number of non-empty lines in path, treating a missing
+// file as zero lines: the shim never runs when the wrapper never calls mktemp,
+// which is itself an assertion some tests make.
+func countLines(t *testing.T, path string) int {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0
+		}
+		t.Fatalf("Failed to read the mktemp log %s: %v", path, err)
+	}
+	count := 0
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) != "" {
+			count++
+		}
+	}
+	return count
+}
+
+// ShellTempFileLeftovers returns the navigation temp files the wrapper left
+// behind in the TMPDIR of a finished run. The wrapper must remove its file on
+// every path, so a non-empty result is always a defect.
+//
+// It is a plain function rather than an assertion so a test can prove the check
+// itself works by pointing it at a directory that deliberately leaks.
+func ShellTempFileLeftovers(t *testing.T, tempDir string) []string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(tempDir, "git-flow-cd.*"))
+	if err != nil {
+		t.Fatalf("Failed to glob %s for temp files: %v", tempDir, err)
+	}
+	return matches
+}
+
+// CheckShellSyntax parses script with the shell's parse-only mode and returns
+// what the shell wrote to stderr plus whether it accepted the script. It catches
+// what content assertions cannot: a syntax error in an emitted script.
+func CheckShellSyntax(t *testing.T, shell string, script string) (string, bool) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("The emitted shell-init scripts target POSIX shells and fish")
+	}
+	RequireShell(t, shell)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shell-init-script")
+	if err := os.WriteFile(path, []byte(script), 0644); err != nil {
+		t.Fatalf("Failed to write the emitted script: %v", err)
+	}
+
+	flag := "-n"
+	if shell == "fish" {
+		flag = "--no-execute"
+	}
+	cmd := exec.Command(shell, flag, path)
+	cmd.Dir = dir
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return stderr.String(), err == nil
+}
+
+// WriteExecutable writes an executable script, for tests that need a stub on
+// PATH of their own.
+func WriteExecutable(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0755); err != nil {
+		t.Fatalf("Failed to write executable %s: %v", path, err)
+	}
+}
+
+// ShellInstallLine returns the line that installs the emitted wrapper in shell,
+// as documented for users: an eval of the command substitution for bash and zsh,
+// a pipe into source for fish.
+func ShellInstallLine(shell string) string {
+	if shell == "fish" {
+		return "git-flow shell-init fish | source"
+	}
+	return fmt.Sprintf("eval \"$(git-flow shell-init %s)\"", shell)
+}


### PR DESCRIPTION
Makes `checkout` navigate to a branch's worktree instead of failing to switch to it, and adds `git flow shell-init` so that navigation becomes a real `cd` in the calling shell.

When the resolved branch has a worktree, `checkout` now prints that worktree's path and offers it to the caller through `GIT_FLOW_CD_FILE` rather than switching the current worktree's branch; `--worktree` creates a missing worktree first and records git-flow as its creator, `--force` clears a plain directory out of the way, `--no-cd` suppresses only the channel write, and `--quiet` drops the shell-init tip. The new `shell-init {bash|zsh|fish}` command prints a wrapper that supplies a fresh temp file per invocation, points `GIT_FLOW_CD_FILE` at it for that single command, changes directory when the command came back with a destination, removes the file on every path, and preserves git-flow's exit code. `worktree add` gains the same tip and its own `--quiet`. Changes touch `cmd/checkout.go`, the new `cmd/shellinit.go`, `cmd/worktree.go` (where worktree creation is extracted into a helper both commands share), `cmd/topicbranch.go` and `internal/errors`, with new manpages `docs/git-flow-shell-init.1.md`, an expanded `docs/git-flow-checkout.1.md`, and 70 new tests that execute the emitted scripts against real bash, zsh and fish.

Resolves #174
Relates #171

### Remarks

- The wrapper intercepts **both** `git flow ...` and `git-flow ...`. A function named `git-flow` alone can never intercept the `git flow ...` form that every doc and every epic example teaches: git execs the `git-flow` binary as a subprocess of its own, so a `cd` performed there dies with that subprocess. That is why a `git()` function is emitted as well, delegating every non-flow invocation through `command git` with git's own exit code intact.
- Navigation happens **only when the destination differs from the current worktree**, compared with symlinks resolved on both sides. Checking out the branch you are already on, or any branch in a repository with no worktrees at all, produces exactly today's `Switched to branch ...` output and writes nothing to the channel. Behaviour for users who do not use worktrees is unchanged.
- The flag that clears an obstructing directory ships as **`--force`**, not the `--clobber` the spec names. `--force` is already this project's word for overriding a safety refusal (`git flow worktree remove --force`), so `--clobber` was the odd one out. Spec #174 has deliberately been left as written, so the divergence is intentional rather than an oversight. It is declared without a `-f` shorthand on purpose: `-f` on `delete` and `finish` means *branch*-force, and reusing it here would mislead.
- `--force` refuses far more than it removes: a file, a registered worktree of this repository (pointing the user at `git flow worktree remove`, which has the dirty check), and any directory containing a `.git` entry in either its file or its directory form. Only a plain, unregistered directory is removed, and the removal announces itself. `--force` without `--worktree` is a silent no-op.
- Checkout keeps using `git checkout` rather than `git switch`. The spec's prose says "classic `git switch`", but `git switch` requires Git 2.23 and would raise the floor above the 2.17 documented in #172.
- CI now installs zsh and fish so all three emitted scripts actually execute against their real interpreters. There is deliberately no `LookPath` skip: a missing shell is a hard test failure with an actionable message, because a skip would leave the suite green while two of the three scripts had never been run once. `TESTING_GUIDELINES.md` records the requirement.
- The `docs/git-flow-checkout.1.md` EXIT STATUS correction fixes a **pre-existing defect** and is not something this PR introduced. That block documented 1/2/3/4, none of which matched the command's actual behaviour; the real codes are 1/2/3/5/6, verified line by line against `internal/errors/errors.go`.
- Spec scenario 9 ships as a labelled forward guard, not as live coverage. Its config key `gitflow.branch.<type>.worktree` does not exist until #173, so the test asserts only that `checkout` never creates a worktree without an explicit `--worktree`, and its doc comment says so in as many words.
- Known limitation: Ctrl-C during a wrapped invocation can leak one empty temp file. No `trap` prevents it reliably, and `mktemp` remains the right call versus a predictable `$$`-based name. The manpage states it, along with the other ratified caveats: `git -C <dir> flow ...` does not navigate, the `git()` function shadows a user's own `git` alias (so source the output last), and `bash --posix` gets `git()` but no `git-flow()` function.
- Two defects found in review are fixed here. The stale-worktree guard originally only checked that the recorded path existed, so a path replaced by a plain directory or a regular file was still handed to the shell as a destination — navigating the shell somewhere that is not the worktree, or failing to enter it, while git-flow exited 0. And the fish script tested `set -q TMPDIR`, which is true for a variable that is set but empty; navigation was then silently lost with a raw `mktemp` error on stderr, where bash and zsh fell back cleanly.
- Nothing from the rest of the epic is implemented: no `start --worktree` or per-type worktree default (#173), no cleanup navigation on `finish`/`delete` (#175), no `list` integration (#176), no hooks or hook env scrubbing (#177), and no PowerShell or `cmd` wrapper. The epic was reordered so that shell-init lands before #173, which inherits the tip string and the shared creation helper.

**Review focus:**
- `cmd/shellinit.go` — the shared POSIX navigation core and the quoted `eval` that defines `git-flow()`; a bare `git-flow()` is a parse error under `bash --posix` that would otherwise kill the whole `eval "$(...)"` and take `git()` down with it
- `cmd/checkout.go` — the destination-differs comparison, and the stale-worktree guard that now requires a `.git` entry at the recorded path
- `cmd/worktree.go` — `removeObstruction`'s refusal order, and `createWorktreeAt` as the helper `checkout` and #173 both call
- `test/testutil/shell.go` — the shell runner's per-run `TMPDIR` and temp-file leak detection, which has its own self-test proving the assertion can fail