### PR TITLE
fix(finish): End on the integration branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The EXIT STATUS section of the `git flow <type> checkout` manpage documented codes 1/2/3/4 that the command has never returned; it now documents the actual 1/2/3/5/6
 - `finish` collected the auto-update child base branches in Go's randomized map order, so with more than one auto-update child the order they were updated in, the order they were reported in, and the order recorded in merge state (the resume order after a conflict) all varied between identical runs; children are now processed in sorted order, matching `integrate`
+- `finish` left you on the parent branch, so a `release` or `hotfix` finish ended on `main` instead of on `develop` as git-flow-avh does — even under `--keep`, where nothing is deleted and the checkout served no purpose. It now ends on the integration branch: the last auto-update child of the parent, or the parent itself when it has none. The branch is derived from the configured topology rather than a hardcoded name, so it works for custom branch names too, and finish reports the branch it leaves you on
 - Worktree path comparison ignores case on Windows, where two spellings of one location differing only in case were treated as different paths. The refusal to remove or detach the main worktree, the refusal to delete a registered worktree, and the detection that the shell is standing inside a worktree being removed all failed to fire on a case mismatch
 
 ## [2.0.0] - 2026-08-09

--- a/CODE_REFERENCE.md
+++ b/CODE_REFERENCE.md
@@ -209,7 +209,9 @@ git flow feature finish my-feature --rebase
    → Update branches with autoUpdate=true
    → On conflict: save state (including current child), exit
 5. STATE: DELETE_BRANCH
+   → Checkout the landing branch (last auto-update child of the parent, else the parent)
    → Delete local/remote (unless --keep)
+   → Report the branch you are left on
 ```
 
 ### Continue After Conflict

--- a/cmd/finish.go
+++ b/cmd/finish.go
@@ -768,11 +768,29 @@ func handleUpdateChildrenStep(repo *git.Repo, cfg *config.Config, state *mergest
 	return nil
 }
 
+// landingBranch returns the branch a completed finish leaves the user on: the
+// last auto-update child of the parent that the integration sequence processed,
+// or the parent itself when the parent has no auto-update children. Children are
+// collected from configuration in sorted order and persisted in the merge state,
+// so the result is stable across runs and identical on --continue even if the
+// configuration changed while conflicts were being resolved.
+func landingBranch(state *mergestate.MergeState) string {
+	if n := len(state.ChildBranches); n > 0 {
+		return state.ChildBranches[n-1]
+	}
+	return state.ParentBranch
+}
+
 // handleDeleteBranchStep handles branch deletion
 func handleDeleteBranchStep(repo *git.Repo, cfg *config.Config, state *mergestate.MergeState, resolvedOptions *config.ResolvedFinishOptions) error {
-	// Ensure we're on the parent branch before deletion
-	if err := repo.Checkout(state.ParentBranch); err != nil {
-		return &errors.GitError{Operation: fmt.Sprintf("checkout parent branch '%s'", state.ParentBranch), Err: err}
+	// Land on the integration branch: the last auto-update child of the parent,
+	// or the parent when there is none. The checkout also guarantees HEAD is not
+	// on the branch about to be deleted. It is a no-op in every normal path (HEAD
+	// is already there by construction) and only does real work when --continue
+	// resumes directly at this step.
+	landing := landingBranch(state)
+	if err := repo.Checkout(landing); err != nil {
+		return &errors.GitError{Operation: fmt.Sprintf("checkout branch '%s'", landing), Err: err}
 	}
 
 	// Clear the merge state before branch deletion. By this point all merges,
@@ -814,6 +832,7 @@ func handleDeleteBranchStep(repo *git.Repo, cfg *config.Config, state *mergestat
 	}
 
 	fmt.Printf("Successfully finished branch '%s' and updated %d child base branches\n", state.FullBranchName, len(state.UpdatedBranches))
+	fmt.Printf("You are now on branch '%s'\n", landing)
 
 	// Run post-hook after successful completion
 	hookCtx := hooks.HookContext{

--- a/docs/avh-compatibility-analysis.md
+++ b/docs/avh-compatibility-analysis.md
@@ -219,6 +219,8 @@ git-flow-next implements shorthand commands that work on the current branch:
 | `--ff-master` | ✅ | ❌ |
 | `--showcommands` | ✅ | ❌ |
 
+**Landing branch parity**: like AVH, a completed `release` or `hotfix` finish leaves you on `develop` rather than on `main`. git-flow-next derives that branch from the configured topology — the last auto-update child of the finished branch's parent, or the parent when it has none — instead of hardcoding a branch name, so the same rule holds for custom topologies where no branch is called `develop`.
+
 #### Other Commands
 | Command | Missing from git-flow-next |
 |---------|---------------------------|

--- a/docs/git-flow-finish.1.md
+++ b/docs/git-flow-finish.1.md
@@ -18,7 +18,7 @@ The finish operation follows a strict state machine with these steps:
 1. **Merge**: Merges the topic branch to its parent branch using the configured upstream strategy
 2. **Create Tag**: Optionally creates and signs tags (if configured)
 3. **Update Children**: Updates any child branches that have `autoUpdate=true` using their downstream strategies
-4. **Delete Branch**: Optionally deletes the topic branch (local and/or remote)
+4. **Delete Branch**: Checks out the integration branch, optionally deletes the topic branch (local and/or remote), and reports the branch you are left on
 
 The operation maintains a persistent state file that allows it to resume after conflicts. If conflicts occur during any merge operation (main merge or child updates), the state is saved and the operation can be continued with **--continue** or aborted with **--abort**.
 
@@ -461,6 +461,12 @@ Only branches with `autoUpdate=true` are updated:
 ```bash
 git config gitflow.branch.develop.autoUpdate true
 ```
+
+### Landing Branch
+
+A completed finish leaves you on the **integration branch**: the last auto-update child of the topic branch's parent — the alphabetically last one when there are several — or on the parent itself when it has no auto-update children. In the default configuration that means `git flow release finish` and `git flow hotfix finish` end on `develop` rather than `main`, and `git flow feature finish` ends on `develop` as before. Finish reports the result as `You are now on branch '<name>'`.
+
+The branch is resolved from the configured topology, not from a branch named `develop`, so it is well defined for custom branch names. The rule is identical whether the topic branch is deleted or kept with **--keep**, on the first run and on **--continue** after a conflict, and for every merge strategy. **--abort** is unaffected: it returns you to the topic branch.
 
 ## CONFIGURATION
 

--- a/test/cmd/finish_conflicts_test.go
+++ b/test/cmd/finish_conflicts_test.go
@@ -781,13 +781,13 @@ func TestFinishWithConsecutiveConflicts(t *testing.T) {
 		t.Error("Expected merge state file to be cleaned up after successful completion")
 	}
 
-	// Verify final repository state - should be on main branch after release finish
+	// Verify final repository state - should be on the integration branch after release finish
 	currentBranch, err := testutil.RunGit(t, dir, "rev-parse", "--abbrev-ref", "HEAD")
 	if err != nil {
 		t.Fatalf("Failed to get current branch: %v", err)
 	}
-	if strings.TrimSpace(currentBranch) != "main" {
-		t.Errorf("Expected to be on main branch after release finish, got: %s", strings.TrimSpace(currentBranch))
+	if strings.TrimSpace(currentBranch) != "develop" {
+		t.Errorf("Expected to be on develop branch after release finish, got: %s", strings.TrimSpace(currentBranch))
 	}
 
 	// Verify release branch is deleted
@@ -800,6 +800,10 @@ func TestFinishWithConsecutiveConflicts(t *testing.T) {
 	}
 
 	// Verify main branch has the resolved content with release info
+	_, err = testutil.RunGit(t, dir, "checkout", "main")
+	if err != nil {
+		t.Fatalf("Failed to checkout main branch: %v", err)
+	}
 	mainContent := testutil.ReadFile(t, dir, "version.txt")
 	if !strings.Contains(mainContent, "version: 1.1.0") || !strings.Contains(mainContent, "release-date: 2024-01-15") {
 		t.Errorf("Expected main branch to have release changes, got: %s", mainContent)

--- a/test/cmd/finish_landing_test.go
+++ b/test/cmd/finish_landing_test.go
@@ -24,7 +24,7 @@ func setupParentMergeConflict(t *testing.T, dir string) {
 	if _, err := testutil.RunGit(t, dir, "checkout", "main"); err != nil {
 		t.Fatalf("Failed to checkout main: %v", err)
 	}
-	writeAndCommit(t, dir, "shared.txt", "base", "Add shared file")
+	landingAddCommit(t, dir, "shared.txt", "base", "Add shared file")
 
 	if _, err := testutil.RunGit(t, dir, "checkout", "develop"); err != nil {
 		t.Fatalf("Failed to checkout develop: %v", err)
@@ -36,12 +36,12 @@ func setupParentMergeConflict(t *testing.T, dir string) {
 	if output, err := testutil.RunGitFlow(t, dir, "release", "start", "1.0.0"); err != nil {
 		t.Fatalf("Failed to start release: %v\nOutput: %s", err, output)
 	}
-	writeAndCommit(t, dir, "shared.txt", "release", "Release change")
+	landingAddCommit(t, dir, "shared.txt", "release", "Release change")
 
 	if _, err := testutil.RunGit(t, dir, "checkout", "main"); err != nil {
 		t.Fatalf("Failed to checkout main: %v", err)
 	}
-	writeAndCommit(t, dir, "shared.txt", "hotfix", "Diverging change on main")
+	landingAddCommit(t, dir, "shared.txt", "hotfix", "Diverging change on main")
 
 	if _, err := testutil.RunGit(t, dir, "checkout", "release/1.0.0"); err != nil {
 		t.Fatalf("Failed to checkout release/1.0.0: %v", err)
@@ -62,7 +62,7 @@ func setupChildUpdateConflict(t *testing.T, dir string) {
 	if _, err := testutil.RunGit(t, dir, "checkout", "main"); err != nil {
 		t.Fatalf("Failed to checkout main: %v", err)
 	}
-	writeAndCommit(t, dir, "shared.txt", "base", "Add shared file")
+	landingAddCommit(t, dir, "shared.txt", "base", "Add shared file")
 
 	if _, err := testutil.RunGit(t, dir, "checkout", "develop"); err != nil {
 		t.Fatalf("Failed to checkout develop: %v", err)
@@ -74,20 +74,20 @@ func setupChildUpdateConflict(t *testing.T, dir string) {
 	if output, err := testutil.RunGitFlow(t, dir, "release", "start", "1.0.0"); err != nil {
 		t.Fatalf("Failed to start release: %v\nOutput: %s", err, output)
 	}
-	writeAndCommit(t, dir, "shared.txt", "release", "Release change")
+	landingAddCommit(t, dir, "shared.txt", "release", "Release change")
 
 	if _, err := testutil.RunGit(t, dir, "checkout", "develop"); err != nil {
 		t.Fatalf("Failed to checkout develop: %v", err)
 	}
-	writeAndCommit(t, dir, "shared.txt", "develop", "Diverging change on develop")
+	landingAddCommit(t, dir, "shared.txt", "develop", "Diverging change on develop")
 
 	if _, err := testutil.RunGit(t, dir, "checkout", "release/1.0.0"); err != nil {
 		t.Fatalf("Failed to checkout release/1.0.0: %v", err)
 	}
 }
 
-// writeAndCommit writes a file in the test repository and commits it.
-func writeAndCommit(t *testing.T, dir string, name string, content string, message string) {
+// landingAddCommit writes a file in the test repository and commits it.
+func landingAddCommit(t *testing.T, dir string, name string, content string, message string) {
 	t.Helper()
 
 	if err := testutil.WriteFile(t, dir, name, content); err != nil {
@@ -155,7 +155,7 @@ func TestFinishReleaseLandsOnIntegrationBranch(t *testing.T) {
 	if output, err := testutil.RunGitFlow(t, dir, "release", "start", "1.0.0"); err != nil {
 		t.Fatalf("Failed to start release: %v\nOutput: %s", err, output)
 	}
-	writeAndCommit(t, dir, "version.txt", "1.0.0", "Add version file")
+	landingAddCommit(t, dir, "version.txt", "1.0.0", "Add version file")
 
 	releaseSha, err := testutil.RunGit(t, dir, "rev-parse", "HEAD")
 	if err != nil {
@@ -213,7 +213,7 @@ func TestFinishHotfixLandsOnIntegrationBranch(t *testing.T) {
 	if output, err := testutil.RunGitFlow(t, dir, "hotfix", "start", "1.0.1"); err != nil {
 		t.Fatalf("Failed to start hotfix: %v\nOutput: %s", err, output)
 	}
-	writeAndCommit(t, dir, "hotfix.txt", "fix", "Add hotfix file")
+	landingAddCommit(t, dir, "hotfix.txt", "fix", "Add hotfix file")
 
 	if output, err := testutil.RunGitFlow(t, dir, "hotfix", "finish", "1.0.1"); err != nil {
 		t.Fatalf("Failed to finish hotfix: %v\nOutput: %s", err, output)
@@ -245,7 +245,7 @@ func TestFinishFeatureLandsOnDevelop(t *testing.T) {
 	if output, err := testutil.RunGitFlow(t, dir, "feature", "start", "f1"); err != nil {
 		t.Fatalf("Failed to start feature: %v\nOutput: %s", err, output)
 	}
-	writeAndCommit(t, dir, "f.txt", "feature", "Add feature file")
+	landingAddCommit(t, dir, "f.txt", "feature", "Add feature file")
 
 	if output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "f1"); err != nil {
 		t.Fatalf("Failed to finish feature: %v\nOutput: %s", err, output)
@@ -277,7 +277,7 @@ func TestFinishBugfixLandsOnDevelop(t *testing.T) {
 	if output, err := testutil.RunGitFlow(t, dir, "bugfix", "start", "b1"); err != nil {
 		t.Fatalf("Failed to start bugfix: %v\nOutput: %s", err, output)
 	}
-	writeAndCommit(t, dir, "b.txt", "bugfix", "Add bugfix file")
+	landingAddCommit(t, dir, "b.txt", "bugfix", "Add bugfix file")
 
 	if output, err := testutil.RunGitFlow(t, dir, "bugfix", "finish", "b1"); err != nil {
 		t.Fatalf("Failed to finish bugfix: %v\nOutput: %s", err, output)
@@ -309,7 +309,7 @@ func TestFinishLandsOnParentWithoutAutoUpdateChildren(t *testing.T) {
 	if output, err := testutil.RunGitFlow(t, dir, "feature", "start", "f1"); err != nil {
 		t.Fatalf("Failed to start feature: %v\nOutput: %s", err, output)
 	}
-	writeAndCommit(t, dir, "f.txt", "feature", "Add feature file")
+	landingAddCommit(t, dir, "f.txt", "feature", "Add feature file")
 
 	if output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "f1"); err != nil {
 		t.Fatalf("Failed to finish feature: %v\nOutput: %s", err, output)
@@ -354,7 +354,7 @@ func TestFinishLandsOnCustomIntegrationBranch(t *testing.T) {
 	if output, err := testutil.RunGitFlow(t, dir, "rel", "start", "1.0.0"); err != nil {
 		t.Fatalf("Failed to start rel: %v\nOutput: %s", err, output)
 	}
-	writeAndCommit(t, dir, "r.txt", "rel", "Add rel file")
+	landingAddCommit(t, dir, "r.txt", "rel", "Add rel file")
 
 	if output, err := testutil.RunGitFlow(t, dir, "rel", "finish", "1.0.0"); err != nil {
 		t.Fatalf("Failed to finish rel: %v\nOutput: %s", err, output)
@@ -386,7 +386,7 @@ func TestFinishWithKeepLandsOnIntegrationBranch(t *testing.T) {
 	if output, err := testutil.RunGitFlow(t, dir, "release", "start", "1.0.0"); err != nil {
 		t.Fatalf("Failed to start release: %v\nOutput: %s", err, output)
 	}
-	writeAndCommit(t, dir, "version.txt", "1.0.0", "Add version file")
+	landingAddCommit(t, dir, "version.txt", "1.0.0", "Add version file")
 
 	if output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0", "--keep"); err != nil {
 		t.Fatalf("Failed to finish release: %v\nOutput: %s", err, output)
@@ -469,6 +469,9 @@ func TestFinishContinueAfterChildConflictLandsOnIntegrationBranch(t *testing.T) 
 		t.Fatalf("Failed to continue release finish: %v\nOutput: %s", err, output)
 	}
 
+	if testutil.IsMergeInProgress(t, dir) {
+		t.Error("Expected no merge in progress after continue")
+	}
 	if current := testutil.GetCurrentBranch(t, dir); current != "develop" {
 		t.Errorf("Expected to be on develop after continue, got %s", current)
 	}
@@ -634,11 +637,13 @@ func TestFinishReportsLandingBranch(t *testing.T) {
 	if output, err := testutil.RunGitFlow(t, dir, "release", "start", "1.0.0"); err != nil {
 		t.Fatalf("Failed to start release: %v\nOutput: %s", err, output)
 	}
-	writeAndCommit(t, dir, "version.txt", "1.0.0", "Add version file")
+	landingAddCommit(t, dir, "version.txt", "1.0.0", "Add version file")
 
-	output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0")
+	// Use the split streams so the report line is pinned to stdout, where the
+	// rest of the finish progress output goes.
+	stdout, stderr, err := testutil.RunGitFlowStreams(t, dir, "release", "finish", "1.0.0")
 	if err != nil {
-		t.Fatalf("Failed to finish release: %v\nOutput: %s", err, output)
+		t.Fatalf("Failed to finish release: %v\nStdout: %s\nStderr: %s", err, stdout, stderr)
 	}
 
 	current := testutil.GetCurrentBranch(t, dir)
@@ -646,8 +651,8 @@ func TestFinishReportsLandingBranch(t *testing.T) {
 		t.Errorf("Expected to be on develop after release finish, got %s", current)
 	}
 	expected := fmt.Sprintf("You are now on branch '%s'", current)
-	if !strings.Contains(output, expected) {
-		t.Errorf("Expected output to contain %q, got: %s", expected, output)
+	if !strings.Contains(stdout, expected) {
+		t.Errorf("Expected stdout to contain %q, got: %s", expected, stdout)
 	}
 }
 
@@ -669,11 +674,11 @@ func TestFinishReportsLandingBranchWithoutChildren(t *testing.T) {
 	if output, err := testutil.RunGitFlow(t, dir, "feature", "start", "f1"); err != nil {
 		t.Fatalf("Failed to start feature: %v\nOutput: %s", err, output)
 	}
-	writeAndCommit(t, dir, "f.txt", "feature", "Add feature file")
+	landingAddCommit(t, dir, "f.txt", "feature", "Add feature file")
 
-	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "f1")
+	stdout, stderr, err := testutil.RunGitFlowStreams(t, dir, "feature", "finish", "f1")
 	if err != nil {
-		t.Fatalf("Failed to finish feature: %v\nOutput: %s", err, output)
+		t.Fatalf("Failed to finish feature: %v\nStdout: %s\nStderr: %s", err, stdout, stderr)
 	}
 
 	current := testutil.GetCurrentBranch(t, dir)
@@ -681,8 +686,8 @@ func TestFinishReportsLandingBranchWithoutChildren(t *testing.T) {
 		t.Errorf("Expected to be on main after feature finish, got %s", current)
 	}
 	expected := fmt.Sprintf("You are now on branch '%s'", current)
-	if !strings.Contains(output, expected) {
-		t.Errorf("Expected output to contain %q, got: %s", expected, output)
+	if !strings.Contains(stdout, expected) {
+		t.Errorf("Expected stdout to contain %q, got: %s", expected, stdout)
 	}
 }
 
@@ -704,7 +709,7 @@ func TestFinishFromUnrelatedBranchLandsOnIntegrationBranch(t *testing.T) {
 	if output, err := testutil.RunGitFlow(t, dir, "release", "start", "1.0.0"); err != nil {
 		t.Fatalf("Failed to start release: %v\nOutput: %s", err, output)
 	}
-	writeAndCommit(t, dir, "version.txt", "1.0.0", "Add version file")
+	landingAddCommit(t, dir, "version.txt", "1.0.0", "Add version file")
 
 	if _, err := testutil.RunGit(t, dir, "checkout", "-b", "unrelated", "main"); err != nil {
 		t.Fatalf("Failed to create unrelated branch: %v", err)
@@ -740,7 +745,7 @@ func TestFinishShorthandLandsOnIntegrationBranch(t *testing.T) {
 	if output, err := testutil.RunGitFlow(t, dir, "release", "start", "1.0.0"); err != nil {
 		t.Fatalf("Failed to start release: %v\nOutput: %s", err, output)
 	}
-	writeAndCommit(t, dir, "version.txt", "1.0.0", "Add version file")
+	landingAddCommit(t, dir, "version.txt", "1.0.0", "Add version file")
 
 	if output, err := testutil.RunGitFlow(t, dir, "finish"); err != nil {
 		t.Fatalf("Failed to finish via shorthand: %v\nOutput: %s", err, output)
@@ -775,12 +780,18 @@ func TestFinishSquashStrategyLandsOnIntegrationBranch(t *testing.T) {
 	if output, err := testutil.RunGitFlow(t, dir, "release", "start", "1.0.0"); err != nil {
 		t.Fatalf("Failed to start release: %v\nOutput: %s", err, output)
 	}
-	writeAndCommit(t, dir, "version.txt", "1.0.0", "Add version file")
+	landingAddCommit(t, dir, "version.txt", "1.0.0", "Add version file")
 
-	if output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0"); err != nil {
+	output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0")
+	if err != nil {
 		t.Fatalf("Failed to finish release: %v\nOutput: %s", err, output)
 	}
 
+	// Confirm the squash path was actually taken, so the test cannot pass by
+	// silently falling back to the default merge strategy.
+	if !strings.Contains(output, "Merging using strategy: squash") {
+		t.Errorf("Expected finish to use the squash strategy, got: %s", output)
+	}
 	if current := testutil.GetCurrentBranch(t, dir); current != "develop" {
 		t.Errorf("Expected to be on develop after squash finish, got %s", current)
 	}
@@ -810,12 +821,18 @@ func TestFinishRebaseStrategyLandsOnIntegrationBranch(t *testing.T) {
 	if output, err := testutil.RunGitFlow(t, dir, "release", "start", "1.0.0"); err != nil {
 		t.Fatalf("Failed to start release: %v\nOutput: %s", err, output)
 	}
-	writeAndCommit(t, dir, "version.txt", "1.0.0", "Add version file")
+	landingAddCommit(t, dir, "version.txt", "1.0.0", "Add version file")
 
-	if output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0"); err != nil {
+	output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0")
+	if err != nil {
 		t.Fatalf("Failed to finish release: %v\nOutput: %s", err, output)
 	}
 
+	// Confirm the rebase path was actually taken, so the test cannot pass by
+	// silently falling back to the default merge strategy.
+	if !strings.Contains(output, "Merging using strategy: rebase") {
+		t.Errorf("Expected finish to use the rebase strategy, got: %s", output)
+	}
 	if current := testutil.GetCurrentBranch(t, dir); current != "develop" {
 		t.Errorf("Expected to be on develop after rebase finish, got %s", current)
 	}
@@ -842,7 +859,7 @@ func TestFinishSupportLandsOnIntegrationBranch(t *testing.T) {
 	if output, err := testutil.RunGitFlow(t, dir, "support", "start", "1.x"); err != nil {
 		t.Fatalf("Failed to start support: %v\nOutput: %s", err, output)
 	}
-	writeAndCommit(t, dir, "s.txt", "support", "Add support file")
+	landingAddCommit(t, dir, "s.txt", "support", "Add support file")
 
 	if output, err := testutil.RunGitFlow(t, dir, "support", "finish", "1.x"); err != nil {
 		t.Fatalf("Failed to finish support: %v\nOutput: %s", err, output)
@@ -850,6 +867,9 @@ func TestFinishSupportLandsOnIntegrationBranch(t *testing.T) {
 
 	if current := testutil.GetCurrentBranch(t, dir); current != "develop" {
 		t.Errorf("Expected to be on develop after support finish, got %s", current)
+	}
+	if testutil.BranchExists(t, dir, "support/1.x") {
+		t.Error("Expected support/1.x to be deleted after finish")
 	}
 }
 
@@ -886,7 +906,7 @@ func TestFinishLandsOnLastAutoUpdateChild(t *testing.T) {
 	if output, err := testutil.RunGitFlow(t, dir, "release", "start", "1.0.0"); err != nil {
 		t.Fatalf("Failed to start release: %v\nOutput: %s", err, output)
 	}
-	writeAndCommit(t, dir, "version.txt", "1.0.0", "Add version file")
+	landingAddCommit(t, dir, "version.txt", "1.0.0", "Add version file")
 
 	output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0")
 	if err != nil {

--- a/test/cmd/finish_landing_test.go
+++ b/test/cmd/finish_landing_test.go
@@ -1,0 +1,911 @@
+package cmd_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gittower/git-flow-next/test/testutil"
+)
+
+// setupParentMergeConflict prepares a repository in which finishing release/1.0.0
+// conflicts while merging into the parent branch 'main'.
+// Steps:
+// 1. Writes shared.txt with content "base" on main and commits it
+// 2. Fast-forwards develop to main so both branches share the base commit
+// 3. Starts release/1.0.0 and sets shared.txt to "release"
+// 4. Sets shared.txt to "hotfix" on main so the merge into main conflicts
+// 5. Leaves HEAD on release/1.0.0
+func setupParentMergeConflict(t *testing.T, dir string) {
+	t.Helper()
+
+	if _, err := testutil.RunGit(t, dir, "checkout", "main"); err != nil {
+		t.Fatalf("Failed to checkout main: %v", err)
+	}
+	writeAndCommit(t, dir, "shared.txt", "base", "Add shared file")
+
+	if _, err := testutil.RunGit(t, dir, "checkout", "develop"); err != nil {
+		t.Fatalf("Failed to checkout develop: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "merge", "--ff-only", "main"); err != nil {
+		t.Fatalf("Failed to fast-forward develop to main: %v", err)
+	}
+
+	if output, err := testutil.RunGitFlow(t, dir, "release", "start", "1.0.0"); err != nil {
+		t.Fatalf("Failed to start release: %v\nOutput: %s", err, output)
+	}
+	writeAndCommit(t, dir, "shared.txt", "release", "Release change")
+
+	if _, err := testutil.RunGit(t, dir, "checkout", "main"); err != nil {
+		t.Fatalf("Failed to checkout main: %v", err)
+	}
+	writeAndCommit(t, dir, "shared.txt", "hotfix", "Diverging change on main")
+
+	if _, err := testutil.RunGit(t, dir, "checkout", "release/1.0.0"); err != nil {
+		t.Fatalf("Failed to checkout release/1.0.0: %v", err)
+	}
+}
+
+// setupChildUpdateConflict prepares a repository in which finishing release/1.0.0
+// merges into 'main' cleanly and then conflicts while auto-updating 'develop'.
+// Steps:
+// 1. Writes shared.txt with content "base" on main and commits it
+// 2. Fast-forwards develop to main so both branches share the base commit
+// 3. Starts release/1.0.0 and sets shared.txt to "release"
+// 4. Sets shared.txt to "develop" on develop so the child update conflicts
+// 5. Leaves HEAD on release/1.0.0
+func setupChildUpdateConflict(t *testing.T, dir string) {
+	t.Helper()
+
+	if _, err := testutil.RunGit(t, dir, "checkout", "main"); err != nil {
+		t.Fatalf("Failed to checkout main: %v", err)
+	}
+	writeAndCommit(t, dir, "shared.txt", "base", "Add shared file")
+
+	if _, err := testutil.RunGit(t, dir, "checkout", "develop"); err != nil {
+		t.Fatalf("Failed to checkout develop: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "merge", "--ff-only", "main"); err != nil {
+		t.Fatalf("Failed to fast-forward develop to main: %v", err)
+	}
+
+	if output, err := testutil.RunGitFlow(t, dir, "release", "start", "1.0.0"); err != nil {
+		t.Fatalf("Failed to start release: %v\nOutput: %s", err, output)
+	}
+	writeAndCommit(t, dir, "shared.txt", "release", "Release change")
+
+	if _, err := testutil.RunGit(t, dir, "checkout", "develop"); err != nil {
+		t.Fatalf("Failed to checkout develop: %v", err)
+	}
+	writeAndCommit(t, dir, "shared.txt", "develop", "Diverging change on develop")
+
+	if _, err := testutil.RunGit(t, dir, "checkout", "release/1.0.0"); err != nil {
+		t.Fatalf("Failed to checkout release/1.0.0: %v", err)
+	}
+}
+
+// writeAndCommit writes a file in the test repository and commits it.
+func writeAndCommit(t *testing.T, dir string, name string, content string, message string) {
+	t.Helper()
+
+	if err := testutil.WriteFile(t, dir, name, content); err != nil {
+		t.Fatalf("Failed to write %s: %v", name, err)
+	}
+	if _, err := testutil.RunGit(t, dir, "add", name); err != nil {
+		t.Fatalf("Failed to stage %s: %v", name, err)
+	}
+	if _, err := testutil.RunGit(t, dir, "commit", "-m", message); err != nil {
+		t.Fatalf("Failed to commit %s: %v", name, err)
+	}
+}
+
+// resolveSharedConflict writes the agreed resolution for the shared.txt fixtures
+// and stages it, so the finish can be continued.
+func resolveSharedConflict(t *testing.T, dir string) {
+	t.Helper()
+
+	if err := testutil.WriteFile(t, dir, "shared.txt", "resolved"); err != nil {
+		t.Fatalf("Failed to write resolution: %v", err)
+	}
+	if _, err := testutil.RunGit(t, dir, "add", "shared.txt"); err != nil {
+		t.Fatalf("Failed to stage resolution: %v", err)
+	}
+}
+
+// assertMergeConflictAt verifies that a merge conflict is in progress and that
+// the persisted merge state stopped in the expected step and child branch.
+// An empty expectedChild means the child branch is not checked.
+func assertMergeConflictAt(t *testing.T, dir string, expectedStep string, expectedChild string) {
+	t.Helper()
+
+	if !testutil.IsMergeInProgress(t, dir) {
+		t.Fatal("Expected a merge to be in progress")
+	}
+	state, err := testutil.LoadMergeState(t, dir)
+	if err != nil {
+		t.Fatalf("Failed to load merge state: %v", err)
+	}
+	if state.CurrentStep != expectedStep {
+		t.Fatalf("Expected merge state step %q, got %q", expectedStep, state.CurrentStep)
+	}
+	if expectedChild != "" && state.CurrentChildBranch != expectedChild {
+		t.Fatalf("Expected merge state child branch %q, got %q", expectedChild, state.CurrentChildBranch)
+	}
+}
+
+// TestFinishReleaseLandsOnIntegrationBranch tests that a default-config release finish
+// leaves the user on the integration branch 'develop' rather than the parent 'main'.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Starts release/1.0.0 and commits a file
+// 3. Finishes the release branch
+// 4. Verifies HEAD is on develop
+// 5. Verifies the release commit is reachable from main and the tag points at main
+// 6. Verifies the release branch was deleted
+func TestFinishReleaseLandsOnIntegrationBranch(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if output, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+	if output, err := testutil.RunGitFlow(t, dir, "release", "start", "1.0.0"); err != nil {
+		t.Fatalf("Failed to start release: %v\nOutput: %s", err, output)
+	}
+	writeAndCommit(t, dir, "version.txt", "1.0.0", "Add version file")
+
+	releaseSha, err := testutil.RunGit(t, dir, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("Failed to resolve release commit: %v", err)
+	}
+	releaseSha = strings.TrimSpace(releaseSha)
+
+	output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0")
+	if err != nil {
+		t.Fatalf("Failed to finish release: %v\nOutput: %s", err, output)
+	}
+
+	// Assert the landing branch before anything else moves HEAD.
+	if current := testutil.GetCurrentBranch(t, dir); current != "develop" {
+		t.Errorf("Expected to be on develop after release finish, got %s", current)
+	}
+
+	// The release commit must be part of main's history, not merely its content.
+	if _, err := testutil.RunGit(t, dir, "merge-base", "--is-ancestor", releaseSha, "main"); err != nil {
+		t.Errorf("Expected release commit %s to be an ancestor of main: %v", releaseSha, err)
+	}
+
+	tagSha, err := testutil.RunGit(t, dir, "rev-parse", "1.0.0^{commit}")
+	if err != nil {
+		t.Fatalf("Failed to resolve tag 1.0.0: %v", err)
+	}
+	mainSha, err := testutil.RunGit(t, dir, "rev-parse", "main")
+	if err != nil {
+		t.Fatalf("Failed to resolve main: %v", err)
+	}
+	if strings.TrimSpace(tagSha) != strings.TrimSpace(mainSha) {
+		t.Errorf("Expected tag 1.0.0 to point at main (%s), got %s", strings.TrimSpace(mainSha), strings.TrimSpace(tagSha))
+	}
+
+	if testutil.BranchExists(t, dir, "release/1.0.0") {
+		t.Error("Expected release/1.0.0 to be deleted after finish")
+	}
+}
+
+// TestFinishHotfixLandsOnIntegrationBranch tests that a default-config hotfix finish
+// leaves the user on the integration branch 'develop'.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Starts hotfix/1.0.1 and commits a file
+// 3. Finishes the hotfix branch
+// 4. Verifies HEAD is on develop and the hotfix branch was deleted
+func TestFinishHotfixLandsOnIntegrationBranch(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if output, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+	if output, err := testutil.RunGitFlow(t, dir, "hotfix", "start", "1.0.1"); err != nil {
+		t.Fatalf("Failed to start hotfix: %v\nOutput: %s", err, output)
+	}
+	writeAndCommit(t, dir, "hotfix.txt", "fix", "Add hotfix file")
+
+	if output, err := testutil.RunGitFlow(t, dir, "hotfix", "finish", "1.0.1"); err != nil {
+		t.Fatalf("Failed to finish hotfix: %v\nOutput: %s", err, output)
+	}
+
+	if current := testutil.GetCurrentBranch(t, dir); current != "develop" {
+		t.Errorf("Expected to be on develop after hotfix finish, got %s", current)
+	}
+	if testutil.BranchExists(t, dir, "hotfix/1.0.1") {
+		t.Error("Expected hotfix/1.0.1 to be deleted after finish")
+	}
+}
+
+// TestFinishFeatureLandsOnDevelop tests that a default-config feature finish still
+// leaves the user on develop, its parent, which has no auto-update children.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Starts feature/f1 and commits a file
+// 3. Finishes the feature branch
+// 4. Verifies HEAD is on develop and the feature branch was deleted
+func TestFinishFeatureLandsOnDevelop(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if output, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+	if output, err := testutil.RunGitFlow(t, dir, "feature", "start", "f1"); err != nil {
+		t.Fatalf("Failed to start feature: %v\nOutput: %s", err, output)
+	}
+	writeAndCommit(t, dir, "f.txt", "feature", "Add feature file")
+
+	if output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "f1"); err != nil {
+		t.Fatalf("Failed to finish feature: %v\nOutput: %s", err, output)
+	}
+
+	if current := testutil.GetCurrentBranch(t, dir); current != "develop" {
+		t.Errorf("Expected to be on develop after feature finish, got %s", current)
+	}
+	if testutil.BranchExists(t, dir, "feature/f1") {
+		t.Error("Expected feature/f1 to be deleted after finish")
+	}
+}
+
+// TestFinishBugfixLandsOnDevelop tests that a default-config bugfix finish still
+// leaves the user on develop.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Starts bugfix/b1 and commits a file
+// 3. Finishes the bugfix branch
+// 4. Verifies HEAD is on develop and the bugfix branch was deleted
+func TestFinishBugfixLandsOnDevelop(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if output, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+	if output, err := testutil.RunGitFlow(t, dir, "bugfix", "start", "b1"); err != nil {
+		t.Fatalf("Failed to start bugfix: %v\nOutput: %s", err, output)
+	}
+	writeAndCommit(t, dir, "b.txt", "bugfix", "Add bugfix file")
+
+	if output, err := testutil.RunGitFlow(t, dir, "bugfix", "finish", "b1"); err != nil {
+		t.Fatalf("Failed to finish bugfix: %v\nOutput: %s", err, output)
+	}
+
+	if current := testutil.GetCurrentBranch(t, dir); current != "develop" {
+		t.Errorf("Expected to be on develop after bugfix finish, got %s", current)
+	}
+	if testutil.BranchExists(t, dir, "bugfix/b1") {
+		t.Error("Expected bugfix/b1 to be deleted after finish")
+	}
+}
+
+// TestFinishLandsOnParentWithoutAutoUpdateChildren tests that a finish whose parent has
+// no auto-update children leaves the user on the parent branch.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with the github preset
+// 2. Starts feature/f1 and commits a file
+// 3. Finishes the feature branch
+// 4. Verifies HEAD is on main, the feature branch is gone and no develop branch exists
+func TestFinishLandsOnParentWithoutAutoUpdateChildren(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if output, err := testutil.RunGitFlow(t, dir, "init", "--preset=github"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+	if output, err := testutil.RunGitFlow(t, dir, "feature", "start", "f1"); err != nil {
+		t.Fatalf("Failed to start feature: %v\nOutput: %s", err, output)
+	}
+	writeAndCommit(t, dir, "f.txt", "feature", "Add feature file")
+
+	if output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "f1"); err != nil {
+		t.Fatalf("Failed to finish feature: %v\nOutput: %s", err, output)
+	}
+
+	if current := testutil.GetCurrentBranch(t, dir); current != "main" {
+		t.Errorf("Expected to be on main after feature finish, got %s", current)
+	}
+	if testutil.BranchExists(t, dir, "feature/f1") {
+		t.Error("Expected feature/f1 to be deleted after finish")
+	}
+	if testutil.BranchExists(t, dir, "develop") {
+		t.Error("Expected no develop branch in a github preset repository")
+	}
+}
+
+// TestFinishLandsOnCustomIntegrationBranch tests that the landing branch is resolved from
+// configuration rather than from a branch named 'develop'.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Configures a custom topology: base trunk, auto-update base integration, topic rel
+// 3. Starts rel/1.0.0 and commits a file
+// 4. Finishes the rel branch
+// 5. Verifies HEAD is on integration, not trunk and not develop
+func TestFinishLandsOnCustomIntegrationBranch(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if output, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+	if output, err := testutil.RunGitFlow(t, dir, "config", "add", "base", "trunk"); err != nil {
+		t.Fatalf("Failed to add base trunk: %v\nOutput: %s", err, output)
+	}
+	if output, err := testutil.RunGitFlow(t, dir, "config", "add", "base", "integration", "trunk", "--auto-update"); err != nil {
+		t.Fatalf("Failed to add base integration: %v\nOutput: %s", err, output)
+	}
+	if output, err := testutil.RunGitFlow(t, dir, "config", "add", "topic", "rel", "trunk", "--starting-point", "integration", "--prefix", "rel/"); err != nil {
+		t.Fatalf("Failed to add topic rel: %v\nOutput: %s", err, output)
+	}
+	if output, err := testutil.RunGitFlow(t, dir, "rel", "start", "1.0.0"); err != nil {
+		t.Fatalf("Failed to start rel: %v\nOutput: %s", err, output)
+	}
+	writeAndCommit(t, dir, "r.txt", "rel", "Add rel file")
+
+	if output, err := testutil.RunGitFlow(t, dir, "rel", "finish", "1.0.0"); err != nil {
+		t.Fatalf("Failed to finish rel: %v\nOutput: %s", err, output)
+	}
+
+	if current := testutil.GetCurrentBranch(t, dir); current != "integration" {
+		t.Errorf("Expected to be on integration after rel finish, got %s", current)
+	}
+	if testutil.BranchExists(t, dir, "rel/1.0.0") {
+		t.Error("Expected rel/1.0.0 to be deleted after finish")
+	}
+}
+
+// TestFinishWithKeepLandsOnIntegrationBranch tests that the landing rule is independent
+// of whether the topic branch is deleted.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Starts release/1.0.0 and commits a file
+// 3. Finishes the release branch with --keep
+// 4. Verifies HEAD is on develop and the release branch still exists
+func TestFinishWithKeepLandsOnIntegrationBranch(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if output, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+	if output, err := testutil.RunGitFlow(t, dir, "release", "start", "1.0.0"); err != nil {
+		t.Fatalf("Failed to start release: %v\nOutput: %s", err, output)
+	}
+	writeAndCommit(t, dir, "version.txt", "1.0.0", "Add version file")
+
+	if output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0", "--keep"); err != nil {
+		t.Fatalf("Failed to finish release: %v\nOutput: %s", err, output)
+	}
+
+	if current := testutil.GetCurrentBranch(t, dir); current != "develop" {
+		t.Errorf("Expected to be on develop after release finish --keep, got %s", current)
+	}
+	if !testutil.BranchExists(t, dir, "release/1.0.0") {
+		t.Error("Expected release/1.0.0 to be kept with --keep")
+	}
+}
+
+// TestFinishContinueAfterParentConflictLandsOnIntegrationBranch tests that continuing a
+// finish after a parent-merge conflict lands on the integration branch.
+// Steps:
+// 1. Sets up a test repository with a conflicting merge into main
+// 2. Runs release finish and verifies it stops in the merge step
+// 3. Resolves and stages the conflict
+// 4. Runs release finish --continue
+// 5. Verifies HEAD is on develop and the release branch was deleted
+func TestFinishContinueAfterParentConflictLandsOnIntegrationBranch(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if output, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+	setupParentMergeConflict(t, dir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0"); err == nil {
+		t.Fatal("Expected release finish to fail with a merge conflict")
+	}
+	assertMergeConflictAt(t, dir, "merge", "")
+
+	resolveSharedConflict(t, dir)
+
+	if output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0", "--continue"); err != nil {
+		t.Fatalf("Failed to continue release finish: %v\nOutput: %s", err, output)
+	}
+
+	if testutil.IsMergeInProgress(t, dir) {
+		t.Error("Expected no merge in progress after continue")
+	}
+	if current := testutil.GetCurrentBranch(t, dir); current != "develop" {
+		t.Errorf("Expected to be on develop after continue, got %s", current)
+	}
+	if testutil.BranchExists(t, dir, "release/1.0.0") {
+		t.Error("Expected release/1.0.0 to be deleted after finish")
+	}
+}
+
+// TestFinishContinueAfterChildConflictLandsOnIntegrationBranch tests that continuing a
+// finish after a child-update conflict lands on the integration branch.
+// Steps:
+// 1. Sets up a test repository where the develop auto-update conflicts
+// 2. Runs release finish and verifies it stops while updating develop
+// 3. Resolves and stages the conflict
+// 4. Runs release finish --continue
+// 5. Verifies HEAD is on develop, the release branch is gone and the tag exists
+func TestFinishContinueAfterChildConflictLandsOnIntegrationBranch(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if output, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+	setupChildUpdateConflict(t, dir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0"); err == nil {
+		t.Fatal("Expected release finish to fail while updating develop")
+	}
+	assertMergeConflictAt(t, dir, "update_children", "develop")
+
+	resolveSharedConflict(t, dir)
+
+	if output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0", "--continue"); err != nil {
+		t.Fatalf("Failed to continue release finish: %v\nOutput: %s", err, output)
+	}
+
+	if current := testutil.GetCurrentBranch(t, dir); current != "develop" {
+		t.Errorf("Expected to be on develop after continue, got %s", current)
+	}
+	if testutil.BranchExists(t, dir, "release/1.0.0") {
+		t.Error("Expected release/1.0.0 to be deleted after finish")
+	}
+	tags, err := testutil.RunGit(t, dir, "tag", "-l")
+	if err != nil {
+		t.Fatalf("Failed to list tags: %v", err)
+	}
+	if !strings.Contains(tags, "1.0.0") {
+		t.Errorf("Expected tag 1.0.0 to exist, got tags: %s", tags)
+	}
+}
+
+// TestFinishContinueWithRebaseLandsOnIntegrationBranch tests that continuing a finish that
+// used the rebase strategy lands on the integration branch.
+// Steps:
+// 1. Sets up a test repository and configures the release type to rebase upstream
+// 2. Provokes a parent-merge conflict and verifies the rebase state via .git/rebase-merge
+// 3. Resolves and stages the conflict
+// 4. Runs release finish --continue
+// 5. Verifies HEAD is on develop and the release branch was deleted
+func TestFinishContinueWithRebaseLandsOnIntegrationBranch(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if output, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.branch.release.upstreamstrategy", "rebase"); err != nil {
+		t.Fatalf("Failed to configure rebase strategy: %v", err)
+	}
+	setupParentMergeConflict(t, dir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0"); err == nil {
+		t.Fatal("Expected release finish to fail with a rebase conflict")
+	}
+
+	// During a rebase conflict the branch name is unreliable; verify Git's internal state.
+	rebaseMergeDir := filepath.Join(dir, ".git", "rebase-merge")
+	if _, err := os.Stat(rebaseMergeDir); os.IsNotExist(err) {
+		t.Fatal("Expected to be in a rebase conflict state")
+	}
+	headName, err := os.ReadFile(filepath.Join(rebaseMergeDir, "head-name"))
+	if err != nil {
+		t.Fatalf("Failed to read rebase head-name: %v", err)
+	}
+	if strings.TrimSpace(string(headName)) != "refs/heads/release/1.0.0" {
+		t.Fatalf("Expected release/1.0.0 to be rebased, got %s", strings.TrimSpace(string(headName)))
+	}
+	state, err := testutil.LoadMergeState(t, dir)
+	if err != nil {
+		t.Fatalf("Failed to load merge state: %v", err)
+	}
+	if state.CurrentStep != "merge" {
+		t.Fatalf("Expected merge state step \"merge\", got %q", state.CurrentStep)
+	}
+
+	resolveSharedConflict(t, dir)
+
+	if output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0", "--continue"); err != nil {
+		t.Fatalf("Failed to continue release finish: %v\nOutput: %s", err, output)
+	}
+
+	if current := testutil.GetCurrentBranch(t, dir); current != "develop" {
+		t.Errorf("Expected to be on develop after continue, got %s", current)
+	}
+	if testutil.BranchExists(t, dir, "release/1.0.0") {
+		t.Error("Expected release/1.0.0 to be deleted after finish")
+	}
+}
+
+// TestFinishAbortDuringParentMergeReturnsToTopicBranch tests that aborting during the parent
+// merge still returns to the topic branch.
+// Steps:
+// 1. Sets up a test repository with a conflicting merge into main
+// 2. Runs release finish and verifies it stops in the merge step
+// 3. Runs release finish --abort
+// 4. Verifies HEAD is on release/1.0.0, the branch still exists and no merge is in progress
+func TestFinishAbortDuringParentMergeReturnsToTopicBranch(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if output, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+	setupParentMergeConflict(t, dir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0"); err == nil {
+		t.Fatal("Expected release finish to fail with a merge conflict")
+	}
+	assertMergeConflictAt(t, dir, "merge", "")
+
+	if output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0", "--abort"); err != nil {
+		t.Fatalf("Failed to abort release finish: %v\nOutput: %s", err, output)
+	}
+
+	if current := testutil.GetCurrentBranch(t, dir); current != "release/1.0.0" {
+		t.Errorf("Expected to be on release/1.0.0 after abort, got %s", current)
+	}
+	if !testutil.BranchExists(t, dir, "release/1.0.0") {
+		t.Error("Expected release/1.0.0 to still exist after abort")
+	}
+	if testutil.IsMergeInProgress(t, dir) {
+		t.Error("Expected no merge in progress after abort")
+	}
+}
+
+// TestFinishAbortDuringChildUpdateReturnsToTopicBranch tests that aborting once the parent
+// merge already succeeded still returns to the topic branch.
+// Steps:
+// 1. Sets up a test repository where the develop auto-update conflicts
+// 2. Runs release finish and verifies it stops while updating develop
+// 3. Runs release finish --abort
+// 4. Verifies HEAD is on release/1.0.0, the branch still exists and no merge is in progress
+func TestFinishAbortDuringChildUpdateReturnsToTopicBranch(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if output, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+	setupChildUpdateConflict(t, dir)
+
+	if _, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0"); err == nil {
+		t.Fatal("Expected release finish to fail while updating develop")
+	}
+	assertMergeConflictAt(t, dir, "update_children", "develop")
+
+	if output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0", "--abort"); err != nil {
+		t.Fatalf("Failed to abort release finish: %v\nOutput: %s", err, output)
+	}
+
+	if current := testutil.GetCurrentBranch(t, dir); current != "release/1.0.0" {
+		t.Errorf("Expected to be on release/1.0.0 after abort, got %s", current)
+	}
+	if !testutil.BranchExists(t, dir, "release/1.0.0") {
+		t.Error("Expected release/1.0.0 to still exist after abort")
+	}
+	if testutil.IsMergeInProgress(t, dir) {
+		t.Error("Expected no merge in progress after abort")
+	}
+}
+
+// TestFinishReportsLandingBranch tests that finish reports the branch it leaves the user on.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Starts release/1.0.0 and commits a file
+// 3. Finishes the release branch, capturing output
+// 4. Verifies HEAD is on develop and the output names that same branch
+func TestFinishReportsLandingBranch(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if output, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+	if output, err := testutil.RunGitFlow(t, dir, "release", "start", "1.0.0"); err != nil {
+		t.Fatalf("Failed to start release: %v\nOutput: %s", err, output)
+	}
+	writeAndCommit(t, dir, "version.txt", "1.0.0", "Add version file")
+
+	output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0")
+	if err != nil {
+		t.Fatalf("Failed to finish release: %v\nOutput: %s", err, output)
+	}
+
+	current := testutil.GetCurrentBranch(t, dir)
+	if current != "develop" {
+		t.Errorf("Expected to be on develop after release finish, got %s", current)
+	}
+	expected := fmt.Sprintf("You are now on branch '%s'", current)
+	if !strings.Contains(output, expected) {
+		t.Errorf("Expected output to contain %q, got: %s", expected, output)
+	}
+}
+
+// TestFinishReportsLandingBranchWithoutChildren tests that finish reports the landing branch
+// even when HEAD did not move.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with the github preset
+// 2. Starts feature/f1 and commits a file
+// 3. Finishes the feature branch, capturing output
+// 4. Verifies HEAD is on main and the output names that same branch
+func TestFinishReportsLandingBranchWithoutChildren(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if output, err := testutil.RunGitFlow(t, dir, "init", "--preset=github"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+	if output, err := testutil.RunGitFlow(t, dir, "feature", "start", "f1"); err != nil {
+		t.Fatalf("Failed to start feature: %v\nOutput: %s", err, output)
+	}
+	writeAndCommit(t, dir, "f.txt", "feature", "Add feature file")
+
+	output, err := testutil.RunGitFlow(t, dir, "feature", "finish", "f1")
+	if err != nil {
+		t.Fatalf("Failed to finish feature: %v\nOutput: %s", err, output)
+	}
+
+	current := testutil.GetCurrentBranch(t, dir)
+	if current != "main" {
+		t.Errorf("Expected to be on main after feature finish, got %s", current)
+	}
+	expected := fmt.Sprintf("You are now on branch '%s'", current)
+	if !strings.Contains(output, expected) {
+		t.Errorf("Expected output to contain %q, got: %s", expected, output)
+	}
+}
+
+// TestFinishFromUnrelatedBranchLandsOnIntegrationBranch tests that the branch finish was
+// invoked from does not affect the landing branch.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Starts release/1.0.0, commits a file and checks out an unrelated branch
+// 3. Finishes the release branch by name
+// 4. Verifies HEAD is on develop and the unrelated branch still exists
+func TestFinishFromUnrelatedBranchLandsOnIntegrationBranch(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if output, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+	if output, err := testutil.RunGitFlow(t, dir, "release", "start", "1.0.0"); err != nil {
+		t.Fatalf("Failed to start release: %v\nOutput: %s", err, output)
+	}
+	writeAndCommit(t, dir, "version.txt", "1.0.0", "Add version file")
+
+	if _, err := testutil.RunGit(t, dir, "checkout", "-b", "unrelated", "main"); err != nil {
+		t.Fatalf("Failed to create unrelated branch: %v", err)
+	}
+
+	if output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0"); err != nil {
+		t.Fatalf("Failed to finish release: %v\nOutput: %s", err, output)
+	}
+
+	if current := testutil.GetCurrentBranch(t, dir); current != "develop" {
+		t.Errorf("Expected to be on develop after release finish, got %s", current)
+	}
+	if !testutil.BranchExists(t, dir, "unrelated") {
+		t.Error("Expected the unrelated branch to still exist")
+	}
+}
+
+// TestFinishShorthandLandsOnIntegrationBranch tests that the shorthand 'git flow finish'
+// lands on the same branch as the explicit form.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Starts release/1.0.0 and commits a file, staying on the release branch
+// 3. Runs git flow finish without a type or name
+// 4. Verifies HEAD is on develop and the release branch was deleted
+func TestFinishShorthandLandsOnIntegrationBranch(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if output, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+	if output, err := testutil.RunGitFlow(t, dir, "release", "start", "1.0.0"); err != nil {
+		t.Fatalf("Failed to start release: %v\nOutput: %s", err, output)
+	}
+	writeAndCommit(t, dir, "version.txt", "1.0.0", "Add version file")
+
+	if output, err := testutil.RunGitFlow(t, dir, "finish"); err != nil {
+		t.Fatalf("Failed to finish via shorthand: %v\nOutput: %s", err, output)
+	}
+
+	if current := testutil.GetCurrentBranch(t, dir); current != "develop" {
+		t.Errorf("Expected to be on develop after shorthand finish, got %s", current)
+	}
+	if testutil.BranchExists(t, dir, "release/1.0.0") {
+		t.Error("Expected release/1.0.0 to be deleted after finish")
+	}
+}
+
+// TestFinishSquashStrategyLandsOnIntegrationBranch tests that the squash strategy lands on
+// the integration branch.
+// Steps:
+// 1. Sets up a test repository and configures the release type to squash upstream
+// 2. Starts release/1.0.0 and commits a file
+// 3. Finishes the release branch
+// 4. Verifies HEAD is on develop and the release branch was deleted
+func TestFinishSquashStrategyLandsOnIntegrationBranch(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if output, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.branch.release.upstreamstrategy", "squash"); err != nil {
+		t.Fatalf("Failed to configure squash strategy: %v", err)
+	}
+	if output, err := testutil.RunGitFlow(t, dir, "release", "start", "1.0.0"); err != nil {
+		t.Fatalf("Failed to start release: %v\nOutput: %s", err, output)
+	}
+	writeAndCommit(t, dir, "version.txt", "1.0.0", "Add version file")
+
+	if output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0"); err != nil {
+		t.Fatalf("Failed to finish release: %v\nOutput: %s", err, output)
+	}
+
+	if current := testutil.GetCurrentBranch(t, dir); current != "develop" {
+		t.Errorf("Expected to be on develop after squash finish, got %s", current)
+	}
+	if testutil.BranchExists(t, dir, "release/1.0.0") {
+		t.Error("Expected release/1.0.0 to be deleted after finish")
+	}
+}
+
+// TestFinishRebaseStrategyLandsOnIntegrationBranch tests that the rebase strategy lands on
+// the integration branch.
+// Steps:
+// 1. Sets up a test repository and configures the release type to rebase upstream
+// 2. Starts release/1.0.0 and commits a file
+// 3. Finishes the release branch
+// 4. Verifies HEAD is on develop and the release branch was deleted
+func TestFinishRebaseStrategyLandsOnIntegrationBranch(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if output, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+	if _, err := testutil.RunGit(t, dir, "config", "gitflow.branch.release.upstreamstrategy", "rebase"); err != nil {
+		t.Fatalf("Failed to configure rebase strategy: %v", err)
+	}
+	if output, err := testutil.RunGitFlow(t, dir, "release", "start", "1.0.0"); err != nil {
+		t.Fatalf("Failed to start release: %v\nOutput: %s", err, output)
+	}
+	writeAndCommit(t, dir, "version.txt", "1.0.0", "Add version file")
+
+	if output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0"); err != nil {
+		t.Fatalf("Failed to finish release: %v\nOutput: %s", err, output)
+	}
+
+	if current := testutil.GetCurrentBranch(t, dir); current != "develop" {
+		t.Errorf("Expected to be on develop after rebase finish, got %s", current)
+	}
+	if testutil.BranchExists(t, dir, "release/1.0.0") {
+		t.Error("Expected release/1.0.0 to be deleted after finish")
+	}
+}
+
+// TestFinishSupportLandsOnIntegrationBranch tests that a support finish follows the same
+// landing rule, without any special-casing of release and hotfix.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Starts support/1.x and commits a file
+// 3. Finishes the support branch
+// 4. Verifies HEAD is on develop, the auto-update child of main
+func TestFinishSupportLandsOnIntegrationBranch(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if output, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+	if output, err := testutil.RunGitFlow(t, dir, "support", "start", "1.x"); err != nil {
+		t.Fatalf("Failed to start support: %v\nOutput: %s", err, output)
+	}
+	writeAndCommit(t, dir, "s.txt", "support", "Add support file")
+
+	if output, err := testutil.RunGitFlow(t, dir, "support", "finish", "1.x"); err != nil {
+		t.Fatalf("Failed to finish support: %v\nOutput: %s", err, output)
+	}
+
+	if current := testutil.GetCurrentBranch(t, dir); current != "develop" {
+		t.Errorf("Expected to be on develop after support finish, got %s", current)
+	}
+}
+
+// TestFinishLandsOnLastAutoUpdateChild tests that with several auto-update children the
+// landing branch is the last one the integration sequence processed.
+// Steps:
+// 1. Sets up a test repository and initializes git-flow with defaults
+// 2. Adds 'staging' as a second auto-update base child of main
+// 3. Starts release/1.0.0 and commits a file
+// 4. Finishes the release branch, capturing output
+// 5. Verifies HEAD is on staging and the last child-update line names staging
+func TestFinishLandsOnLastAutoUpdateChild(t *testing.T) {
+	t.Parallel()
+	dir := testutil.SetupTestRepo(t)
+	defer testutil.CleanupTestRepo(t, dir)
+
+	if output, err := testutil.RunGitFlow(t, dir, "init", "--defaults"); err != nil {
+		t.Fatalf("Failed to initialize git-flow: %v\nOutput: %s", err, output)
+	}
+	if _, err := testutil.RunGit(t, dir, "checkout", "-b", "staging", "main"); err != nil {
+		t.Fatalf("Failed to create staging branch: %v", err)
+	}
+	for key, value := range map[string]string{
+		"gitflow.branch.staging.type":               "base",
+		"gitflow.branch.staging.parent":             "main",
+		"gitflow.branch.staging.autoUpdate":         "true",
+		"gitflow.branch.staging.downstreamStrategy": "merge",
+	} {
+		if _, err := testutil.RunGit(t, dir, "config", key, value); err != nil {
+			t.Fatalf("Failed to set %s: %v", key, err)
+		}
+	}
+
+	if output, err := testutil.RunGitFlow(t, dir, "release", "start", "1.0.0"); err != nil {
+		t.Fatalf("Failed to start release: %v\nOutput: %s", err, output)
+	}
+	writeAndCommit(t, dir, "version.txt", "1.0.0", "Add version file")
+
+	output, err := testutil.RunGitFlow(t, dir, "release", "finish", "1.0.0")
+	if err != nil {
+		t.Fatalf("Failed to finish release: %v\nOutput: %s", err, output)
+	}
+
+	if current := testutil.GetCurrentBranch(t, dir); current != "staging" {
+		t.Errorf("Expected to be on staging, the last processed auto-update child, got %s", current)
+	}
+
+	// The last child actually processed is named by the last update line, which is
+	// printed as each child is integrated (unlike the collection-time report).
+	lastUpdated := ""
+	for _, line := range strings.Split(output, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "Successfully updated branch '") {
+			lastUpdated = strings.TrimSpace(line)
+		}
+	}
+	if !strings.Contains(lastUpdated, "'staging'") {
+		t.Errorf("Expected the last child update line to name staging, got: %q\nOutput: %s", lastUpdated, output)
+	}
+}

--- a/test/cmd/finish_test.go
+++ b/test/cmd/finish_test.go
@@ -1128,10 +1128,10 @@ func TestFinishReleaseWithMergeContinue(t *testing.T) {
 		t.Error("Expected no merge in progress after continue")
 	}
 
-	// Verify we're on the main branch
+	// Verify we're on the integration branch
 	currentBranch := testutil.GetCurrentBranch(t, dir)
-	if !strings.Contains(currentBranch, "main") {
-		t.Errorf("Expected to be on main branch after continue, got %s", currentBranch)
+	if currentBranch != "develop" {
+		t.Errorf("Expected to be on develop branch after continue, got %s", currentBranch)
 	}
 
 	// Verify the release branch was deleted
@@ -1139,7 +1139,11 @@ func TestFinishReleaseWithMergeContinue(t *testing.T) {
 		t.Error("Expected release branch to be deleted after successful finish")
 	}
 
-	// Verify the file content matches our resolution
+	// Verify the file content on main matches our resolution
+	_, err = testutil.RunGit(t, dir, "checkout", "main")
+	if err != nil {
+		t.Fatalf("Failed to checkout main: %v", err)
+	}
 	content := testutil.ReadFile(t, dir, "version.txt")
 	if content != "1.0.0" {
 		t.Errorf("Expected file content to be '1.0.0', got '%s'", content)


### PR DESCRIPTION
Makes `git flow <type> finish` end on the integration branch instead of the parent, so a release or hotfix finish leaves you on `develop` as git-flow-avh does.

The terminal step of finish checked out the parent branch before deleting the topic branch. That checkout existed only to guarantee HEAD was not on the branch about to be deleted — ending on the parent was never a designed outcome, and it ran even under `--keep`, where nothing is deleted. `handleDeleteBranchStep` now checks out the landing branch: the last auto-update child of the parent that the integration sequence processed, or the parent itself when there is none. It is read from the sorted `ChildBranches` list already persisted in the merge state, so `--continue` cannot disagree with the first run and the collection predicate is not duplicated. Finish also reports the result as `You are now on branch '<name>'`. No new configuration keys, no state-schema change: the rule is derived entirely from the existing `parent` and `autoUpdate` properties, so it holds for custom topologies where no branch is called `develop`. Changes touch `cmd/finish.go`, `test/cmd/finish_landing_test.go` (new), `test/cmd/finish_test.go`, `test/cmd/finish_conflicts_test.go`, `docs/git-flow-finish.1.md`, `docs/avh-compatibility-analysis.md`, `CODE_REFERENCE.md`, and `CHANGELOG.md`.

Resolves #206

### Remarks

- `integrate` keeps its parent checkout and `--abort` still returns to the topic branch, both explicitly out of scope in the spec and both guarded by tests.
- The new `test/cmd/finish_landing_test.go` covers the spec's 18 scenarios plus a multi-child case that pins the "last processed child" half of the rule, which no single-child scenario can distinguish.
- Two existing assertions expected `main` after a release finish and now expect `develop`. Each was followed by a working-tree read that relied on HEAD being `main` and would have kept passing while silently inspecting `develop`, so both reads now check out `main` explicitly first.

**Review focus:**
- `cmd/finish.go` — the `landingBranch` helper and the checkout it replaces in `handleDeleteBranchStep`
- `test/cmd/finish_landing_test.go` — the conflict fixtures and the phase assertions made before each conflict is resolved